### PR TITLE
Fix IllegalStateExceptions in CF client extended

### DIFF
--- a/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/CloudFoundryClientExtended.java
+++ b/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/CloudFoundryClientExtended.java
@@ -838,13 +838,12 @@ public class CloudFoundryClientExtended extends CloudFoundryClient implements Cl
         }
     }
 
-    private static CloudFoundryException fromException(String message, Throwable e, HttpStatus status) {
+    protected static CloudFoundryException fromException(String message, Throwable e, HttpStatus status) {
         if (e instanceof CloudFoundryException) {
-            throw (CloudFoundryException) e;
+            return (CloudFoundryException) e;
         }
-        CloudFoundryException ex = new CloudFoundryException(status, message + ": " + e.getMessage());
-        ex.initCause(e);
-        return ex;
+        // do not use initCause to set cause -> IllegalStateException
+        return new CloudFoundryException(status, message + ": " + e.getMessage(), null, -1, null, e);
     }
 
     private <T> T executeWithRetry(Supplier<T> supplier, HttpStatus... httpStatusesToIgnore) {

--- a/com.sap.cloud.lm.sl.cf.client/src/test/java/com/sap/cloud/lm/sl/cf/client/CloudFoundryClientExtendedTest.java
+++ b/com.sap.cloud.lm.sl.cf.client/src/test/java/com/sap/cloud/lm/sl/cf/client/CloudFoundryClientExtendedTest.java
@@ -1,0 +1,26 @@
+package com.sap.cloud.lm.sl.cf.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.cloudfoundry.client.lib.CloudFoundryException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class CloudFoundryClientExtendedTest {
+
+    @Test
+    void testFromNonCFE() {
+        Throwable cause = new Throwable("a");
+        CloudFoundryException newException = CloudFoundryClientExtended.fromException("test", cause, HttpStatus.INTERNAL_SERVER_ERROR);
+        assertEquals(cause, newException.getCause());
+    }
+
+    @Test
+    void testFromCFE() {
+        Throwable source = new CloudFoundryException(HttpStatus.NOT_FOUND);
+        CloudFoundryException newException = CloudFoundryClientExtended.fromException("test", source, HttpStatus.INTERNAL_SERVER_ERROR);
+        assertEquals(source, newException);
+        assertEquals(HttpStatus.NOT_FOUND, newException.getStatusCode());
+    }
+
+}


### PR DESCRIPTION
When transforming ExecutionExceptions in CloudFondryExceptions an
IllegalStateException is thrown when root cause is set. This is due to
the imperfect design of the CFE. Using a less readable constructor
achieves the goal of root cause setting.

JIRA: iLMCROSSITXSADEPLOY-1119