### PR TITLE
Enhance blue-green deployment

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/helpers/XsPlaceholderResolverInvoker.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/helpers/XsPlaceholderResolverInvoker.java
@@ -57,6 +57,8 @@ public class XsPlaceholderResolverInvoker extends Visitor implements SimplePrope
         Map<String, Object> parameters = propertiesAccessor.getParameters(propertiesContainer, supportedParameters);
         Map<String, Object> properties = propertiesAccessor.getProperties(propertiesContainer);
         Map<String, Object> resolvedParameters = (Map<String, Object>) new VisitableObject(parameters).accept(this);
+        // Parameters are merged into properties, because v1 of the MTA spec does not have parameters.
+        // TODO Parameters should not be merged into properties, for bigger versions than v1 of the MTA spec, because they have parameters.
         propertiesAccessor.setParameters(propertiesContainer, MapUtil.merge(properties, resolvedParameters));
     }
 

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/model/ApplicationColor.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/model/ApplicationColor.java
@@ -9,12 +9,7 @@ public enum ApplicationColor {
     }
 
     public String asSuffix() {
-        return "-" + toString();
-    }
-
-    @Override
-    public String toString() {
-        return super.toString().toLowerCase();
+        return "-" + super.toString().toLowerCase();
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.core/src/test/resources/com/sap/cloud/lm/sl/cf/core/security/serialization/secured-object-03.json
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/resources/com/sap/cloud/lm/sl/cf/core/security/serialization/secured-object-03.json
@@ -10,6 +10,9 @@
           }
         }
       },
+      "parametersMetadata": {
+        "metadata": {}
+      },
       "parameters": {},
       "name": "test-module",
       "type": "test-type",

--- a/com.sap.cloud.lm.sl.cf.core/src/test/resources/com/sap/cloud/lm/sl/cf/core/security/serialization/secured-object-04.json
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/resources/com/sap/cloud/lm/sl/cf/core/security/serialization/secured-object-04.json
@@ -36,6 +36,9 @@
               }
             }
           },
