### PR TITLE
Skip audit logging app configuration

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfiguration.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfiguration.java
@@ -18,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sap.cloud.lm.sl.cf.core.auditlogging.AuditLoggingProvider;
 import com.sap.cloud.lm.sl.cf.core.cf.PlatformType;
 import com.sap.cloud.lm.sl.cf.core.health.model.HealthCheckConfiguration;
 import com.sap.cloud.lm.sl.cf.core.helpers.Environment;
@@ -31,8 +30,6 @@ import com.sap.cloud.lm.sl.common.util.JsonUtil;
 import com.sap.cloud.lm.sl.common.util.MiscUtil;
 import com.sap.cloud.lm.sl.common.util.Pair;
 import com.sap.cloud.lm.sl.mta.handlers.v1_0.ConfigurationParser;
-import com.sap.cloud.lm.sl.mta.model.AuditableConfiguration;
-import com.sap.cloud.lm.sl.mta.model.ConfigurationIdentifier;
 import com.sap.cloud.lm.sl.mta.model.v1_0.Platform;
 import com.sap.cloud.lm.sl.mta.model.v1_0.Target;
 
@@ -231,35 +228,6 @@ public class ApplicationConfiguration {
         getAuditLogClientMaxThreads();
         getAuditLogClientQueueCapacity();
         getAuditLogClientKeepAlive();
-    }
-
-    public void logFullConfig() {
-        for (Map.Entry<String, String> envVariable : getFilteredEnv().entrySet()) {
-            AuditableConfiguration auditConfiguration = getAuditableConfiguration(envVariable.getKey(), envVariable.getValue());
-            AuditLoggingProvider.getFacade()
-                .logConfig(auditConfiguration);
-        }
-    }
-
-    private AuditableConfiguration getAuditableConfiguration(String key, String value) {
-        return new AuditableConfiguration() {
-
-            @Override
-            public String getConfigurationType() {
-                return "environmental configuration";
-            }
-
-            @Override
-            public String getConfiguratioName() {
-                return key;
-            }
-
-            @Override
-            public List<ConfigurationIdentifier> getConfigurationIdentifiers() {
-                return Arrays.asList(new ConfigurationIdentifier(key, value));
-            };
-
-        };
     }
 
     public Map<String, String> getFilteredEnv() {

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/bootstrap/BootstrapServlet.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/bootstrap/BootstrapServlet.java
@@ -71,7 +71,6 @@ public class BootstrapServlet extends HttpServlet {
             initializeActiviti();
             addDeployTargets();
             initExtras();
-            configuration.logFullConfig();
             processEngine.getProcessEngineConfiguration().getJobExecutor().start();
             LOGGER.info(Messages.ALM_SERVICE_ENV_INITIALIZED);
         } catch (Exception e) {


### PR DESCRIPTION
Auditlog config tracking api is not able to handle large content being
traced
The content being traced is not vital for the audit log as it's not
controlled by any end-user input nor is it volatile.
BUG: NGPBUG-58959