### PR TITLE
Poll async service deletions

### DIFF
--- a/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/model/Constants.java
+++ b/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/model/Constants.java
@@ -1,0 +1,5 @@
+package com.sap.cloud.lm.sl.cf.web.api.model;
+
+public class Constants {
+    public static final String NULL_STRING_VALUE = (String) null;
+}

--- a/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/model/ProcessTypeJsonAdapter.java
+++ b/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/model/ProcessTypeJsonAdapter.java
@@ -15,7 +15,11 @@ public class ProcessTypeJsonAdapter extends TypeAdapter<ProcessType> {
 
     @Override
     public void write(JsonWriter out, ProcessType type) throws IOException {
-        out.value(type.toString());
+        if (type != null) {
+            out.value(type.toString());
+        } else {
+            out.value(Constants.NULL_STRING_VALUE);
+        }
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/model/ZonedDateTimeJsonAdapter.java
+++ b/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/model/ZonedDateTimeJsonAdapter.java
@@ -16,7 +16,11 @@ public class ZonedDateTimeJsonAdapter extends TypeAdapter<ZonedDateTime> {
 
     @Override
     public void write(JsonWriter out, ZonedDateTime zonedDateTime) throws IOException {
-        out.value(Operation.DATE_TIME_FORMATTER.format(zonedDateTime));
+        if(zonedDateTime != null) {
+            out.value(Operation.DATE_TIME_FORMATTER.format(zonedDateTime));            
+        } else {
+            out.value(Constants.NULL_STRING_VALUE);
+        }
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/AbstractServiceGetter.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/AbstractServiceGetter.java
@@ -1,5 +1,6 @@
 package com.sap.cloud.lm.sl.cf.core.cf.clients;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -7,7 +8,6 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import org.cloudfoundry.client.lib.CloudControllerClient;
-import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
 import com.sap.cloud.lm.sl.common.util.JsonUtil;
@@ -23,7 +23,7 @@ public abstract class AbstractServiceGetter extends CustomControllerClient {
     public Map<String, Object> getServiceInstanceEntity(CloudControllerClient client, String serviceName, String spaceId) {
         Map<String, Object> serviceInstance = new CustomControllerClientErrorHandler()
             .handleErrorsOrReturnResult(() -> attemptToGetServiceInstance(client, serviceName, spaceId));
-        return serviceInstance != null ? (Map<String, Object>) serviceInstance.get("entity") : null;
+        return serviceInstance != null ? (Map<String, Object>) serviceInstance.get("entity") : Collections.emptyMap();
     }
 
     public Map<String, Object> getServiceInstance(CloudControllerClient client, String serviceName, String spaceId) {

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/AbstractServiceGetter.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/AbstractServiceGetter.java
@@ -1,0 +1,81 @@
+package com.sap.cloud.lm.sl.cf.core.cf.clients;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.cloudfoundry.client.lib.CloudControllerClient;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import com.sap.cloud.lm.sl.common.util.JsonUtil;
+
+public abstract class AbstractServiceGetter extends CustomControllerClient {
+
+    @Inject
+    public AbstractServiceGetter(RestTemplateFactory restTemplateFactory) {
+        super(restTemplateFactory);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getServiceInstanceEntity(CloudControllerClient client, String serviceName, String spaceId) {
+        Map<String, Object> serviceInstance = new CustomControllerClientErrorHandler()
+            .handleErrorsOrReturnResult(() -> attemptToGetServiceInstance(client, serviceName, spaceId));
+        return serviceInstance != null ? (Map<String, Object>) serviceInstance.get("entity") : null;
+    }
+
+    public Map<String, Object> getServiceInstance(CloudControllerClient client, String serviceName, String spaceId) {
+        return new CustomControllerClientErrorHandler()
+            .handleErrorsOrReturnResult(() -> attemptToGetServiceInstance(client, serviceName, spaceId));
+    }
+
+    private Map<String, Object> attemptToGetServiceInstance(CloudControllerClient client, String serviceName, String spaceId) {
+        String serviceInstancesEndpoint = getUrl(client.getCloudControllerUrl()
+            .toString(), getServiceInstanceURL());
+        Map<String, Object> queryParameters = buildQueryParameters(serviceName, spaceId);
+
+        return getCloudServiceInstance(client, serviceInstancesEndpoint, queryParameters);
+    }
+
+    private Map<String, Object> buildQueryParameters(String serviceName, String spaceId) {
+        Map<String, Object> queryVariables = new HashMap<>();
+        queryVariables.put("name", serviceName);
+        queryVariables.put("space_guid", spaceId);
+        return queryVariables;
+    }
+
+    private Map<String, Object> getCloudServiceInstance(CloudControllerClient client, String serviceInstancesEndpoint,
+        Map<String, Object> queryParameters) {
+        String response = getRestTemplate(client).getForObject(serviceInstancesEndpoint, String.class, queryParameters);
+        Map<String, Object> serviceInstancesResponse = parseResponse(response);
+        return getCloudServiceInstance(serviceInstancesResponse);
+    }
+
+    private Map<String, Object> parseResponse(String response) {
+        return JsonUtil.convertJsonToMap(response);
+    }
+
+    private Map<String, Object> getCloudServiceInstance(Map<String, Object> serviceInstancesResponse) {
+        validateServiceInstanceResponse(serviceInstancesResponse);
+        List<Map<String, Object>> cloudServiceInstanceResources = getResourcesFromResponse(serviceInstancesResponse);
+        if (!cloudServiceInstanceResources.isEmpty()) {
+            return cloudServiceInstanceResources.get(0);
+        }
+        return null;
+    }
+
+    private void validateServiceInstanceResponse(Map<String, Object> serviceInstancesResponse) {
+        List<Map<String, Object>> resources = getResourcesFromResponse(serviceInstancesResponse);
+        Assert.notNull(resources, "The response of finding a service instance should contain a 'resources' element");
+        Assert.isTrue(resources.size() <= 1, "The response of finding a service instance should not have more than one resource element");
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> getResourcesFromResponse(Map<String, Object> serviceInstancesResponse) {
+        return (List<Map<String, Object>>) serviceInstancesResponse.get("resources");
+    }
+
+    public abstract String getServiceInstanceURL();
+}

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/EventsGetter.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/EventsGetter.java
@@ -1,0 +1,56 @@
+package com.sap.cloud.lm.sl.cf.core.cf.clients;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.cloudfoundry.client.lib.CloudControllerClient;
+import org.cloudfoundry.client.lib.domain.CloudEvent;
+import org.cloudfoundry.client.lib.util.CloudEntityResourceMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class EventsGetter extends CustomControllerClient {
+
+    private static final String GUID = "guid";
+    private static final String EVENTS_URL = "/v2/events?q=actee:{guid}&order-by:timestamp&order-direction=desc";
+    private CloudEntityResourceMapper resourceMapper = new CloudEntityResourceMapper();
+
+    @Inject
+    public EventsGetter(RestTemplateFactory restTemplateFactory) {
+        super(restTemplateFactory);
+    }
+
+    private Map<String, Object> buildQueryParameters(UUID uuid) {
+        Map<String, Object> urlVars = new HashMap<>();
+        urlVars.put(GUID, uuid);
+        return urlVars;
+    }
+
+    public List<CloudEvent> getEvents(UUID uuid, CloudControllerClient client) {
+        Map<String, Object> queryParames = buildQueryParameters(uuid);
+        String controllerUrl = client.getCloudControllerUrl()
+            .toString();
+
+        RestTemplate restTemplate = getRestTemplate(client);
+
+        List<Map<String, Object>> resources = getAllResources(restTemplate, controllerUrl, EVENTS_URL, queryParames);
+
+        return resources.stream()
+            .filter(Objects::nonNull)
+            .map(map -> resourceMapper.mapResource(map, CloudEvent.class))
+            .collect(Collectors.toList());
+    }
+    
+    public CloudEvent getLastEvent(UUID uuid, CloudControllerClient client) {
+        List<CloudEvent> events = getEvents(uuid, client);
+        return events.isEmpty() ? null : events.get(0);
+    }
+
+}

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/EventsGetter.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/EventsGetter.java
@@ -20,6 +20,10 @@ public class EventsGetter extends CustomControllerClient {
 
     private static final String GUID = "guid";
     private static final String EVENTS_URL = "/v2/events?q=actee:{guid}&order-by:timestamp&order-direction=desc";
+    
+    private static final String USER_PROVIDED_SERVICE_EVENT_TYPE_DELETE = "audit.user_provided_service_instance.delete";
+    private static final String SERVICE_EVENT_TYPE_DELETE = "audit.service_instance.delete";
+    
     private CloudEntityResourceMapper resourceMapper = new CloudEntityResourceMapper();
 
     @Inject
@@ -53,4 +57,8 @@ public class EventsGetter extends CustomControllerClient {
         return events.isEmpty() ? null : events.get(0);
     }
 
+    public boolean isDeleteEvent(String eventType) {
+        return SERVICE_EVENT_TYPE_DELETE.equalsIgnoreCase(eventType)
+            || USER_PROVIDED_SERVICE_EVENT_TYPE_DELETE.equalsIgnoreCase(eventType);
+    }
 }

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/ServiceGetter.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/ServiceGetter.java
@@ -2,35 +2,39 @@ package com.sap.cloud.lm.sl.cf.core.cf.clients;
 
 import java.util.Map;
 
+import javax.inject.Inject;
+
 import org.cloudfoundry.client.lib.CloudControllerClient;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ServiceGetter {
 
-    @Autowired
-    @Qualifier("serviceInstanceGetter")
     private AbstractServiceGetter serviceInstanceGetter;
-    
-    @Autowired
-    @Qualifier("userProvidedServiceInstanceGetter")
     private AbstractServiceGetter userProvidedServiceInstanceGetter;
-    
+
+    @Inject
+    public ServiceGetter(@Qualifier("serviceInstanceGetter") AbstractServiceGetter serviceInstanceGetter,
+        @Qualifier("userProvidedServiceInstanceGetter") AbstractServiceGetter userProvidedServiceInstanceGetter) {
+
+        this.serviceInstanceGetter = serviceInstanceGetter;
+        this.userProvidedServiceInstanceGetter = userProvidedServiceInstanceGetter;
+    }
+
     public Map<String, Object> getServiceInstance(CloudControllerClient client, String serviceName, String spaceId) {
         Map<String, Object> serviceInstance = serviceInstanceGetter.getServiceInstance(client, serviceName, spaceId);
-        if(serviceInstance == null || serviceInstance.isEmpty()) {
+        if (serviceInstance == null || serviceInstance.isEmpty()) {
             serviceInstance = userProvidedServiceInstanceGetter.getServiceInstance(client, serviceName, spaceId);
         }
         return serviceInstance;
     }
-    
+
     public Map<String, Object> getServiceInstanceEntity(CloudControllerClient client, String serviceName, String spaceId) {
         Map<String, Object> serviceInstance = serviceInstanceGetter.getServiceInstanceEntity(client, serviceName, spaceId);
-        if(serviceInstance == null || serviceInstance.isEmpty()) {
+        if (serviceInstance == null || serviceInstance.isEmpty()) {
             serviceInstance = userProvidedServiceInstanceGetter.getServiceInstanceEntity(client, serviceName, spaceId);
         }
         return serviceInstance;
-    } 
+    }
 }

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/ServiceGetter.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/ServiceGetter.java
@@ -1,0 +1,36 @@
+package com.sap.cloud.lm.sl.cf.core.cf.clients;
+
+import java.util.Map;
+
+import org.cloudfoundry.client.lib.CloudControllerClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ServiceGetter {
+
+    @Autowired
+    @Qualifier("serviceInstanceGetter")
+    private AbstractServiceGetter serviceInstanceGetter;
+    
+    @Autowired
+    @Qualifier("userProvidedServiceInstanceGetter")
+    private AbstractServiceGetter userProvidedServiceInstanceGetter;
+    
+    public Map<String, Object> getServiceInstance(CloudControllerClient client, String serviceName, String spaceId) {
+        Map<String, Object> serviceInstance = serviceInstanceGetter.getServiceInstance(client, serviceName, spaceId);
+        if(serviceInstance == null || serviceInstance.isEmpty()) {
+            serviceInstance = userProvidedServiceInstanceGetter.getServiceInstance(client, serviceName, spaceId);
+        }
+        return serviceInstance;
+    }
+    
+    public Map<String, Object> getServiceInstanceEntity(CloudControllerClient client, String serviceName, String spaceId) {
+        Map<String, Object> serviceInstance = serviceInstanceGetter.getServiceInstanceEntity(client, serviceName, spaceId);
+        if(serviceInstance == null || serviceInstance.isEmpty()) {
+            serviceInstance = userProvidedServiceInstanceGetter.getServiceInstanceEntity(client, serviceName, spaceId);
+        }
+        return serviceInstance;
+    } 
+}

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/ServiceInstanceGetter.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/ServiceInstanceGetter.java
@@ -1,78 +1,19 @@
 package com.sap.cloud.lm.sl.cf.core.cf.clients;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.inject.Inject;
-
-import org.cloudfoundry.client.lib.CloudControllerClient;
 import org.springframework.stereotype.Component;
-import org.springframework.util.Assert;
 
-import com.sap.cloud.lm.sl.common.util.JsonUtil;
+@Component("serviceInstanceGetter")
+public class ServiceInstanceGetter extends AbstractServiceGetter {
 
-@Component
-public class ServiceInstanceGetter extends CustomControllerClient {
-
-    private static final String SERVICE_INSTANCES_URL = "/v2/service_instances?q=name:{name}&q=space_guid:{space_guid}";
-
-    @Inject
-    public ServiceInstanceGetter(RestTemplateFactory restTemplateFactory) {
+    protected ServiceInstanceGetter(RestTemplateFactory restTemplateFactory) {
         super(restTemplateFactory);
     }
 
-    public Map<String, Object> getServiceInstance(CloudControllerClient client, String serviceName, String spaceId) {
-        return new CustomControllerClientErrorHandler()
-            .handleErrorsOrReturnResult(() -> attemptToGetServiceInstance(client, serviceName, spaceId));
-    }
+    private static final String SERVICE_INSTANCES_URL = "/v2/service_instances?q=name:{name}&q=space_guid:{space_guid}";
 
-    private Map<String, Object> attemptToGetServiceInstance(CloudControllerClient client, String serviceName, String spaceId) {
-        String serviceInstancesEndpoint = getUrl(client.getCloudControllerUrl()
-            .toString(), SERVICE_INSTANCES_URL);
-        Map<String, Object> queryParameters = buildQueryParameters(serviceName, spaceId);
-
-        return getCloudServiceInstance(client, serviceInstancesEndpoint, queryParameters);
-    }
-
-    private Map<String, Object> buildQueryParameters(String serviceName, String spaceId) {
-        Map<String, Object> queryVariables = new HashMap<>();
-        queryVariables.put("name", serviceName);
-        queryVariables.put("space_guid", spaceId);
-        return queryVariables;
-    }
-
-    private Map<String, Object> getCloudServiceInstance(CloudControllerClient client, String serviceInstancesEndpoint,
-        Map<String, Object> queryParameters) {
-        String response = getRestTemplate(client).getForObject(serviceInstancesEndpoint, String.class, queryParameters);
-        Map<String, Object> serviceInstancesResponse = parseResponse(response);
-        return getCloudServiceInstance(serviceInstancesResponse);
-    }
-
-    private Map<String, Object> parseResponse(String response) {
-        return JsonUtil.convertJsonToMap(response);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> getCloudServiceInstance(Map<String, Object> serviceInstancesResponse) {
-        validateServiceInstanceResponse(serviceInstancesResponse);
-        List<Map<String, Object>> cloudServiceInstanceResources = getResourcesFromResponse(serviceInstancesResponse);
-        if (!cloudServiceInstanceResources.isEmpty()) {
-            return (Map<String, Object>) cloudServiceInstanceResources.get(0)
-                .get("entity");
-        }
-        return null;
-    }
-
-    private void validateServiceInstanceResponse(Map<String, Object> serviceInstancesResponse) {
-        List<Map<String, Object>> resources = getResourcesFromResponse(serviceInstancesResponse);
-        Assert.notNull(resources, "The response of finding a service instance should contain a 'resources' element");
-        Assert.isTrue(resources.size() <= 1, "The response of finding a service instance should not have more than one resource element");
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<Map<String, Object>> getResourcesFromResponse(Map<String, Object> serviceInstancesResponse) {
-        return (List<Map<String, Object>>) serviceInstancesResponse.get("resources");
+    @Override
+    public String getServiceInstanceURL() {
+        return SERVICE_INSTANCES_URL;
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/UserProvidedServiceInstanceGetter.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/UserProvidedServiceInstanceGetter.java
@@ -1,0 +1,19 @@
+package com.sap.cloud.lm.sl.cf.core.cf.clients;
+
+import org.springframework.stereotype.Component;
+
+@Component("userProvidedServiceInstanceGetter")
+public class UserProvidedServiceInstanceGetter extends AbstractServiceGetter {
+
+    public UserProvidedServiceInstanceGetter(RestTemplateFactory restTemplateFactory) {
+        super(restTemplateFactory);
+    }
+
+    private static final String SERVICE_INSTANCES_URL = "/v2/user_provided_service_instances?q=name:{name}&q=space_guid:{space_guid}";
+
+    @Override
+    public String getServiceInstanceURL() {
+        return SERVICE_INSTANCES_URL;
+    }
+
+}

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Constants.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Constants.java
@@ -99,6 +99,7 @@ public class Constants {
     public static final String VAR_APPS_TO_RESTART_COUNT = "appsToRestartCount";
     public static final String VAR_APPS_TO_UNDEPLOY = "appsToUndeploy";
     public static final String VAR_SERVICES_TO_DELETE = "servicesToDelete";
+    public static final String VAR_SERVICES_GUIDS = "servicesGuids";
     public static final String VAR_SERVICE_URLS_TO_REGISTER = "serviceUrlsToRegister";
     public static final String VAR_SERVICE_BROKERS_TO_CREATE = "serviceBrokersToCreate";
     public static final String VAR_SUBSCRIPTIONS_TO_CREATE = "subscriptionsToCreate";

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -135,6 +135,9 @@ public class Messages {
     public static final String ERROR_UPDATING_OPTIONAL_SERVICE = "Error updating optional service \"{0}\" from offering \"{1}\" and plan \"{2}\": {3}";
     public static final String ERROR_DELETING_OPTIONAL_SERVICE = "Error deleting optional service \"{0}\" from offering \"{1}\" and plan \"{2}\": {3}";
     public static final String ERROR_MONITORING_CREATION_OF_SERVICES = "Error monitoring creation of services";
+    public static final String ERROR_MAPPING_SERVICE_NAME_TO_GUID = "Error mapping service \"{0}\" to guid";
+    public static final String ERROR_MAPPING_SERVICE_NAMES_TO_GUIDS = "Error mapping service names to guids";
+    
 
     // WARN log messages
     public static final String CANNOT_RETRIEVE_SERVICE_INSTANCE_OF_OPTIONAL_SERVICE = "Cannot retrieve service instance of optional service {0}";

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -135,8 +135,7 @@ public class Messages {
     public static final String ERROR_UPDATING_OPTIONAL_SERVICE = "Error updating optional service \"{0}\" from offering \"{1}\" and plan \"{2}\": {3}";
     public static final String ERROR_DELETING_OPTIONAL_SERVICE = "Error deleting optional service \"{0}\" from offering \"{1}\" and plan \"{2}\": {3}";
     public static final String ERROR_MONITORING_CREATION_OF_SERVICES = "Error monitoring creation of services";
-    public static final String ERROR_MAPPING_SERVICE_NAME_TO_GUID = "Error mapping service \"{0}\" to guid";
-    public static final String ERROR_MAPPING_SERVICE_NAMES_TO_GUIDS = "Error mapping service names to guids";
+    public static final String ERROR_MAPPING_SERVICE_NAMES_TO_GUIDS = "Error mapping services \"{0}\" to guids";
     
 
     // WARN log messages

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateServicesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateServicesStep.java
@@ -33,6 +33,7 @@ import com.sap.cloud.lm.sl.cf.client.XsCloudControllerClient;
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudApplicationExtended;
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudServiceExtended;
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudServiceOfferingExtended;
+import com.sap.cloud.lm.sl.cf.core.cf.clients.EventsGetter;
 import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceInstanceGetter;
 import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceUpdater;
 import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceWithAlternativesCreator;
@@ -64,6 +65,9 @@ public class CreateOrUpdateServicesStep extends AsyncActivitiStep {
 
     @Inject
     private ServiceInstanceGetter serviceInstanceGetter;
+    
+    @Inject
+    private EventsGetter eventsGetter;
 
     @Inject
     private ApplicationConfiguration configuration;
@@ -467,7 +471,7 @@ public class CreateOrUpdateServicesStep extends AsyncActivitiStep {
             CloudServiceExtended serviceExtended = (CloudServiceExtended) service;
             return serviceExtended.getTags();
         }
-        Map<String, Object> serviceInstance = serviceInstanceGetter.getServiceInstance(client, service.getName(), spaceId);
+        Map<String, Object> serviceInstance = serviceInstanceGetter.getServiceInstanceEntity(client, service.getName(), spaceId);
         return CommonUtil.cast(serviceInstance.get("tags"));
     }
 
@@ -511,6 +515,6 @@ public class CreateOrUpdateServicesStep extends AsyncActivitiStep {
 
     @Override
     protected List<AsyncExecution> getAsyncStepExecutions(ExecutionWrapper execution) {
-        return Arrays.asList(new PollServiceOperationsExecution(serviceInstanceGetter));
+        return Arrays.asList(new PollServiceCreateOrUpdateOperationsExecution(serviceInstanceGetter));
     }
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
@@ -1,7 +1,14 @@
 package com.sap.cloud.lm.sl.cf.process.steps;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.cloudfoundry.client.lib.CloudControllerClient;
@@ -17,61 +24,145 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+import com.sap.cloud.lm.sl.cf.client.XsCloudControllerClient;
+import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudServiceExtended;
+import com.sap.cloud.lm.sl.cf.core.cf.clients.EventsGetter;
+import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceGetter;
+import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceInstanceGetter;
+import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperationType;
 import com.sap.cloud.lm.sl.cf.core.security.serialization.SecureSerializationFacade;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.common.SLException;
+import com.sap.cloud.lm.sl.common.util.CommonUtil;
+import com.sap.cloud.lm.sl.common.util.JsonUtil;
 
 @Component("deleteServicesStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
-public class DeleteServicesStep extends SyncActivitiStep {
+public class DeleteServicesStep extends AsyncActivitiStep {
 
     private SecureSerializationFacade secureSerializer = new SecureSerializationFacade();
 
+    @Inject
+    private ServiceGetter serviceGetter;
+
+    @Inject
+    private EventsGetter eventsGetter;
+
     @Override
-    protected StepPhase executeStep(ExecutionWrapper execution) {
+    protected StepPhase executeAsyncStep(ExecutionWrapper execution) throws Exception {
         try {
             getStepLogger().debug(Messages.DELETING_SERVICES);
 
             CloudControllerClient client = execution.getControllerClient();
 
             List<String> servicesToDelete = StepsUtil.getServicesToDelete(execution.getContext());
-            deleteServices(client, servicesToDelete);
+            
+            XsCloudControllerClient xsClient = execution.getXsControllerClient();
+            if (xsClient == null) {
+                getServicesGuids(servicesToDelete, execution);
+            }
+            
+            Map<String, ServiceOperationType> triggeredServiceOperations = deleteServices(client, servicesToDelete);
+
+            execution.getStepLogger()
+                .debug(Messages.TRIGGERED_SERVICE_OPERATIONS, JsonUtil.toJson(triggeredServiceOperations, true));
+            StepsUtil.setTriggeredServiceOperations(execution.getContext(), triggeredServiceOperations);
 
             getStepLogger().debug(Messages.SERVICES_DELETED);
-            return StepPhase.DONE;
+            return StepPhase.POLL;
         } catch (SLException e) {
             getStepLogger().error(e, Messages.ERROR_DELETING_SERVICES);
             throw e;
         }
     }
 
-    private void deleteServices(CloudControllerClient client, List<String> serviceNames) {
-        for (String serviceName : serviceNames) {
-            deleteService(client, serviceName);
+    private void getServicesGuids(List<String> servicesToDeleteNames, ExecutionWrapper execution) {
+        Map<String, String> serviceGuids = getServiceGuids(servicesToDeleteNames, execution);
+        validateGuidMapping(servicesToDeleteNames, serviceGuids, execution);
+        StepsUtil.setServicesGuids(execution.getContext(), serviceGuids);
+    }
+
+    private Map<String, String> getServiceGuids(List<String> services, ExecutionWrapper execution) {
+        String spaceId = StepsUtil.getSpaceId(execution.getContext());
+        CloudControllerClient client = execution.getControllerClient();
+
+        return services.stream()
+            .map(name -> serviceGetter.getServiceInstance(client, name, spaceId))
+            .filter(instance -> instance != null && !instance.isEmpty())
+            .collect(Collectors.toMap(this::getNameFromInstance, this::getGuidFromInstance));
+    }
+
+    private void validateGuidMapping(List<String> servicesToDelete, Map<String, String> serviceGuids, ExecutionWrapper execution) {
+        servicesToDelete.stream()
+            .filter(name -> serviceGuids.get(name) == null)
+            .forEach(invalidEntry -> execution.getStepLogger()
+                .error(Messages.ERROR_MAPPING_SERVICE_NAME_TO_GUID, invalidEntry));
+
+        Optional<String> firstServiceWithoutGuid = servicesToDelete.stream()
+            .filter(name -> serviceGuids.get(name) == null)
+            .findFirst();
+
+        if (firstServiceWithoutGuid.isPresent()) {
+            throw new SLException(Messages.ERROR_MAPPING_SERVICE_NAMES_TO_GUIDS);
         }
+    }
+
+    private String getGuidFromInstance(Map<String, Object> serviceInstance) {
+        Map<String, Object> metadata = CommonUtil.cast(serviceInstance.get("metadata"));
+        return CommonUtil.cast(metadata.get("guid"));
+    }
+
+    private String getNameFromInstance(Map<String, Object> serviceInstance) {
+        Map<String, Object> metadata = CommonUtil.cast(serviceInstance.get("entity"));
+        return CommonUtil.cast(metadata.get("name"));
+    }
+
+    private Map<String, ServiceOperationType> deleteServices(CloudControllerClient client, List<String> serviceNames) {
+        Map<String, ServiceOperationType> triggeredServiceOperations = new HashMap<>();
+
+        List<CloudServiceInstance> serviceInstances = getServiceInstances(serviceNames, client);
+        List<CloudServiceInstance> deletableServices = getDeletableServices(serviceInstances);
+
+        for (CloudServiceInstance instance : deletableServices) {
+            try {
+                deleteService(client, instance.getService()
+                    .getName());
+                triggeredServiceOperations.put(instance.getService()
+                    .getName(), ServiceOperationType.DELETE);
+            } catch (CloudOperationException | CloudException e) {
+                processException(e, instance, instance.getService()
+                    .getName());
+            }
+        }
+        return triggeredServiceOperations;
+    }
+
+    private List<CloudServiceInstance> getServiceInstances(List<String> serviceNames, CloudControllerClient client) {
+        return serviceNames.parallelStream()
+            .map(client::getServiceInstance)
+            .collect(Collectors.toList());
+    }
+
+    private List<CloudServiceInstance> getDeletableServices(List<CloudServiceInstance> serviceInstances) {
+        return serviceInstances.parallelStream()
+            .filter(serviceInstance -> validateServiceHasNoBindings(serviceInstance, serviceInstance.getName()))
+            .collect(Collectors.toList());
     }
 
     private void deleteService(CloudControllerClient client, String serviceName) {
-        CloudServiceInstance serviceInstance = null;
-        try {
-            serviceInstance = client.getServiceInstance(serviceName);
-            attemptToDeleteService(client, serviceInstance, serviceName);
-        } catch (CloudOperationException | CloudException e) {
-            processException(e, serviceInstance, serviceName);
-        }
+        getStepLogger().info(Messages.DELETING_SERVICE, serviceName);
+        client.deleteService(serviceName);
+        getStepLogger().debug(Messages.SERVICE_DELETED, serviceName);
     }
 
-    private void attemptToDeleteService(CloudControllerClient client, CloudServiceInstance serviceInstance, String serviceName) {
+    private boolean validateServiceHasNoBindings(CloudServiceInstance serviceInstance, String serviceName) {
         List<CloudServiceBinding> bindings = serviceInstance.getBindings();
         if (!CollectionUtils.isEmpty(bindings)) {
             logBindings(bindings);
             getStepLogger().info(Messages.SERVICE_HAS_BINDINGS_AND_CANNOT_BE_DELETED, serviceName);
-            return;
+            return false;
         }
-
-        getStepLogger().info(Messages.DELETING_SERVICE, serviceName);
-        client.deleteService(serviceName);
-        getStepLogger().debug(Messages.SERVICE_DELETED, serviceName);
+        return true;
     }
 
     private void processException(Exception e, CloudServiceInstance serviceInstance, String serviceName) {
@@ -112,6 +203,11 @@ public class DeleteServicesStep extends SyncActivitiStep {
 
     private void logBindings(List<CloudServiceBinding> bindings) {
         getStepLogger().debug(Messages.SERVICE_BINDINGS_EXISTS, secureSerializer.toJson(bindings));
+    }
+
+    @Override
+    protected List<AsyncExecution> getAsyncStepExecutions(ExecutionWrapper execution) {
+        return Arrays.asList(new PollServiceDeleteOperationsExecution(serviceGetter, eventsGetter));
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceCreateOrUpdateOperationsExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceCreateOrUpdateOperationsExecution.java
@@ -1,0 +1,87 @@
+package com.sap.cloud.lm.sl.cf.process.steps;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.cloudfoundry.client.lib.CloudControllerClient;
+import org.flowable.engine.delegate.DelegateExecution;
+
+import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudServiceExtended;
+import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceInstanceGetter;
+import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperation;
+import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperationState;
+import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperationType;
+import com.sap.cloud.lm.sl.cf.process.message.Messages;
+import com.sap.cloud.lm.sl.cf.process.util.ServiceOperationExecutor;
+
+public class PollServiceCreateOrUpdateOperationsExecution extends PollServiceOperationsExecution implements AsyncExecution {
+
+    private static final String LAST_SERVICE_OPERATION = "last_operation";
+    private static final String SERVICE_NAME = "name";
+    private static final String SERVICE_OPERATION_TYPE = "type";
+    private static final String SERVICE_OPERATION_STATE = "state";
+    private static final String SERVICE_OPERATION_DESCRIPTION = "description";
+
+    private ServiceOperationExecutor serviceOperationExecutor = new ServiceOperationExecutor();
+    private ServiceInstanceGetter serviceInstanceGetter;
+
+    public PollServiceCreateOrUpdateOperationsExecution(ServiceInstanceGetter serviceInstanceGetter) {
+        this.serviceInstanceGetter = serviceInstanceGetter;
+    }
+
+    @Override
+    protected List<CloudServiceExtended> computeServicesToPoll(ExecutionWrapper execution,
+        Map<String, ServiceOperationType> triggeredServiceOperations) {
+
+        List<CloudServiceExtended> servicesToCreate = getServicesToCreate(execution.getContext());
+
+        return getServicesWithTriggeredOperations(servicesToCreate, triggeredServiceOperations);
+    }
+
+    private List<CloudServiceExtended> getServicesToCreate(DelegateExecution context) {
+        List<CloudServiceExtended> allServicesToCreate = StepsUtil.getServicesToCreate(context);
+        // There's no need to poll the creation or update of user-provided services, because it is done synchronously:
+        return allServicesToCreate.stream()
+            .filter(s -> !s.isUserProvided())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    protected ServiceOperation getLastServiceOperation(ExecutionWrapper execution, CloudControllerClient client,
+        CloudServiceExtended service) {
+        Map<String, Object> cloudServiceInstance = serviceOperationExecutor.executeServiceOperation(service,
+            () -> serviceInstanceGetter.getServiceInstanceEntity(client, service.getName(), StepsUtil.getSpaceId(execution.getContext())),
+            execution.getStepLogger());
+
+        if (cloudServiceInstance == null || cloudServiceInstance.isEmpty()) {
+            handleMissingServiceInstance(execution, service);
+            return null;
+        }
+        return getLastOperation(execution, cloudServiceInstance);
+    }
+
+    @SuppressWarnings("unchecked")
+    private ServiceOperation getLastOperation(ExecutionWrapper execution, Map<String, Object> cloudServiceInstance) {
+        Map<String, Object> lastOperationAsMap = (Map<String, Object>) cloudServiceInstance.get(LAST_SERVICE_OPERATION);
+        ServiceOperation lastOperation = parseServiceOperationFromMap(lastOperationAsMap);
+        // TODO Separate create and update steps
+        // Be fault tolerant on failure on update of service
+        if (lastOperation.getType() == ServiceOperationType.UPDATE && lastOperation.getState() == ServiceOperationState.FAILED) {
+            execution.getStepLogger()
+                .warn(Messages.FAILED_SERVICE_UPDATE, cloudServiceInstance.get(SERVICE_NAME), lastOperation.getDescription());
+            return new ServiceOperation(lastOperation.getType(), lastOperation.getDescription(), ServiceOperationState.SUCCEEDED);
+        }
+        return lastOperation;
+    }
+
+    private ServiceOperation parseServiceOperationFromMap(Map<String, Object> serviceOperation) {
+        ServiceOperationType type = ServiceOperationType.fromString((String) serviceOperation.get(SERVICE_OPERATION_TYPE));
+        ServiceOperationState state = ServiceOperationState.fromString((String) serviceOperation.get(SERVICE_OPERATION_STATE));
+        String description = (String) serviceOperation.get(SERVICE_OPERATION_DESCRIPTION);
+        if (description == null && state == ServiceOperationState.FAILED) {
+            description = Messages.DEFAULT_FAILED_OPERATION_DESCRIPTION;
+        }
+        return new ServiceOperation(type, description, state);
+    }
+}

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceDeleteOperationsExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceDeleteOperationsExecution.java
@@ -1,0 +1,71 @@
+package com.sap.cloud.lm.sl.cf.process.steps;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.cloudfoundry.client.lib.CloudControllerClient;
+import org.cloudfoundry.client.lib.domain.CloudEntity.Meta;
+import org.cloudfoundry.client.lib.domain.CloudEvent;
+
+import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudServiceExtended;
+import com.sap.cloud.lm.sl.cf.core.cf.clients.EventsGetter;
+import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceGetter;
+import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperation;
+import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperationState;
+import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperationType;
+import com.sap.cloud.lm.sl.cf.process.message.Messages;
+import com.sap.cloud.lm.sl.common.SLException;
+import com.sap.cloud.lm.sl.common.util.CommonUtil;
+
+public class PollServiceDeleteOperationsExecution extends PollServiceOperationsExecution implements AsyncExecution {
+
+    private static final String SERVICE_EVENT_TYPE_DELETE = "audit.service_instance.delete";
+
+    private EventsGetter eventsGetter;
+
+    private ServiceGetter serviceGetter;
+
+    public PollServiceDeleteOperationsExecution(ServiceGetter serviceGetter, EventsGetter eventsGetter) {
+        this.eventsGetter = eventsGetter;
+        this.serviceGetter = serviceGetter;
+    }
+
+    @Override
+    protected List<CloudServiceExtended> computeServicesToPoll(ExecutionWrapper execution,
+        Map<String, ServiceOperationType> triggeredServiceOperations) {
+        List<String> servicesToDeleteNames = StepsUtil.getServicesToDelete(execution.getContext());
+        List<CloudServiceExtended> servicesToDelete = getServicesData(servicesToDeleteNames, execution);
+        return getServicesWithTriggeredOperations(servicesToDelete, triggeredServiceOperations);
+    }
+
+    private List<CloudServiceExtended> getServicesData(List<String> servicesToDeleteNames, ExecutionWrapper execution) {
+        Map<String, String> servicesGuids = StepsUtil.getServicesGuids(execution.getContext());
+        return servicesToDeleteNames.stream()
+            .map(name -> new CloudServiceExtended(new Meta(UUID.fromString(servicesGuids.get(name)), null, null), name))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    protected ServiceOperation getLastServiceOperation(ExecutionWrapper execution, CloudControllerClient client,
+        CloudServiceExtended service) {
+        return getLastDeleteServiceOperation(execution, service);
+    }
+
+    private ServiceOperation getLastDeleteServiceOperation(ExecutionWrapper execution, CloudServiceExtended service) {
+        if (service.getMeta() == null) {
+            return null;
+        }
+        boolean isServiceDeleted = isServiceDeleted(execution, service.getMeta()
+            .getGuid());
+        ServiceOperationState operationState = isServiceDeleted ? ServiceOperationState.SUCCEEDED : ServiceOperationState.IN_PROGRESS;
+        return new ServiceOperation(ServiceOperationType.DELETE, ServiceOperationType.DELETE.name(), operationState);
+    }
+
+    private boolean isServiceDeleted(ExecutionWrapper execution, UUID uuid) {
+        CloudEvent serviceEvent = eventsGetter.getLastEvent(uuid, execution.getControllerClient());
+        return serviceEvent != null && SERVICE_EVENT_TYPE_DELETE.equals(serviceEvent.getType());
+    }
+}

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceDeleteOperationsExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceDeleteOperationsExecution.java
@@ -2,7 +2,6 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -12,25 +11,16 @@ import org.cloudfoundry.client.lib.domain.CloudEvent;
 
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudServiceExtended;
 import com.sap.cloud.lm.sl.cf.core.cf.clients.EventsGetter;
-import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceGetter;
 import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperation;
 import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperationState;
 import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperationType;
-import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
-import com.sap.cloud.lm.sl.common.util.CommonUtil;
 
 public class PollServiceDeleteOperationsExecution extends PollServiceOperationsExecution implements AsyncExecution {
 
-    private static final String SERVICE_EVENT_TYPE_DELETE = "audit.service_instance.delete";
-
     private EventsGetter eventsGetter;
 
-    private ServiceGetter serviceGetter;
-
-    public PollServiceDeleteOperationsExecution(ServiceGetter serviceGetter, EventsGetter eventsGetter) {
+    public PollServiceDeleteOperationsExecution(EventsGetter eventsGetter) {
         this.eventsGetter = eventsGetter;
-        this.serviceGetter = serviceGetter;
     }
 
     @Override
@@ -66,6 +56,6 @@ public class PollServiceDeleteOperationsExecution extends PollServiceOperationsE
 
     private boolean isServiceDeleted(ExecutionWrapper execution, UUID uuid) {
         CloudEvent serviceEvent = eventsGetter.getLastEvent(uuid, execution.getControllerClient());
-        return serviceEvent != null && SERVICE_EVENT_TYPE_DELETE.equals(serviceEvent.getType());
+        return serviceEvent != null && eventsGetter.isDeleteEvent(serviceEvent.getType());
     }
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceOperationsExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceOperationsExecution.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import org.cloudfoundry.client.lib.CloudControllerClient;
 import org.cloudfoundry.client.lib.CloudControllerException;
 import org.cloudfoundry.client.lib.CloudOperationException;
-import org.flowable.engine.delegate.DelegateExecution;
 
 import com.sap.cloud.lm.sl.cf.client.XsCloudControllerClient;
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudServiceExtended;

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceOperationsExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceOperationsExecution.java
@@ -19,30 +19,15 @@ import org.flowable.engine.delegate.DelegateExecution;
 
 import com.sap.cloud.lm.sl.cf.client.XsCloudControllerClient;
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudServiceExtended;
-import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceInstanceGetter;
 import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperation;
 import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperationState;
 import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperationType;
 import com.sap.cloud.lm.sl.cf.core.cf.services.TypedServiceOperationState;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.cf.process.util.ServiceOperationExecutor;
 import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.common.util.JsonUtil;
 
-public class PollServiceOperationsExecution implements AsyncExecution {
-
-    private static final String LAST_SERVICE_OPERATION = "last_operation";
-    private static final String SERVICE_NAME = "name";
-    private static final String SERVICE_OPERATION_TYPE = "type";
-    private static final String SERVICE_OPERATION_STATE = "state";
-    private static final String SERVICE_OPERATION_DESCRIPTION = "description";
-
-    private ServiceOperationExecutor serviceOperationExecutor = new ServiceOperationExecutor();
-    private ServiceInstanceGetter serviceInstanceGetter;
-
-    public PollServiceOperationsExecution(ServiceInstanceGetter serviceInstanceGetter) {
-        this.serviceInstanceGetter = serviceInstanceGetter;
-    }
+public abstract class PollServiceOperationsExecution implements AsyncExecution {
 
     @Override
     public AsyncExecutionState execute(ExecutionWrapper execution) {
@@ -96,86 +81,37 @@ public class PollServiceOperationsExecution implements AsyncExecution {
         }
     }
 
-    private List<CloudServiceExtended> getServiceOperationsToPoll(ExecutionWrapper execution,
+    protected List<CloudServiceExtended> getServiceOperationsToPoll(ExecutionWrapper execution,
         Map<String, ServiceOperationType> triggeredServiceOperations) {
         List<CloudServiceExtended> servicesToPoll = StepsUtil.getServicesToPoll(execution.getContext());
         if (servicesToPoll == null) {
-            return computeServicesToPoll(execution.getContext(), triggeredServiceOperations);
+            return computeServicesToPoll(execution, triggeredServiceOperations);
         }
         return servicesToPoll;
     }
-
-    private List<CloudServiceExtended> computeServicesToPoll(DelegateExecution context,
+    
+    protected List<CloudServiceExtended> getServicesWithTriggeredOperations(List<CloudServiceExtended> services,
         Map<String, ServiceOperationType> triggeredServiceOperations) {
-        List<CloudServiceExtended> services = StepsUtil.getServicesToCreate(context);
-        // There's no need to poll the creation or update of user-provided services, because it is done synchronously:
         return services.stream()
             .filter(service -> triggeredServiceOperations.containsKey(service.getName()))
-            .filter(service -> !service.isUserProvided())
             .collect(Collectors.toList());
     }
 
-    private ServiceOperation getLastServiceOperation(ExecutionWrapper execution, CloudControllerClient client,
-        CloudServiceExtended service) {
-        Map<String, Object> cloudServiceInstance = serviceOperationExecutor.executeServiceOperation(service,
-            () -> serviceInstanceGetter.getServiceInstance(client, service.getName(), StepsUtil.getSpaceId(execution.getContext())),
-            execution.getStepLogger());
+    protected abstract List<CloudServiceExtended> computeServicesToPoll(ExecutionWrapper execution,
+        Map<String, ServiceOperationType> triggeredServiceOperations);
 
-        validateCloudServiceInstance(execution, service, cloudServiceInstance);
-        if (cloudServiceInstance == null) {
-            return null;
-        }
+    protected abstract ServiceOperation getLastServiceOperation(ExecutionWrapper execution, CloudControllerClient client,
+        CloudServiceExtended service);
 
-        return getLastOperation(execution, cloudServiceInstance);
-    }
 
-    private void validateCloudServiceInstance(ExecutionWrapper execution, CloudServiceExtended service,
-        Map<String, Object> cloudServiceInstance) {
-        if (cloudServiceInstance == null && !service.isOptional()) {
-            throw new SLException(Messages.CANNOT_RETRIEVE_INSTANCE_OF_SERVICE, service.getName());
-        }
-
-        if (cloudServiceInstance == null && service.isOptional()) {
-            // Here we're assuming that we cannot retrieve the service instance, because its creation was synchronous and it failed. If that
-            // is really the case, then showing a warning progress message to the user is unnecessary, since one should have been shown back
-            // in CreateOrUpdateServicesStep.
-            execution.getStepLogger()
-                .warnWithoutProgressMessage(Messages.CANNOT_RETRIEVE_SERVICE_INSTANCE_OF_OPTIONAL_SERVICE, service.getName());
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private ServiceOperation getLastOperation(ExecutionWrapper execution, Map<String, Object> cloudServiceInstance) {
-        Map<String, Object> lastOperationAsMap = (Map<String, Object>) cloudServiceInstance.get(LAST_SERVICE_OPERATION);
-        ServiceOperation lastOperation = parseServiceOperationFromMap(lastOperationAsMap);
-        // TODO Separate create and update steps
-        // Be fault tolerant on failure on update of service
-        if (lastOperation.getType() == ServiceOperationType.UPDATE && lastOperation.getState() == ServiceOperationState.FAILED) {
-            execution.getStepLogger()
-                .warn(Messages.FAILED_SERVICE_UPDATE, cloudServiceInstance.get(SERVICE_NAME), lastOperation.getDescription());
-            return new ServiceOperation(lastOperation.getType(), lastOperation.getDescription(), ServiceOperationState.SUCCEEDED);
-        }
-        return lastOperation;
-    }
-
-    private ServiceOperation parseServiceOperationFromMap(Map<String, Object> serviceOperation) {
-        ServiceOperationType type = ServiceOperationType.fromString((String) serviceOperation.get(SERVICE_OPERATION_TYPE));
-        ServiceOperationState state = ServiceOperationState.fromString((String) serviceOperation.get(SERVICE_OPERATION_STATE));
-        String description = (String) serviceOperation.get(SERVICE_OPERATION_DESCRIPTION);
-        if (description == null && state == ServiceOperationState.FAILED) {
-            description = Messages.DEFAULT_FAILED_OPERATION_DESCRIPTION;
-        }
-        return new ServiceOperation(type, description, state);
-    }
-
-    private void reportIndividualServiceState(ExecutionWrapper execution,
+    protected void reportIndividualServiceState(ExecutionWrapper execution,
         Map<CloudServiceExtended, ServiceOperation> servicesWithLastOperation) {
         for (Entry<CloudServiceExtended, ServiceOperation> serviceWithLastOperation : servicesWithLastOperation.entrySet()) {
             reportIndividualServiceState(execution, serviceWithLastOperation.getKey(), serviceWithLastOperation.getValue());
         }
     }
 
-    private void reportIndividualServiceState(ExecutionWrapper execution, CloudServiceExtended service, ServiceOperation lastOperation) {
+    protected void reportIndividualServiceState(ExecutionWrapper execution, CloudServiceExtended service, ServiceOperation lastOperation) {
         if (lastOperation.getState() == ServiceOperationState.SUCCEEDED) {
             execution.getStepLogger()
                 .debug(getSuccessMessage(service, lastOperation.getType()));
@@ -191,6 +127,43 @@ public class PollServiceOperationsExecution implements AsyncExecution {
         }
     }
 
+
+    protected void reportServiceOperationsState(ExecutionWrapper execution,
+        Map<CloudServiceExtended, ServiceOperation> servicesWithLastOperation,
+        Map<String, ServiceOperationType> triggeredServiceOperations) {
+        List<TypedServiceOperationState> nonFinalStates = getNonFinalStates(servicesWithLastOperation.values());
+        List<String> nonFinalStateStrings = getStateStrings(nonFinalStates);
+
+        int doneOperations = triggeredServiceOperations.size() - nonFinalStates.size();
+        if (!nonFinalStateStrings.isEmpty()) {
+            execution.getStepLogger()
+                .info("{0} of {1} done, ({2})", doneOperations, triggeredServiceOperations.size(), String.join(",", nonFinalStateStrings));
+        } else {
+            execution.getStepLogger()
+                .info("{0} of {0} done", triggeredServiceOperations.size());
+        }
+    }
+
+    protected List<CloudServiceExtended> getRemainingServicesToPoll(Map<CloudServiceExtended, ServiceOperation> servicesWithLastOperation) {
+        return servicesWithLastOperation.entrySet()
+            .stream()
+            .filter(serviceWithLastOperation -> serviceWithLastOperation.getValue()
+                .getState() == ServiceOperationState.IN_PROGRESS)
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
+    }
+    
+    protected void handleMissingServiceInstance(ExecutionWrapper execution, CloudServiceExtended service) {
+        if (!service.isOptional()) {
+            throw new SLException(Messages.CANNOT_RETRIEVE_INSTANCE_OF_SERVICE, service.getName());
+        }
+        // Here we're assuming that we cannot retrieve the service instance, because its creation was synchronous and it failed. If that
+        // is really the case, then showing a warning progress message to the user is unnecessary, since one should have been shown back
+        // in CreateOrUpdateServicesStep.
+        execution.getStepLogger()
+        .warnWithoutProgressMessage(Messages.CANNOT_RETRIEVE_SERVICE_INSTANCE_OF_OPTIONAL_SERVICE, service.getName());
+    }
+
     private String getSuccessMessage(CloudServiceExtended service, ServiceOperationType type) {
         switch (type) {
             case CREATE:
@@ -204,7 +177,7 @@ public class PollServiceOperationsExecution implements AsyncExecution {
                     MessageFormat.format(com.sap.cloud.lm.sl.cf.core.message.Messages.ILLEGAL_SERVICE_OPERATION_TYPE, type));
         }
     }
-
+    
     private String getFailureMessage(CloudServiceExtended service, ServiceOperation operation) {
         switch (operation.getType()) {
             case CREATE:
@@ -221,7 +194,7 @@ public class PollServiceOperationsExecution implements AsyncExecution {
                     MessageFormat.format(com.sap.cloud.lm.sl.cf.core.message.Messages.ILLEGAL_SERVICE_OPERATION_TYPE, operation.getType()));
         }
     }
-
+    
     private String getWarningMessage(CloudServiceExtended service, ServiceOperation operation) {
         switch (operation.getType()) {
             case CREATE:
@@ -238,23 +211,7 @@ public class PollServiceOperationsExecution implements AsyncExecution {
                     MessageFormat.format(com.sap.cloud.lm.sl.cf.core.message.Messages.ILLEGAL_SERVICE_OPERATION_TYPE, operation.getType()));
         }
     }
-
-    private void reportServiceOperationsState(ExecutionWrapper execution,
-        Map<CloudServiceExtended, ServiceOperation> servicesWithLastOperation,
-        Map<String, ServiceOperationType> triggeredServiceOperations) {
-        List<TypedServiceOperationState> nonFinalStates = getNonFinalStates(servicesWithLastOperation.values());
-        List<String> nonFinalStateStrings = getStateStrings(nonFinalStates);
-
-        int doneOperations = triggeredServiceOperations.size() - nonFinalStates.size();
-        if (!nonFinalStateStrings.isEmpty()) {
-            execution.getStepLogger()
-                .info("{0} of {1} done, ({2})", doneOperations, triggeredServiceOperations.size(), String.join(",", nonFinalStateStrings));
-        } else {
-            execution.getStepLogger()
-                .info("{0} of {0} done", triggeredServiceOperations.size());
-        }
-    }
-
+    
     private List<TypedServiceOperationState> getNonFinalStates(Collection<ServiceOperation> operations) {
         return operations.stream()
             .map(TypedServiceOperationState::fromServiceOperation)
@@ -278,12 +235,4 @@ public class PollServiceOperationsExecution implements AsyncExecution {
             .collect(Collectors.groupingBy(state -> state, TreeMap::new, Collectors.counting()));
     }
 
-    private List<CloudServiceExtended> getRemainingServicesToPoll(Map<CloudServiceExtended, ServiceOperation> servicesWithLastOperation) {
-        return servicesWithLastOperation.entrySet()
-            .stream()
-            .filter(serviceWithLastOperation -> serviceWithLastOperation.getValue()
-                .getState() == ServiceOperationState.IN_PROGRESS)
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toList());
-    }
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StepsUtil.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StepsUtil.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StepsUtil.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StepsUtil.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -319,9 +320,10 @@ public class StepsUtil {
     @SuppressWarnings("unchecked")
     public static List<CloudServiceExtended> getServicesToCreate(DelegateExecution context) {
         List<String> services = (List<String>) context.getVariable(Constants.VAR_SERVICES_TO_CREATE);
-        return services.stream()
-            .map(service -> (CloudServiceExtended) JsonUtil.fromJson(service, CloudServiceExtended.class))
-            .collect(Collectors.toList());
+        return services == null ? Collections.emptyList()
+            : services.stream()
+                .map(service -> (CloudServiceExtended) JsonUtil.fromJson(service, CloudServiceExtended.class))
+                .collect(Collectors.toList());
     }
 
     static void setServicesToCreate(DelegateExecution context, List<CloudServiceExtended> services) {
@@ -479,7 +481,8 @@ public class StepsUtil {
     }
 
     public static List<String> getServicesToDelete(DelegateExecution context) {
-        return getArrayVariableAsList(context, Constants.VAR_SERVICES_TO_DELETE);
+        List<String> arrayVariableAsList = getArrayVariableAsList(context, Constants.VAR_SERVICES_TO_DELETE);
+        return arrayVariableAsList != null ? arrayVariableAsList : Collections.emptyList();
     }
 
     public static void setServicesToDelete(DelegateExecution context, List<String> services) {
@@ -1037,4 +1040,19 @@ public class StepsUtil {
     public static boolean getSkipUpdateConfigurationEntries(DelegateExecution context) {
         return (boolean) context.getVariable(Constants.VAR_SKIP_UPDATE_CONFIGURATION_ENTRIES);
     }
+
+    public static void setServicesGuids(DelegateExecution context, Map<String, String> serviceGuids) {
+        context.setVariable(Constants.VAR_SERVICES_GUIDS, JsonUtil.getAsBinaryJson(serviceGuids));
+    }
+
+    public static Map<String, String> getServicesGuids(DelegateExecution context) {
+        byte[] binaryJson = (byte[]) context.getVariable(Constants.VAR_SERVICES_GUIDS);
+        if (binaryJson == null) {
+            return Collections.emptyMap();
+        }
+        String jsonString = new String(binaryJson, StandardCharsets.UTF_8);
+        return JsonUtil.fromJson(jsonString, new TypeToken<Map<String, String>>() {
+        }.getType());
+    }
+
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/delete-services.bpmn
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/delete-services.bpmn
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="deleteServicesSubProcess" name="Delete Services Sub Process " isExecutable="true">
+    <startEvent id="startEvent" name="Start" activiti:initiator="initiator"></startEvent>
+    <endEvent id="endevent1" name="End"></endEvent>
+    <serviceTask id="deleteServicesWithPolling" name="Delete services with polling" activiti:async="true" activiti:delegateExpression="${deleteServicesStep}"></serviceTask>
+    <sequenceFlow id="flow1" sourceRef="startEvent" targetRef="deleteServicesWithPolling"></sequenceFlow>
+    <intermediateCatchEvent id="timerintermediatecatchevent1" name="TimerCatchEvent">
+      <timerEventDefinition>
+        <timeDuration>PT10S</timeDuration>
+      </timerEventDefinition>
+    </intermediateCatchEvent>
+    <exclusiveGateway id="exclusivegateway1" name="Exclusive Gateway" default="waitFlow"></exclusiveGateway>
+    <sequenceFlow id="flow2" sourceRef="deleteServicesWithPolling" targetRef="exclusivegateway1"></sequenceFlow>
+    <sequenceFlow id="waitFlow" name="Wait" sourceRef="exclusivegateway1" targetRef="timerintermediatecatchevent1"></sequenceFlow>
+    <sequenceFlow id="pollingFlow" name="Poll" sourceRef="timerintermediatecatchevent1" targetRef="deleteServicesWithPolling"></sequenceFlow>
+    <sequenceFlow id="doneFlow" name="Done" sourceRef="exclusivegateway1" targetRef="endevent1">
+      <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(StepExecution == "DONE")}]]></conditionExpression>
+    </sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_deleteServicesSubProcess">
+    <bpmndi:BPMNPlane bpmnElement="deleteServicesSubProcess" id="BPMNPlane_deleteServicesSubProcess">
+      <bpmndi:BPMNShape bpmnElement="startEvent" id="BPMNShape_startEvent">
+        <omgdc:Bounds height="35.0" width="35.0" x="165.0" y="111.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endevent1" id="BPMNShape_endevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="660.0" y="115.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="deleteServicesWithPolling" id="BPMNShape_deleteServicesWithPolling">
+        <omgdc:Bounds height="71.0" width="105.0" x="310.0" y="93.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="timerintermediatecatchevent1" id="BPMNShape_timerintermediatecatchevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="345.0" y="248.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="exclusivegateway1" id="BPMNShape_exclusivegateway1">
+        <omgdc:Bounds height="40.0" width="40.0" x="520.0" y="111.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="200.0" y="128.0"></omgdi:waypoint>
+        <omgdi:waypoint x="310.0" y="128.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+        <omgdi:waypoint x="415.0" y="128.0"></omgdi:waypoint>
+        <omgdi:waypoint x="520.0" y="131.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="waitFlow" id="BPMNEdge_waitFlow">
+        <omgdi:waypoint x="540.0" y="151.0"></omgdi:waypoint>
+        <omgdi:waypoint x="362.0" y="248.0"></omgdi:waypoint>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="13.0" width="22.0" x="459.0" y="183.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="pollingFlow" id="BPMNEdge_pollingFlow">
+        <omgdi:waypoint x="362.0" y="248.0"></omgdi:waypoint>
+        <omgdi:waypoint x="362.0" y="164.0"></omgdi:waypoint>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="13.0" width="19.0" x="330.0" y="191.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="doneFlow" id="BPMNEdge_doneFlow">
+        <omgdi:waypoint x="560.0" y="131.0"></omgdi:waypoint>
+        <omgdi:waypoint x="660.0" y="132.0"></omgdi:waypoint>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="13.0" width="27.0" x="580.0" y="111.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-bg-deploy.bpmn
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-bg-deploy.bpmn
@@ -17,8 +17,6 @@
     <sequenceFlow id="flow16" sourceRef="deleteUnusedReservedRoutesTask" targetRef="createOrUpdateServicesTask"></sequenceFlow>
     <sequenceFlow id="flow12" sourceRef="buildDeployModelTask" targetRef="buildUndeployModelTask"></sequenceFlow>
     <serviceTask id="prepareToUndeployAppsTask" name="Prepare To Undeploy Apps" activiti:async="true" activiti:delegateExpression="${prepareToUndeployAppsStep}"></serviceTask>
-    <sequenceFlow id="flow43" sourceRef="deleteServicesTask" targetRef="createOrUpdateServiceBrokersTask"></sequenceFlow>
-    <serviceTask id="deleteServicesTask" name="Delete Services" activiti:async="true" activiti:delegateExpression="${deleteServicesStep}"></serviceTask>
     <serviceTask id="validateParametersTask" name="Validate Parameters" activiti:async="true" activiti:delegateExpression="${validateDeployParametersStep}"></serviceTask>
     <sequenceFlow id="flow2" sourceRef="validateParametersTask" targetRef="processArchiveTask"></sequenceFlow>
     <serviceTask id="registerServiceUrlsTask" name="Register Service URLs" activiti:async="true" activiti:delegateExpression="${registerServiceUrlsStep}"></serviceTask>
@@ -103,7 +101,6 @@
     <sequenceFlow id="appsUndeployedFlow" sourceRef="shouldUndeployAppGateway" targetRef="shouldDeleteDiscontinuedServicesGateway">
       <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(appsToUndeployCount == appsToUndeployIndex)}]]></conditionExpression>
     </sequenceFlow>
-    <sequenceFlow id="deleteDiscontinuedServicesFlow" sourceRef="shouldDeleteDiscontinuedServicesGateway" targetRef="deleteServicesTask"></sequenceFlow>
     <sequenceFlow id="doNotDeleteDiscontinuedServicesFlow" sourceRef="shouldDeleteDiscontinuedServicesGateway" targetRef="createOrUpdateServiceBrokersTask">
       <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(deleteServices == false)}]]></conditionExpression>
     </sequenceFlow>
@@ -161,6 +158,9 @@
     </callActivity>
     <sequenceFlow id="flow149" sourceRef="prepareAppsRestartTask" targetRef="restartAppCallActivity"></sequenceFlow>
     <sequenceFlow id="flow150" sourceRef="restartAppCallActivity" targetRef="deleteIdleRoutesTask"></sequenceFlow>
+    <callActivity id="deleteServicesCallActivity" name="Delete Services Sub Process" activiti:async="true" calledElement="deleteServicesSubProcess" activiti:inheritVariables="true"></callActivity>
+    <sequenceFlow id="deleteDiscontinuedServicesFlow" sourceRef="shouldDeleteDiscontinuedServicesGateway" targetRef="deleteServicesCallActivity"></sequenceFlow>
+    <sequenceFlow id="flow152" sourceRef="deleteServicesCallActivity" targetRef="createOrUpdateServiceBrokersTask"></sequenceFlow>
   </process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_xs2-bg-deploy">
     <bpmndi:BPMNPlane bpmnElement="xs2-bg-deploy" id="BPMNPlane_xs2-bg-deploy">
@@ -181,9 +181,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="prepareToUndeployAppsTask" id="BPMNShape_prepareToUndeployAppsTask">
         <omgdc:Bounds height="65.0" width="105.0" x="945.0" y="580.0"></omgdc:Bounds>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="deleteServicesTask" id="BPMNShape_deleteServicesTask">
-        <omgdc:Bounds height="65.0" width="106.0" x="532.0" y="582.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="validateParametersTask" id="BPMNShape_validateParametersTask">
         <omgdc:Bounds height="65.0" width="105.0" x="428.0" y="27.0"></omgdc:Bounds>
@@ -329,6 +326,9 @@
       <bpmndi:BPMNShape bpmnElement="restartAppCallActivity" id="BPMNShape_restartAppCallActivity">
         <omgdc:Bounds height="61.0" width="105.0" x="1529.0" y="380.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="deleteServicesCallActivity" id="BPMNShape_deleteServicesCallActivity">
+        <omgdc:Bounds height="67.0" width="105.0" x="522.0" y="581.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge bpmnElement="flow16" id="BPMNEdge_flow16">
         <omgdi:waypoint x="772.0" y="265.0"></omgdi:waypoint>
         <omgdi:waypoint x="603.0" y="266.0"></omgdi:waypoint>
@@ -336,10 +336,6 @@
       <bpmndi:BPMNEdge bpmnElement="flow12" id="BPMNEdge_flow12">
         <omgdi:waypoint x="443.0" y="154.0"></omgdi:waypoint>
         <omgdi:waypoint x="388.0" y="154.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="flow43" id="BPMNEdge_flow43">
-        <omgdi:waypoint x="532.0" y="614.0"></omgdi:waypoint>
-        <omgdi:waypoint x="495.0" y="614.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
         <omgdi:waypoint x="533.0" y="59.0"></omgdi:waypoint>
@@ -522,10 +518,6 @@
         <omgdi:waypoint x="678.0" y="567.0"></omgdi:waypoint>
         <omgdi:waypoint x="679.0" y="594.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="deleteDiscontinuedServicesFlow" id="BPMNEdge_deleteDiscontinuedServicesFlow">
-        <omgdi:waypoint x="659.0" y="614.0"></omgdi:waypoint>
-        <omgdi:waypoint x="638.0" y="614.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="doNotDeleteDiscontinuedServicesFlow" id="BPMNEdge_doNotDeleteDiscontinuedServicesFlow">
         <omgdi:waypoint x="679.0" y="634.0"></omgdi:waypoint>
         <omgdi:waypoint x="679.0" y="678.0"></omgdi:waypoint>
@@ -617,6 +609,14 @@
       <bpmndi:BPMNEdge bpmnElement="flow150" id="BPMNEdge_flow150">
         <omgdi:waypoint x="1581.0" y="441.0"></omgdi:waypoint>
         <omgdi:waypoint x="1581.0" y="579.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="deleteDiscontinuedServicesFlow" id="BPMNEdge_deleteDiscontinuedServicesFlow">
+        <omgdi:waypoint x="659.0" y="614.0"></omgdi:waypoint>
+        <omgdi:waypoint x="627.0" y="614.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow152" id="BPMNEdge_flow152">
+        <omgdi:waypoint x="522.0" y="614.0"></omgdi:waypoint>
+        <omgdi:waypoint x="495.0" y="614.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-deploy.bpmn
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-deploy.bpmn
@@ -23,8 +23,6 @@
     <serviceTask id="processArchiveTask" name="Process Archive" activiti:async="true" activiti:delegateExpression="${processMtaArchiveStep}"></serviceTask>
     <sequenceFlow id="flow16" sourceRef="deleteUnusedReservedRoutesTask" targetRef="createOrUpdateServicesTask"></sequenceFlow>
     <sequenceFlow id="flow12" sourceRef="buildDeployModelTask" targetRef="buildUndeployModelTask"></sequenceFlow>
-    <sequenceFlow id="flow43" sourceRef="deleteServicesTask" targetRef="createOrUpdateServiceBrokersTask"></sequenceFlow>
-    <serviceTask id="deleteServicesTask" name="Delete Services" activiti:async="true" activiti:delegateExpression="${deleteServicesStep}"></serviceTask>
     <exclusiveGateway id="shouldDeleteDiscontinuedServicesGateway" name="Should Delete Discontinued Services" default="deleteDiscontinuedServicesFlow"></exclusiveGateway>
     <sequenceFlow id="doNotDeleteDiscontinuedServicesFlow" name="Don't delete services" sourceRef="shouldDeleteDiscontinuedServicesGateway" targetRef="createOrUpdateServiceBrokersTask">
       <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(deleteServices == false)}]]></conditionExpression>
@@ -60,7 +58,6 @@
     <serviceTask id="buildUndeployModelTask" name="Build Undeploy Model" activiti:async="true" activiti:delegateExpression="${buildCloudUndeployModelStep}"></serviceTask>
     <serviceTask id="detectDeployedMtaTask" name="Detect Deployed MTA" activiti:async="true" activiti:delegateExpression="${detectDeployedMtaStep}"></serviceTask>
     <sequenceFlow id="flow8" sourceRef="detectDeployedMtaTask" targetRef="collectSystemParametersTask"></sequenceFlow>
-    <sequenceFlow id="deleteDiscontinuedServicesFlow" sourceRef="shouldDeleteDiscontinuedServicesGateway" targetRef="deleteServicesTask"></sequenceFlow>
     <serviceTask id="deleteUnusedReservedRoutesTask" name="Delete Unused Reserved Routes" activiti:async="true" activiti:delegateExpression="${deleteUnusedReservedRoutesStep}"></serviceTask>
     <serviceTask id="createSubscriptionsTask" name="Create Subscriptions" activiti:async="true" activiti:delegateExpression="${createSubscriptionsStep}"></serviceTask>
     <sequenceFlow id="flow14" sourceRef="addDomainsTask" targetRef="deleteUnusedReservedRoutesTask"></sequenceFlow>
@@ -140,6 +137,9 @@
     </callActivity>
     <sequenceFlow id="flow118" sourceRef="prepareAppsDeploymentTask" targetRef="deployAppCallActivity"></sequenceFlow>
     <sequenceFlow id="flow119" sourceRef="deployAppCallActivity" targetRef="createSubscriptionsTask"></sequenceFlow>
+    <callActivity id="deleteServicesCallActivity" name="Delete Services Sub Process" activiti:async="true" calledElement="deleteServicesSubProcess" activiti:inheritVariables="true"></callActivity>
+    <sequenceFlow id="deleteDiscontinuedServicesFlow" sourceRef="shouldDeleteDiscontinuedServicesGateway" targetRef="deleteServicesCallActivity"></sequenceFlow>
+    <sequenceFlow id="flow121" sourceRef="deleteServicesCallActivity" targetRef="createOrUpdateServiceBrokersTask"></sequenceFlow>
   </process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_xs2-deploy">
     <bpmndi:BPMNPlane bpmnElement="xs2-deploy" id="BPMNPlane_xs2-deploy">
@@ -164,9 +164,6 @@
       <bpmndi:BPMNShape bpmnElement="processArchiveTask" id="BPMNShape_processArchiveTask">
         <omgdc:Bounds height="65.0" width="105.0" x="756.0" y="28.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="deleteServicesTask" id="BPMNShape_deleteServicesTask">
-        <omgdc:Bounds height="61.0" width="106.0" x="936.0" y="592.0"></omgdc:Bounds>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="shouldDeleteDiscontinuedServicesGateway" id="BPMNShape_shouldDeleteDiscontinuedServicesGateway">
         <omgdc:Bounds height="40.0" width="40.0" x="1105.0" y="603.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
@@ -180,7 +177,7 @@
         <omgdc:Bounds height="61.0" width="105.0" x="1389.0" y="476.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="createOrUpdateServiceBrokersTask" id="BPMNShape_createOrUpdateServiceBrokersTask">
-        <omgdc:Bounds height="61.0" width="105.0" x="775.0" y="592.0"></omgdc:Bounds>
+        <omgdc:Bounds height="61.0" width="105.0" x="756.0" y="592.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="deleteServiceBrokersTask" id="BPMNShape_deleteServiceBrokersTask">
         <omgdc:Bounds height="61.0" width="106.0" x="522.0" y="592.0"></omgdc:Bounds>
@@ -284,6 +281,9 @@
       <bpmndi:BPMNShape bpmnElement="deployAppCallActivity" id="BPMNShape_deployAppCallActivity">
         <omgdc:Bounds height="62.0" width="105.0" x="431.0" y="219.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="deleteServicesCallActivity" id="BPMNShape_deleteServicesCallActivity">
+        <omgdc:Bounds height="61.0" width="105.0" x="918.0" y="592.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge bpmnElement="flow17" id="BPMNEdge_flow17">
         <omgdi:waypoint x="1033.0" y="249.0"></omgdi:waypoint>
         <omgdi:waypoint x="963.0" y="249.0"></omgdi:waypoint>
@@ -296,15 +296,11 @@
         <omgdi:waypoint x="886.0" y="141.0"></omgdi:waypoint>
         <omgdi:waypoint x="861.0" y="141.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="flow43" id="BPMNEdge_flow43">
-        <omgdi:waypoint x="936.0" y="622.0"></omgdi:waypoint>
-        <omgdi:waypoint x="880.0" y="622.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="doNotDeleteDiscontinuedServicesFlow" id="BPMNEdge_doNotDeleteDiscontinuedServicesFlow">
         <omgdi:waypoint x="1125.0" y="643.0"></omgdi:waypoint>
         <omgdi:waypoint x="1124.0" y="682.0"></omgdi:waypoint>
         <omgdi:waypoint x="826.0" y="682.0"></omgdi:waypoint>
-        <omgdi:waypoint x="827.0" y="653.0"></omgdi:waypoint>
+        <omgdi:waypoint x="808.0" y="653.0"></omgdi:waypoint>
         <bpmndi:BPMNLabel>
           <omgdc:Bounds height="39.0" width="100.0" x="1056.0" y="651.0"></omgdc:Bounds>
         </bpmndi:BPMNLabel>
@@ -322,7 +318,7 @@
         <omgdi:waypoint x="485.0" y="622.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="flow44" id="BPMNEdge_flow44">
-        <omgdi:waypoint x="775.0" y="622.0"></omgdi:waypoint>
+        <omgdi:waypoint x="756.0" y="622.0"></omgdi:waypoint>
         <omgdi:waypoint x="718.0" y="622.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="deleteDiscontinuedServiceBrokersFlow" id="BPMNEdge_deleteDiscontinuedServiceBrokersFlow">
@@ -371,10 +367,6 @@
       <bpmndi:BPMNEdge bpmnElement="flow8" id="BPMNEdge_flow8">
         <omgdi:waypoint x="1307.0" y="141.0"></omgdi:waypoint>
         <omgdi:waypoint x="1281.0" y="141.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="deleteDiscontinuedServicesFlow" id="BPMNEdge_deleteDiscontinuedServicesFlow">
-        <omgdi:waypoint x="1105.0" y="623.0"></omgdi:waypoint>
-        <omgdi:waypoint x="1042.0" y="622.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="flow14" id="BPMNEdge_flow14">
         <omgdi:waypoint x="1307.0" y="248.0"></omgdi:waypoint>
@@ -538,6 +530,14 @@
         <omgdi:waypoint x="483.0" y="281.0"></omgdi:waypoint>
         <omgdi:waypoint x="483.0" y="400.0"></omgdi:waypoint>
         <omgdi:waypoint x="793.0" y="400.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="deleteDiscontinuedServicesFlow" id="BPMNEdge_deleteDiscontinuedServicesFlow">
+        <omgdi:waypoint x="1105.0" y="623.0"></omgdi:waypoint>
+        <omgdi:waypoint x="1023.0" y="622.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow121" id="BPMNEdge_flow121">
+        <omgdi:waypoint x="918.0" y="622.0"></omgdi:waypoint>
+        <omgdi:waypoint x="861.0" y="622.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-undeploy.bpmn
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-undeploy.bpmn
@@ -17,16 +17,13 @@
     </endEvent>
     <serviceTask id="prepareToUndeployTask" name="Prepare Undeploy" activiti:async="true" activiti:delegateExpression="${prepareToUndeployStep}"></serviceTask>
     <sequenceFlow id="flow1" sourceRef="startEvent" targetRef="detectDeployedMtaTask"></sequenceFlow>
-    <serviceTask id="deleteServicesTask" name="Delete Services" activiti:async="true" activiti:delegateExpression="${deleteServicesStep}"></serviceTask>
     <exclusiveGateway id="shouldDeleteDiscontinuedServicesGateway" name="Should Delete Discontinued Services" default="deleteDiscontinuedServicesFlow"></exclusiveGateway>
-    <sequenceFlow id="deleteDiscontinuedServicesFlow" sourceRef="shouldDeleteDiscontinuedServicesGateway" targetRef="deleteServicesTask"></sequenceFlow>
     <sequenceFlow id="doNotDeleteDiscontinuedServicesFlow" sourceRef="shouldDeleteDiscontinuedServicesGateway" targetRef="updateSubscribersTask">
       <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(deleteServices == false)}]]></conditionExpression>
     </sequenceFlow>
     <sequenceFlow id="flow3" sourceRef="prepareToUndeployTask" targetRef="buildUndeployModelTask"></sequenceFlow>
     <serviceTask id="unregisterServiceUrlsTask" name="Unregister Service URLs" activiti:async="true" activiti:delegateExpression="${unregisterServiceUrlsStep}"></serviceTask>
     <serviceTask id="deleteServiceBrokersTask" name="Delete Service Brokers" activiti:async="true" activiti:delegateExpression="${deleteServiceBrokersStep}"></serviceTask>
-    <sequenceFlow id="flow10" sourceRef="deleteServicesTask" targetRef="updateSubscribersTask"></sequenceFlow>
     <sequenceFlow id="flow7" sourceRef="unregisterServiceUrlsTask" targetRef="shouldDeleteDiscontinuedServiceBrokersGateway"></sequenceFlow>
     <serviceTask id="deleteDiscontinuedConfigurationEntriesTask" name="Delete Discontinued Configuration Entries" activiti:async="true" activiti:delegateExpression="${deleteDiscontinuedConfigurationEntriesStep}"></serviceTask>
     <sequenceFlow id="flow6" sourceRef="deleteDiscontinuedConfigurationEntriesTask" targetRef="unregisterServiceUrlsTask"></sequenceFlow>
@@ -91,6 +88,9 @@
     <serviceTask id="incrementServiceBrokerSubscribersToRestartIndexTask" name="Increment Index" activiti:async="true" activiti:delegateExpression="${incrementIndexStep}"></serviceTask>
     <sequenceFlow id="flow37" sourceRef="updateServiceBrokerSubscriberTask" targetRef="incrementServiceBrokerSubscribersToRestartIndexTask"></sequenceFlow>
     <sequenceFlow id="flow38" sourceRef="incrementServiceBrokerSubscribersToRestartIndexTask" targetRef="areAllServiceBrokerSubscribersRestartedGateway"></sequenceFlow>
+    <callActivity id="deleteServicesCallActivity" name="Delete Services Sub Process" activiti:async="true" calledElement="deleteServicesSubProcess" activiti:inheritVariables="true"></callActivity>
+    <sequenceFlow id="deleteDiscontinuedServicesFlow" sourceRef="shouldDeleteDiscontinuedServicesGateway" targetRef="deleteServicesCallActivity"></sequenceFlow>
+    <sequenceFlow id="flow40" sourceRef="deleteServicesCallActivity" targetRef="updateSubscribersTask"></sequenceFlow>
   </process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_xs2-undeploy">
     <bpmndi:BPMNPlane bpmnElement="xs2-undeploy" id="BPMNPlane_xs2-undeploy">
@@ -102,9 +102,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="prepareToUndeployTask" id="BPMNShape_prepareToUndeployTask">
         <omgdc:Bounds height="55.0" width="109.0" x="350.0" y="76.0"></omgdc:Bounds>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="deleteServicesTask" id="BPMNShape_deleteServicesTask">
-        <omgdc:Bounds height="55.0" width="105.0" x="521.0" y="195.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="shouldDeleteDiscontinuedServicesGateway" id="BPMNShape_shouldDeleteDiscontinuedServicesGateway">
         <omgdc:Bounds height="40.0" width="40.0" x="720.0" y="202.0"></omgdc:Bounds>
@@ -175,13 +172,12 @@
       <bpmndi:BPMNShape bpmnElement="incrementServiceBrokerSubscribersToRestartIndexTask" id="BPMNShape_incrementServiceBrokerSubscribersToRestartIndexTask">
         <omgdc:Bounds height="64.0" width="105.0" x="876.0" y="396.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="deleteServicesCallActivity" id="BPMNShape_deleteServicesCallActivity">
+        <omgdc:Bounds height="65.0" width="105.0" x="526.0" y="190.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
         <omgdi:waypoint x="61.0" y="103.0"></omgdi:waypoint>
         <omgdi:waypoint x="110.0" y="103.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="deleteDiscontinuedServicesFlow" id="BPMNEdge_deleteDiscontinuedServicesFlow">
-        <omgdi:waypoint x="720.0" y="222.0"></omgdi:waypoint>
-        <omgdi:waypoint x="626.0" y="222.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="doNotDeleteDiscontinuedServicesFlow" id="BPMNEdge_doNotDeleteDiscontinuedServicesFlow">
         <omgdi:waypoint x="740.0" y="242.0"></omgdi:waypoint>
@@ -192,10 +188,6 @@
       <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
         <omgdi:waypoint x="459.0" y="103.0"></omgdi:waypoint>
         <omgdi:waypoint x="520.0" y="103.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="flow10" id="BPMNEdge_flow10">
-        <omgdi:waypoint x="521.0" y="222.0"></omgdi:waypoint>
-        <omgdi:waypoint x="459.0" y="222.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="flow7" id="BPMNEdge_flow7">
         <omgdi:waypoint x="1148.0" y="103.0"></omgdi:waypoint>
@@ -219,7 +211,7 @@
         <omgdi:waypoint x="40.0" y="164.0"></omgdi:waypoint>
         <omgdi:waypoint x="40.0" y="205.0"></omgdi:waypoint>
         <bpmndi:BPMNLabel>
-          <omgdc:Bounds height="14.0" width="93.0" x="215.0" y="169.0"></omgdc:Bounds>
+          <omgdc:Bounds height="13.0" width="93.0" x="215.0" y="169.0"></omgdc:Bounds>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="mtaExistsFlow" id="BPMNEdge_mtaExistsFlow">
@@ -243,7 +235,7 @@
         <omgdi:waypoint x="156.0" y="222.0"></omgdi:waypoint>
         <omgdi:waypoint x="58.0" y="222.0"></omgdi:waypoint>
         <bpmndi:BPMNLabel>
-          <omgdc:Bounds height="42.0" width="100.0" x="70.0" y="231.0"></omgdc:Bounds>
+          <omgdc:Bounds height="39.0" width="100.0" x="70.0" y="231.0"></omgdc:Bounds>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="allServiceBrokerSubscribersWereRestartedFlow" id="BPMNEdge_allServiceBrokerSubscribersWereRestartedFlow">
@@ -327,6 +319,14 @@
         <omgdi:waypoint x="928.0" y="545.0"></omgdi:waypoint>
         <omgdi:waypoint x="361.0" y="545.0"></omgdi:waypoint>
         <omgdi:waypoint x="362.0" y="447.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="deleteDiscontinuedServicesFlow" id="BPMNEdge_deleteDiscontinuedServicesFlow">
+        <omgdi:waypoint x="720.0" y="222.0"></omgdi:waypoint>
+        <omgdi:waypoint x="631.0" y="222.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow40" id="BPMNEdge_flow40">
+        <omgdi:waypoint x="526.0" y="222.0"></omgdi:waypoint>
+        <omgdi:waypoint x="459.0" y="222.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateServicesStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateServicesStepTest.java
@@ -160,6 +160,7 @@ public class CreateOrUpdateServicesStepTest extends SyncActivitiStepTest<CreateO
 
     private void prepareContext() throws Exception {
         StepsUtil.setServicesToCreate(context, ListUtil.upcastUnmodifiable(stepInput.services));
+        StepsUtil.setServicesToDelete(context, Collections.emptyList());
         StepsUtil.setAppsToDeploy(context, toCloudApplications(stepInput.applications));
         StepsUtil.setAppsToUndeploy(context, ListUtil.upcastUnmodifiable(toCloudApplications(stepInput.discontinuedApplications)));
         StepsUtil.setServiceKeysToCreate(context, stepInput.getServiceKeysToCreate());

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStepTest.java
@@ -198,6 +198,7 @@ public class DeleteServicesStepTest extends SyncActivitiStepTest<DeleteServicesS
                 Mockito.when(eventsGetter.getLastEvent(UUID.fromString(service.guid), client))
                     .thenReturn(deleteEvent);
             });
+        Mockito.when(eventsGetter.isDeleteEvent(SERVICE_EVENT_TYPE_DELETE)).thenCallRealMethod();
     }
 
     @SuppressWarnings("unchecked")

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStepTest.java
@@ -1,15 +1,31 @@
 package com.sap.cloud.lm.sl.cf.process.steps;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
 import java.text.MessageFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.cloudfoundry.client.lib.CloudControllerClient;
 import org.cloudfoundry.client.lib.CloudOperationException;
+import org.cloudfoundry.client.lib.domain.CloudEntity.Meta;
+import org.cloudfoundry.client.lib.domain.CloudEvent;
 import org.cloudfoundry.client.lib.domain.CloudService;
 import org.cloudfoundry.client.lib.domain.CloudServiceBinding;
 import org.cloudfoundry.client.lib.domain.CloudServiceInstance;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,9 +33,13 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 
+import com.sap.cloud.lm.sl.cf.core.cf.clients.EventsGetter;
+import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceGetter;
+import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceInstanceGetter;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.common.SLException;
@@ -29,10 +49,25 @@ import com.sap.cloud.lm.sl.common.util.TestUtil;
 @RunWith(Parameterized.class)
 public class DeleteServicesStepTest extends SyncActivitiStepTest<DeleteServicesStep> {
 
+    private static final String POLLING = "polling";
+    private static final String STEP_EXECUTION = "stepExecution";
+    private static final String TEST_SPACE_ID = "testSpace";
+    private static final String SERVICE_EVENT_TYPE_DELETE = "audit.service_instance.delete";
+
     private final StepInput stepInput;
     private final String expectedExceptionMessage;
 
     private List<String> servicesToDelete = new ArrayList<>();
+    private Map<String, String> servicesGuids = new HashMap<>();
+
+    @Mock
+    protected CloudControllerClient client;
+
+    @Mock
+    private ServiceGetter serviceGetter;
+
+    @Mock
+    private EventsGetter eventsGetter;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -53,7 +88,7 @@ public class DeleteServicesStepTest extends SyncActivitiStepTest<DeleteServicesS
             {
                 "delete-services-step-input-3.json", null,
             },
-            // (3) Some services have bindings, some do not:
+            // (3) Some services have bindings, some do not but are deleted slowly:
             {
                 "delete-services-step-input-4.json", null,
             },
@@ -69,6 +104,7 @@ public class DeleteServicesStepTest extends SyncActivitiStepTest<DeleteServicesS
     }
 
     public DeleteServicesStepTest(String stepInput, String expectedExceptionMessage) throws Exception {
+        System.out.println(stepInput);
         this.stepInput = JsonUtil.fromJson(TestUtil.getResourceAsString(stepInput, DeleteServicesStepTest.class), StepInput.class);
         this.expectedExceptionMessage = expectedExceptionMessage;
     }
@@ -82,17 +118,31 @@ public class DeleteServicesStepTest extends SyncActivitiStepTest<DeleteServicesS
 
     @Test
     public void testExecute() throws Exception {
+        prepareResponses(STEP_EXECUTION);
         step.execute(context);
-
-        assertStepFinishedSuccessfully();
-
+        assertStepPhase(STEP_EXECUTION);
         verifyClient();
+
+        prepareResponses(POLLING);
+        step.execute(context);
+        assertStepPhase(POLLING);
+        verifyClient();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertStepPhase(String stepPhase) {
+        Map<String, Object> stepPhaseResults = (Map<String, Object>) stepInput.stepPhaseResults.get(stepPhase);
+        String expectedStepPhase = (String) stepPhaseResults.get("expextedStepPhase");
+        assertEquals(expectedStepPhase, getExecutionStatus());
     }
 
     private void loadParameters() {
         servicesToDelete = stepInput.servicesToDelete.stream()
             .map((service) -> service.name)
             .collect(Collectors.toList());
+        servicesGuids = stepInput.servicesToDelete.stream()
+            .collect(Collectors.toMap(e -> e.name, e -> e.guid));
+
         if (expectedExceptionMessage != null) {
             expectedException.expect(SLException.class);
             expectedException.expectMessage(expectedExceptionMessage);
@@ -101,7 +151,11 @@ public class DeleteServicesStepTest extends SyncActivitiStepTest<DeleteServicesS
 
     private void prepareContext() {
         StepsUtil.setArrayVariableFromCollection(context, Constants.VAR_SERVICES_TO_DELETE, servicesToDelete);
+        StepsUtil.setAsBinaryJson(context, Constants.VAR_SERVICES_GUIDS, servicesGuids);
         context.setVariable(com.sap.cloud.lm.sl.cf.process.Constants.PARAM_DELETE_SERVICES, true);
+        context.setVariable(com.sap.cloud.lm.sl.cf.persistence.message.Constants.VARIABLE_NAME_SPACE_ID, TEST_SPACE_ID);
+        when(clientProvider.getControllerClient(anyString(), anyString())).thenReturn(client);
+        when(clientProvider.getControllerClient(anyString(), anyString(), anyString(), anyString())).thenReturn(client);
     }
 
     private void prepareClient() {
@@ -117,6 +171,51 @@ public class DeleteServicesStepTest extends SyncActivitiStepTest<DeleteServicesS
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private void prepareResponses(String stepPhase) {
+        Map<String, Object> stepPhaseResults = (Map<String, Object>) stepInput.stepPhaseResults.get(stepPhase);
+
+        prepareServiceInstanceGetter(stepPhaseResults);
+        prepareEventsGetter(stepPhaseResults);
+    }
+
+    private void prepareEventsGetter(Map<String, Object> stepPhaseResponse) {
+        Mockito.reset(eventsGetter);
+        Map<String, Map<String, Boolean>> eventsResponse = (Map<String, Map<String, Boolean>>) stepPhaseResponse.get("eventsResponse");
+        stepInput.servicesToDelete.stream()
+            .filter(service -> eventsResponse.get(service.name)
+                .containsKey("containsDeleteEvent"))
+            .filter(service -> eventsResponse.get(service.name)
+                .get("containsDeleteEvent")
+                .equals(true))
+            .forEach(service -> {
+                CloudEvent deleteEvent = createDeleteServiceCloudEvent(service);
+                List<CloudEvent> events = createOlderServiceCloudEvents(deleteEvent, 5);
+                events.add(deleteEvent);
+
+                Mockito.when(eventsGetter.getEvents(UUID.fromString(service.guid), client))
+                    .thenReturn(events);
+                Mockito.when(eventsGetter.getLastEvent(UUID.fromString(service.guid), client))
+                    .thenReturn(deleteEvent);
+            });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void prepareServiceInstanceGetter(Map<String, Object> stepPhaseResponse) {
+        Mockito.reset(serviceGetter);
+        Map<String, Object> serviceInstanceResponse = (Map<String, Object>) stepPhaseResponse.get("serviceInstanceResponse");
+        for (Entry<String, Object> entry : serviceInstanceResponse.entrySet()) {
+            String serviceName = entry.getKey();
+            Map<String, Object> response = (Map<String, Object>) entry.getValue();
+            Map<String, Object> entryResponse = (Map<String, Object>) response.get("entity");
+
+            Mockito.when(serviceGetter.getServiceInstanceEntity(client, serviceName, TEST_SPACE_ID))
+                .thenReturn(entryResponse);
+            Mockito.when(serviceGetter.getServiceInstance(client, serviceName, TEST_SPACE_ID))
+                .thenReturn(response);
+        }
+    }
+
     private CloudServiceInstance createServiceInstance(SimpleService service) {
         CloudServiceInstance instance = new CloudServiceInstance();
         if (service.hasBoundApplications) {
@@ -126,8 +225,49 @@ public class DeleteServicesStepTest extends SyncActivitiStepTest<DeleteServicesS
         cloudService.setName(service.name);
         cloudService.setLabel(service.label);
         cloudService.setPlan(service.plan);
+        UUID guid = UUID.fromString(service.guid);
+        cloudService.setMeta(new Meta(guid, null, null));
         instance.setService(cloudService);
         return instance;
+    }
+
+    private CloudEvent createDeleteServiceCloudEvent(SimpleService service) {
+        CloudEvent event = new CloudEvent(null, null);
+        event.setActee(service.guid);
+        event.setActeeName(service.name);
+        event.setType(SERVICE_EVENT_TYPE_DELETE);
+        event.setTimestamp(new Date());
+        return event;
+    }
+
+    private List<CloudEvent> createOlderServiceCloudEvents(CloudEvent lastEvent, int count) {
+        Assert.assertTrue(count > 0);
+        List<CloudEvent> events = new ArrayList<>();
+        CloudEvent currentEvent = lastEvent;
+        for (int i = 0; i < count; i++) {
+            CloudEvent event = new CloudEvent(null, null);
+            event.setActee(lastEvent.getActee());
+            event.setActeeName(lastEvent.getActeeName());
+            event.setType("nonDelete");
+
+            Date olderDate = getOlderDateFromEvent(currentEvent);
+
+            event.setTimestamp(olderDate);
+            events.add(event);
+            currentEvent = event;
+        }
+        return events;
+    }
+
+    private Date getOlderDateFromEvent(CloudEvent lastEvent) {
+        ZoneId systemDefaultZone = ZoneId.systemDefault();
+        Instant lastEventInstant = lastEvent.getTimestamp()
+            .toInstant();
+        LocalDateTime lastEventDateTime = LocalDateTime.ofInstant(lastEventInstant, systemDefaultZone);
+        LocalDateTime secondBefore = lastEventDateTime.minusSeconds(1);
+        Instant secondBeforeInstant = secondBefore.atZone(systemDefaultZone)
+            .toInstant();
+        return Date.from(secondBeforeInstant);
     }
 
     private void verifyClient() {
@@ -141,12 +281,14 @@ public class DeleteServicesStepTest extends SyncActivitiStepTest<DeleteServicesS
 
     private static class StepInput {
         List<SimpleService> servicesToDelete;
+        Map<String, Object> stepPhaseResults;
     }
 
     private static class SimpleService {
         String name;
         String label;
         String plan;
+        String guid;
         boolean hasBoundApplications;
         Integer httpErrorCodeToReturnOnDelete;
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceOperationsStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceOperationsStepTest.java
@@ -5,7 +5,10 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -101,6 +104,8 @@ public class PollServiceOperationsStepTest extends AsyncStepOperationTest<Create
         context.setVariable(com.sap.cloud.lm.sl.cf.persistence.message.Constants.VARIABLE_NAME_SPACE_ID, TEST_SPACE_ID);
         prepareServiceInstanceGetter();
         StepsUtil.setServicesToCreate(context, input.services);
+        StepsUtil.setServicesToDelete(context, Collections.emptyList());
+        StepsUtil.setServicesGuids(context, Collections.emptyMap());
         StepsUtil.setTriggeredServiceOperations(context, input.triggeredServiceOperations);
         if (expectedExceptionMessage != null) {
             exception.expectMessage(expectedExceptionMessage);
@@ -112,7 +117,7 @@ public class PollServiceOperationsStepTest extends AsyncStepOperationTest<Create
     @SuppressWarnings("unchecked")
     private void prepareServiceInstanceGetter() {
         for (Entry<String, Object> response : input.serviceInstanceResponse.entrySet()) {
-            Mockito.when(serviceInstanceGetter.getServiceInstance(client, response.getKey(), TEST_SPACE_ID))
+            Mockito.when(serviceInstanceGetter.getServiceInstanceEntity(client, response.getKey(), TEST_SPACE_ID))
                 .thenReturn((Map<String, Object>) response.getValue());
         }
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-1.json
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-1.json
@@ -1,12 +1,67 @@
 {
-  "servicesToDelete": [
-    {
-      "name": "service-1",
-      "hasBoundApplications": true
-    },
-    {
-      "name": "service-2",
-      "hasBoundApplications": true
-    }
-  ]
+	"servicesToDelete": [
+		{
+			"name": "service-1",
+			"hasBoundApplications": true,
+			"guid": "5ee63aa7-fb56-4e8f-b43f-a74efead2602"
+		},
+		{
+			"name": "service-2",
+			"hasBoundApplications": true,
+			"guid": "8dbdfd12-807d-4f0a-b909-562d5873f2e8"
+		}
+	],
+	"stepPhaseResults": {
+		"stepExecution": {
+			"serviceInstanceResponse": {
+				"service-1": {
+					"metadata": {
+						"guid": "5ee63aa7-fb56-4e8f-b43f-a74efead2602"
+					},
+					"entity": {
+						"name": "service-1",
+						"last_operation": {
+							"type": "delete",
+							"state": "in progress"
+						}
+					}
+				},
+				"service-2": {
+					"metadata": {
+						"guid": "8dbdfd12-807d-4f0a-b909-562d5873f2e8"
+					},
+					"entity": {
+						"name": "service-2",
+						"last_operation": {
+							"type": "delete",
+							"state": "in progress"
+						}
+					}
+				}
+			},
+			"eventsResponse": {
+				"service-1": {
+					"containsDeleteEvent": false
+				},
+				"service-2": {
+					"containsDeleteEvent": false
+				}
+			},
+			"expextedStepPhase": "POLL"
+		},
+		"polling": {
+			"serviceInstanceResponse": {
+				
+			},
+			"eventsResponse": {
+				"service-1": {
+					"containsDeleteEvent": true
+				},
+				"service-2": {
+					"containsDeleteEvent": true
+				}
+			},
+			"expextedStepPhase": "DONE"
+		}
+	}
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-2.json
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-2.json
@@ -1,12 +1,67 @@
 {
-  "servicesToDelete": [
-    {
-      "name": "service-1",
-      "hasBoundApplications": false
-    },
-    {
-      "name": "service-2",
-      "hasBoundApplications": false
-    }
-  ]
+	"servicesToDelete": [
+		{
+			"name": "service-1",
+			"hasBoundApplications": false,
+			"guid": "5ee63aa7-fb56-4e8f-b43f-a74efead2602"
+		},
+		{
+			"name": "service-2",
+			"hasBoundApplications": false,
+			"guid": "8dbdfd12-807d-4f0a-b909-562d5873f2e8"
+		}
+	],
+	"stepPhaseResults": {
+		"stepExecution": {
+			"serviceInstanceResponse": {
+				"service-1": {
+					"metadata": {
+						"guid": "5ee63aa7-fb56-4e8f-b43f-a74efead2602"
+					},
+					"entity": {
+						"name": "service-1",
+						"last_operation": {
+							"type": "delete",
+							"state": "in progress"
+						}
+					}
+				},
+				"service-2": {
+					"metadata": {
+						"guid": "8dbdfd12-807d-4f0a-b909-562d5873f2e8"
+					},
+					"entity": {
+						"name": "service-2",
+						"last_operation": {
+							"type": "delete",
+							"state": "in progress"
+						}
+					}
+				}
+			},
+			"eventsResponse": {
+				"service-1": {
+					"containsDeleteEvent": false
+				},
+				"service-2": {
+					"containsDeleteEvent": false
+				}
+			},
+			"expextedStepPhase": "POLL"
+		},
+		"polling": {
+			"serviceInstanceResponse": {
+				
+			},
+			"eventsResponse": {
+				"service-1": {
+					"containsDeleteEvent": true
+				},
+				"service-2": {
+					"containsDeleteEvent": true
+				}
+			},
+			"expextedStepPhase": "DONE"
+		}
+	}
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-3.json
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-3.json
@@ -1,3 +1,35 @@
 {
-  "servicesToDelete": []
+	"servicesToDelete": [],
+	"stepPhaseResults": {
+		"stepExecution": {
+			"serviceInstanceResponse": {
+				"service-1": {
+				},
+				"service-2": {
+				}
+			},
+			"eventsResponse": {
+				"service-1": {
+				},
+				"service-2": {
+				}
+			},
+			"expextedStepPhase": "POLL"
+		},
+		"polling": {
+			"serviceInstanceResponse": {
+				"service-1": {
+				},
+				"service-2": {
+				}
+			},
+			"eventsResponse": {
+				"service-1": {
+				},
+				"service-2": {
+				}
+			},
+			"expextedStepPhase": "DONE"
+		}
+	}
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-4.json
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-4.json
@@ -1,16 +1,82 @@
 {
-  "servicesToDelete": [
-    {
-      "name": "service-1",
-      "label": "testoffering",
-      "plan": "testplan",
-      "hasBoundApplications": true
-    },
-    {
-      "name": "service-2",
-      "label": "testoffering",
-      "plan": "testplan",
-      "hasBoundApplications": false
-    }
-  ]
+	"servicesToDelete": [
+		{
+			"name": "service-1",
+			"label": "testoffering",
+			"plan": "testplan",
+			"hasBoundApplications": true,
+			"guid": "5ee63aa7-fb56-4e8f-b43f-a74efead2602"
+		},
+		{
+			"name": "service-2",
+			"label": "testoffering",
+			"plan": "testplan",
+			"hasBoundApplications": false,
+			"guid": "8dbdfd12-807d-4f0a-b909-562d5873f2e8"
+		}
+	],
+	"stepPhaseResults": {
+		"stepExecution": {
+			"serviceInstanceResponse": {
+				"service-1": {
+					"metadata": {
+						"guid": "5ee63aa7-fb56-4e8f-b43f-a74efead2602"
+					},
+					"entity": {
+						"name": "service-1",
+						"last_operation": {
+							"type": "delete",
+							"state": "in progress"
+						}
+					}
+				},
+				"service-2": {
+					"metadata": {
+						"guid": "8dbdfd12-807d-4f0a-b909-562d5873f2e8"
+					},
+					"entity": {
+						"name": "service-2",
+						"last_operation": {
+							"type": "delete",
+							"state": "in progress"
+						}
+					}
+				}
+			},
+			"eventsResponse": {
+				"service-1": {
+					"containsDeleteEvent": false
+				},
+				"service-2": {
+					"containsDeleteEvent": false
+				}
+			},
+			"expextedStepPhase": "POLL"
+		},
+		"polling": {
+			"serviceInstanceResponse": {
+				"service-2": {
+					"metadata": {
+						"guid": "8dbdfd12-807d-4f0a-b909-562d5873f2e8"
+					},
+					"entity": {
+						"name": "service-2",
+						"last_operation": {
+							"type": "delete",
+							"state": "in progress"
+						}
+					}
+				}
+			},
+			"eventsResponse": {
+				"service-1": {
+					"containsDeleteEvent": false
+				},
+				"service-2": {
+					"containsDeleteEvent": false
+				}
+			},
+			"expextedStepPhase": "POLL"
+		}
+	}
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-5.json
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-5.json
@@ -1,13 +1,68 @@
 {
-  "servicesToDelete": [
-    {
-      "name": "service-1",
-      "hasBoundApplications": false
-    },
-    {
-      "name": "service-2",
-      "httpErrorCodeToReturnOnDelete": 404,
-      "hasBoundApplications": false
-    }
-  ]
+	"servicesToDelete": [
+		{
+			"name": "service-1",
+			"hasBoundApplications": false,
+			"guid": "5ee63aa7-fb56-4e8f-b43f-a74efead2602"
+		},
+		{
+			"name": "service-2",
+			"httpErrorCodeToReturnOnDelete": 404,
+			"hasBoundApplications": false,
+			"guid": "8dbdfd12-807d-4f0a-b909-562d5873f2e8"
+		}
+	],
+	"stepPhaseResults": {
+		"stepExecution": {
+			"serviceInstanceResponse": {
+				"service-1": {
+					"metadata": {
+						"guid": "5ee63aa7-fb56-4e8f-b43f-a74efead2602"
+					},
+					"entity": {
+						"name": "service-1",
+						"last_operation": {
+							"type": "delete",
+							"state": "in progress"
+						}
+					}
+				},
+				"service-2": {
+					"metadata": {
+						"guid": "8dbdfd12-807d-4f0a-b909-562d5873f2e8"
+					},
+					"entity": {
+						"name": "service-2",
+						"last_operation": {
+							"type": "delete",
+							"state": "in progress"
+						}
+					}
+				}
+			},
+			"eventsResponse": {
+				"service-1": {
+					"containsDeleteEvent": false
+				},
+				"service-2": {
+					"containsDeleteEvent": false
+				}
+			},
+			"expextedStepPhase": "POLL"
+		},
+		"polling": {
+			"serviceInstanceResponse": {
+				
+			},
+			"eventsResponse": {
+				"service-1": {
+					"containsDeleteEvent": true
+				},
+				"service-2": {
+					"containsDeleteEvent": true
+				}
+			},
+			"expextedStepPhase": "DONE"
+		}
+	}
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-6.json
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/delete-services-step-input-6.json
@@ -1,17 +1,72 @@
 {
-  "servicesToDelete": [
-    {
-      "name": "service-1",
-      "label": "servicelabel",
-      "plan": "serviceplan",
-      "hasBoundApplications": false
-    },
-    {
-      "name": "service-2",
-      "label": "servicelabel",
-      "plan": "serviceplan",
-      "httpErrorCodeToReturnOnDelete": 403,
-      "hasBoundApplications": false
-    }
-  ]
+	"servicesToDelete": [
+		{
+			"name": "service-1",
+			"label": "servicelabel",
+			"plan": "serviceplan",
+			"hasBoundApplications": false,
+			"guid": "5ee63aa7-fb56-4e8f-b43f-a74efead2602"
+		},
+		{
+			"name": "service-2",
+			"label": "servicelabel",
+			"plan": "serviceplan",
+			"httpErrorCodeToReturnOnDelete": 403,
+			"hasBoundApplications": false,
+			"guid": "8dbdfd12-807d-4f0a-b909-562d5873f2e8"
+		}
+	],
+	"stepPhaseResults": {
+		"stepExecution": {
+			"serviceInstanceResponse": {
+				"service-1": {
+					"metadata": {
+						"guid": "5ee63aa7-fb56-4e8f-b43f-a74efead2602"
+					},
+					"entity": {
+						"name": "service-1",
+						"last_operation": {
+							"type": "delete",
+							"state": "in progress"
+						}
+					}
+				},
+				"service-2": {
+					"metadata": {
+						"guid": "8dbdfd12-807d-4f0a-b909-562d5873f2e8"
+					},
+					"entity": {
+						"name": "service-2",
+						"last_operation": {
+							"type": "delete",
+							"state": "in progress"
+						}
+					}
+				}
+			},
+			"eventsResponse": {
+				"service-1": {
+					"containsDeleteEvent": false
+				},
+				"service-2": {
+					"containsDeleteEvent": false
+				}
+			},
+			"expextedStepPhase": "POLL"
+		},
+		"polling": {
+			"serviceInstanceResponse": {
+				
+			},
+			"eventsResponse": {
+				"service-1": {
+					"containsDeleteEvent": false
+				},
+				"service-2": {
+					"containsDeleteEvent": true
+				}
+			},
+			"expextedStepPhase": "POLL"
+		}
+	}
 }


### PR DESCRIPTION
#### Description: 
Currently, all processes that include deletion of services only just trigger the deletion without waiting for those deletions to finish. This could cause problems if the user then attempts to redeploy the same MTA immediately after the process finishes. 

This pull request adopts an already established (in the current BPMN) polling mechanism for waiting for the actual service deletion.
#### Issue: LMCROSSITXSADEPLOY-498

