### PR TITLE
Use HTTP health check

### DIFF
--- a/com.sap.cloud.lm.sl.cf.web/manifests/manifest.yml
+++ b/com.sap.cloud.lm.sl.cf.web/manifests/manifest.yml
@@ -7,6 +7,8 @@ applications:
   path: ../${project.build.finalName}.war
   buildpack: java_buildpack
   timeout: 180 # If the landscape and/or our Liquibase changes are very slow, the application may take longer than 60 seconds to start up.
+  health-check-type: http
+  health-check-http-endpoint: /public/ping
   services:
     - deploy-service-database
   env:


### PR DESCRIPTION
There are cases where the default port-based health-checking mechanism
deems our application healthy, but it is still unable to handle
requests.