+          "parametersMetadata": {
+            "metadata": {}
+          },
           "isPublic": false,
           "name": "test-dependency",
           "properties": {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Constants.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Constants.java
@@ -140,6 +140,8 @@ public class Constants {
     public static final String VAR_STEP_PHASE = "stepPhase";
     public static final String VAR_APP_CONTENT_CHANGED = "appContentChanged";
     public static final String VAR_STEP_START_TIME = "stepStartTime_";
+    public static final String VAR_DEPLOYED_MTA_COLOR = "deployedMtaColor";
+    public static final String VAR_MTA_COLOR = "mtaColor";
 
     public static final String TOOL_TYPE = "tool_type";
     public static final String FEEDBACK_MAIL = "feedback_form";

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BlueGreenRenameStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BlueGreenRenameStep.java
@@ -2,6 +2,11 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 
 import java.util.function.Supplier;
 
+import javax.inject.Named;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Scope;
+
 import com.sap.cloud.lm.sl.cf.core.cf.HandlerFactory;
 import com.sap.cloud.lm.sl.cf.core.helpers.ApplicationColorDetector;
 import com.sap.cloud.lm.sl.cf.core.helpers.v1.ApplicationColorAppender;
@@ -12,6 +17,8 @@ import com.sap.cloud.lm.sl.common.ConflictException;
 import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.mta.model.v1.DeploymentDescriptor;
 
+@Named("blueGreenRenameStep")
+@Scope(BeanDefinition.SCOPE_PROTOTYPE)
 public class BlueGreenRenameStep extends SyncActivitiStep {
 
     private static final ApplicationColor DEFAULT_MTA_COLOR = ApplicationColor.BLUE;

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BlueGreenRenameStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BlueGreenRenameStep.java
@@ -34,8 +34,6 @@ public class BlueGreenRenameStep extends SyncActivitiStep {
                 if (deployedMtaColor != null) {
                     getStepLogger().info(Messages.DEPLOYED_MTA_COLOR, deployedMtaColor);
                     mtaColor = deployedMtaColor.getAlternativeColor();
-                    execution.getContext()
-                        .setVariable("deployedMtaColor", deployedMtaColor);
                 } else {
                     mtaColor = DEFAULT_MTA_COLOR;
                 }
@@ -47,12 +45,13 @@ public class BlueGreenRenameStep extends SyncActivitiStep {
                 getStepLogger().info(Messages.ASSUMED_LIVE_AND_IDLE_COLORS, liveMtaColor, idleMtaColor);
                 mtaColor = idleMtaColor;
             }
+
+            StepsUtil.setDeployedMtaColor(execution.getContext(), deployedMtaColor);
+            StepsUtil.setMtaColor(execution.getContext(), mtaColor);
+
             getStepLogger().info(Messages.NEW_MTA_COLOR, mtaColor);
 
             visit(execution, descriptor, mtaColor, deployedMtaColor);
-
-            execution.getContext()
-                .setVariable("mtaColor", mtaColor);
 
             return StepPhase.DONE;
         } catch (SLException e) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessDescriptorStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessDescriptorStep.java
@@ -32,7 +32,7 @@ import com.sap.cloud.lm.sl.mta.model.v1.Target;
 
 public class ProcessDescriptorStep extends SyncActivitiStep {
 
-    private SecureSerializationFacade secureSerializer = new SecureSerializationFacade();
+    protected SecureSerializationFacade secureSerializer = new SecureSerializationFacade();
 
     @Inject
     private ConfigurationEntryDao configurationEntryDao;
@@ -89,6 +89,7 @@ public class ProcessDescriptorStep extends SyncActivitiStep {
             List<ConfigurationSubscription> subscriptions = resolver.getSubscriptions();
             StepsUtil.setSubscriptionsToCreate(execution.getContext(), subscriptions);
             XsPlaceholderResolver xsPlaceholderResolver = StepsUtil.getXsPlaceholderResolver(execution.getContext());
+
             resolveXsPlaceholders(descriptor, xsPlaceholderResolver, handlerFactory.getMajorVersion());
 
             StepsUtil.setDeploymentDescriptor(execution.getContext(), descriptor);

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StepsUtil.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StepsUtil.java
@@ -45,6 +45,7 @@ import com.sap.cloud.lm.sl.cf.core.cf.v1.DomainsCloudModelBuilder;
 import com.sap.cloud.lm.sl.cf.core.cf.v1.ServiceKeysCloudModelBuilder;
 import com.sap.cloud.lm.sl.cf.core.cf.v1.ServicesCloudModelBuilder;
 import com.sap.cloud.lm.sl.cf.core.helpers.XsPlaceholderResolver;
+import com.sap.cloud.lm.sl.cf.core.model.ApplicationColor;
 import com.sap.cloud.lm.sl.cf.core.model.ConfigurationEntry;
 import com.sap.cloud.lm.sl.cf.core.model.ConfigurationSubscription;
 import com.sap.cloud.lm.sl.cf.core.model.DeployedMta;
@@ -176,10 +177,28 @@ public class StepsUtil {
         context.setVariable(getModuleContentVariable(moduleName), moduleContent);
     }
 
+    public static ApplicationColor getDeployedMtaColor(DelegateExecution context) {
+        String deployedMtaColor = (String) context.getVariable(Constants.VAR_DEPLOYED_MTA_COLOR);
+        return (deployedMtaColor == null) ? null : ApplicationColor.valueOf(deployedMtaColor);
+    }
+
+    public static void setDeployedMtaColor(DelegateExecution context, ApplicationColor deployedMtaColor) {
+        context.setVariable(Constants.VAR_DEPLOYED_MTA_COLOR, (deployedMtaColor == null) ? null : deployedMtaColor.toString());
+    }
+
+    public static ApplicationColor getMtaColor(DelegateExecution context) {
+        String mtaColor = (String) context.getVariable(Constants.VAR_MTA_COLOR);
+        return (mtaColor == null) ? null : ApplicationColor.valueOf(mtaColor);
+    }
+
+    public static void setMtaColor(DelegateExecution context, ApplicationColor mtaColor) {
+        context.setVariable(Constants.VAR_MTA_COLOR, (mtaColor == null) ? null : mtaColor.toString());
+    }
+
     private static String getModuleContentVariable(String moduleName) {
         return Constants.VAR_MTA_MODULE_CONTENT_PREFIX + moduleName;
     }
-
+    
     private static String getModuleFileNameVariable(String moduleName) {
         return Constants.VAR_MTA_MODULE_FILE_NAME_PREFIX + moduleName;
     }
@@ -667,7 +686,7 @@ public class StepsUtil {
         context.setVariable(Constants.VAR_MTA_UNRESOLVED_DEPLOYMENT_DESCRIPTOR, toBinaryYaml(unresolvedDeploymentDescriptor));
     }
 
-    static void setDeploymentDescriptor(DelegateExecution context, DeploymentDescriptor deploymentDescriptor) {
+    public static void setDeploymentDescriptor(DelegateExecution context, DeploymentDescriptor deploymentDescriptor) {
         context.setVariable(Constants.VAR_MTA_DEPLOYMENT_DESCRIPTOR, toBinaryYaml(deploymentDescriptor));
     }
 

--- a/com.sap.cloud.lm.sl.cf.web/src/main/webapp/WEB-INF/application-context.xml
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/webapp/WEB-INF/application-context.xml
@@ -34,9 +34,6 @@
 
         <bean id="serviceUpdater" class="com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceUpdater" />
 
-        <bean id="blueGreenRenameStep" class="com.sap.cloud.lm.sl.cf.process.steps.BlueGreenRenameStep"
-            scope="prototype" />
-
         <bean id="buildCloudDeployModelStep" class="com.sap.cloud.lm.sl.cf.process.steps.BuildCloudDeployModelStep"
             scope="prototype" />
 


### PR DESCRIPTION
#### Description: 
1. Create getters/setters for MtaColor context variables.
    New context vars are created: VAR_DEPLOYED_MTA_COLOR and VAR_MTA_COLOR.
    JIRA: LMCROSSITXSADEPLOY-1200

2. Builders create default Metadata. Fix unit tests.
    The flow for creation of MTA model objects is Parser->Builder.
    Previously only the Parser was creating default Metadata
    for MTA objects, which leads to NPE when use only Builder
    to create MTA object. Now also Builders are creating default
    Metadata.
    JIRA: NGPBUG-68974

3. Refactor BlueGreenRenameStep dependency injection to be annotation based.
    JIRA: LMCROSSITXSADEPLOY-1200