### PR TITLE
Fix Start/End ProcessListeners to not set process finished state earlier

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/listeners/AbstractProcessExecutionListener.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/listeners/AbstractProcessExecutionListener.java
@@ -15,6 +15,7 @@ import com.sap.cloud.lm.sl.cf.persistence.services.FileStorageException;
 import com.sap.cloud.lm.sl.cf.persistence.services.ProcessLoggerProviderFactory;
 import com.sap.cloud.lm.sl.cf.persistence.services.ProgressMessageService;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
+import com.sap.cloud.lm.sl.cf.process.steps.StepsUtil;
 import com.sap.cloud.lm.sl.cf.process.util.StepLogger;
 import com.sap.cloud.lm.sl.common.SLException;
 
@@ -37,6 +38,20 @@ public abstract class AbstractProcessExecutionListener implements ExecutionListe
     public void notify(DelegateExecution context) throws Exception {
         try {
             this.stepLogger = createStepLogger(context);
+            String correlationId = StepsUtil.getCorrelationId(context);
+            if (correlationId == null) {
+                correlationId = context.getProcessInstanceId();
+                context.setVariable(com.sap.cloud.lm.sl.cf.process.Constants.VAR_CORRELATION_ID, correlationId);
+            }
+
+            correlationId = StepsUtil.getCorrelationId(context);
+            String processInstanceId = context.getProcessInstanceId();
+
+            // Check if this is subprocess
+            if (!processInstanceId.equals(correlationId)) {
+                return;
+            }
+
             notifyInternal(context);
         } catch (Exception e) {
             logException(context, e, Messages.EXECUTION_OF_PROCESS_LISTENER_HAS_FAILED);

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/listeners/StartProcessListener.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/listeners/StartProcessListener.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.sap.cloud.lm.sl.cf.core.dao.OperationDao;
 import com.sap.cloud.lm.sl.cf.core.util.ApplicationConfiguration;
-import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.cf.process.metadata.ProcessTypeToOperationMetadataMapper;
 import com.sap.cloud.lm.sl.cf.process.steps.StepsUtil;
@@ -44,10 +43,6 @@ public class StartProcessListener extends AbstractProcessExecutionListener {
     @Override
     protected void notifyInternal(DelegateExecution context) {
         String correlationId = StepsUtil.getCorrelationId(context);
-        if (correlationId == null) {
-            correlationId = context.getProcessInstanceId();
-            context.setVariable(Constants.VAR_CORRELATION_ID, correlationId);
-        }
         ProcessType processType = processTypeParser.getProcessType(context);
 
         if (operationDao.find(correlationId) == null) {


### PR DESCRIPTION
…ier.

If there is process with subprocess, there are registered
Start and EndProcessListeners for the parent process and for the subprocess.
In this case the EndProcessListener of the subprocess set the parent
process (correlationId) in finished state earlier, before it is fully
executed. This leads to earlier report for finished state and missing
progress messages in the client. This commit fixes this bug, because
only EndProcessListener of the parent process set the state to finished,
when it is actually fully executed.

JIRA: LMCROSSITXSADEPLOY-1065