### PR TITLE
Skip audit logging app configuration

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfiguration.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfiguration.java
@@ -34,8 +34,6 @@ import com.sap.cloud.lm.sl.common.util.JsonUtil;
 import com.sap.cloud.lm.sl.common.util.MiscUtil;
 import com.sap.cloud.lm.sl.common.util.Pair;
 import com.sap.cloud.lm.sl.mta.handlers.v1_0.ConfigurationParser;
-import com.sap.cloud.lm.sl.mta.model.AuditableConfiguration;
-import com.sap.cloud.lm.sl.mta.model.ConfigurationIdentifier;
 import com.sap.cloud.lm.sl.mta.model.v1_0.Platform;
 import com.sap.cloud.lm.sl.mta.model.v1_0.Target;
 import com.sap.cloud.lm.sl.persistence.util.Configuration;
@@ -238,36 +236,8 @@ public class ApplicationConfiguration {
         getAuditLogClientKeepAlive();
     }
 
-    public void logFullConfig() {
-        for (Map.Entry<String, String> envVariable : getFilteredEnv().entrySet()) {
-            AuditableConfiguration auditConfiguration = getAuditableConfiguration(envVariable.getKey(), envVariable.getValue());
-            getAuditLoggingFacade().logConfig(auditConfiguration);
-        }
-    }
-
     protected AuditLoggingFacade getAuditLoggingFacade() {
         return AuditLoggingProvider.getFacade();
-    }
-
-    private AuditableConfiguration getAuditableConfiguration(String key, String value) {
-        return new AuditableConfiguration() {
-
-            @Override
-            public String getConfigurationType() {
-                return "environmental configuration";
-            }
-
-            @Override
-            public String getConfigurationName() {
-                return key;
-            }
-
-            @Override
-            public List<ConfigurationIdentifier> getConfigurationIdentifiers() {
-                return Arrays.asList(new ConfigurationIdentifier(key, value));
-            }
-
-        };
     }
 
     public Map<String, String> getFilteredEnv() {

--- a/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfigurationTest.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfigurationTest.java
@@ -1,7 +1,6 @@
 package com.sap.cloud.lm.sl.cf.core.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -14,7 +13,7 @@ import com.sap.cloud.lm.sl.cf.core.auditlogging.AuditLoggingFacade;
 import com.sap.cloud.lm.sl.cf.core.configuration.Environment;
 import com.sap.cloud.lm.sl.cf.core.util.ApplicationConfiguration.DatabaseType;
 
-import jersey.repackaged.com.google.common.collect.ImmutableMap;
+import static org.mockito.Mockito.when;
 
 public class ApplicationConfigurationTest {
 
@@ -55,17 +54,6 @@ public class ApplicationConfigurationTest {
         when(environment.getString(ApplicationConfiguration.CFG_DB_TYPE)).thenReturn(expectedDBType.toString());
         ApplicationConfiguration testedConfiguration = new ApplicationConfiguration(environment);
         assertEquals(expectedDBType, testedConfiguration.getDatabaseType());
-    }
-
-    @Test
-    public void testLogFullConfig() {
-        when(environment.getAllVariables()).thenReturn(ImmutableMap.of(ApplicationConfiguration.CFG_DB_TYPE, "POSTGRES"));
-        ApplicationConfiguration testedConfig = new ApplicationConfiguration(environment) {
-            protected AuditLoggingFacade getAuditLoggingFacade() {
-                return auditLoggingFascade;
-            }
-        };
-        testedConfig.logFullConfig();
     }
 
     @Test

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/bootstrap/BootstrapServlet.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/bootstrap/BootstrapServlet.java
@@ -74,7 +74,6 @@ public class BootstrapServlet extends HttpServlet {
             addDeployTargets();
             initExtras();
             executeAsyncDatabaseChanges();
-            configuration.logFullConfig();
             processEngine.getProcessEngineConfiguration()
                 .getJobExecutor()
                 .start();


### PR DESCRIPTION
Auditlog config tracking api is not able to handle large content being
traced
The content being traced is not vital for the audit log as it's not
controlled by any end-user input nor is it volatile.
BUG: NGPBUG-58959