### PR TITLE
Removed useless (second) parsing of deployment descriptor

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/helpers/MtaDescriptorMerger.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/helpers/MtaDescriptorMerger.java
@@ -34,7 +34,6 @@ public class MtaDescriptorMerger {
         // LOGGER.debug(format(Messages.DEPLOYMENT_DESCRIPTOR, JsonUtil.toJson(deploymentDescriptor, true)));
 
         List<ExtensionDescriptor> extensionDescriptors = parseExtensionDescriptors(extensionDescriptorStrings, parser);
-        deploymentDescriptor = parser.parseDeploymentDescriptorYaml(deploymentDescriptorString);
         for (int i = 0; i < extensionDescriptors.size(); i++) {
             // TODO log without plain text sensitive content
             // LOGGER.debug(format(Messages.EXTENSION_DESCRIPTOR, i, JsonUtil.toJson(extensionDescriptors.get(i), true)));


### PR DESCRIPTION
On line 32 the deployment descriptor is parsed.
Then after parsing the extension descriptors, the deployment descriptor is parsed once again.
The second parse is useless and is reported as such by Sonar.