### PR TITLE
Warn for leftover services after undeploy

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -169,7 +169,8 @@ public class Messages {
     public static final String ERROR_DURING_CLEAN_UP_0 = "Error during clean-up: {0}";
     public static final String COULD_NOT_DELETE_HISTORIC_PROCESS_0 = "Could not delete historic process \"{0}\"";
     public static final String COULD_NOT_ABORT_OPERATION_0 = "Could not abort operation \"{0}\"";
-
+    public static final String DETECTED_LEFTOVER_SERVICES = "Services were not deleted as the --delete-services flag was not specified";
+    
     // INFO log messages
     public static final String MTA_NOT_FOUND = "An MTA with id \"{0}\" does not exist";
     public static final String ACQUIRING_LOCK = "Process \"{0}\" attempting to acquire lock for operation on MTA \"{1}\"";

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import com.sap.cloud.lm.sl.cf.core.security.serialization.SecureSerializationFacade;
+import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.common.SLException;
 
@@ -34,9 +35,14 @@ public class DeleteServicesStep extends SyncActivitiStep {
 
             CloudControllerClient client = execution.getControllerClient();
 
+            boolean deleteServicesFlag = (boolean) execution.getContext()
+                .getVariable(Constants.PARAM_DELETE_SERVICES);
             List<String> servicesToDelete = StepsUtil.getServicesToDelete(execution.getContext());
+            if (!deleteServicesFlag) {
+                getStepLogger().warn(Messages.DETECTED_LEFTOVER_SERVICES);
+                return StepPhase.DONE;
+            }
             deleteServices(client, servicesToDelete);
-
             getStepLogger().debug(Messages.SERVICES_DELETED);
             return StepPhase.DONE;
         } catch (SLException e) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-undeploy.bpmn
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-undeploy.bpmn
@@ -18,11 +18,6 @@
     <serviceTask id="prepareToUndeployTask" name="Prepare Undeploy" activiti:async="true" activiti:delegateExpression="${prepareToUndeployStep}"></serviceTask>
     <sequenceFlow id="flow1" sourceRef="startEvent" targetRef="detectDeployedMtaTask"></sequenceFlow>
     <serviceTask id="deleteServicesTask" name="Delete Services" activiti:async="true" activiti:delegateExpression="${deleteServicesStep}"></serviceTask>
-    <exclusiveGateway id="shouldDeleteDiscontinuedServicesGateway" name="Should Delete Discontinued Services" default="deleteDiscontinuedServicesFlow"></exclusiveGateway>
-    <sequenceFlow id="deleteDiscontinuedServicesFlow" sourceRef="shouldDeleteDiscontinuedServicesGateway" targetRef="deleteServicesTask"></sequenceFlow>
-    <sequenceFlow id="doNotDeleteDiscontinuedServicesFlow" sourceRef="shouldDeleteDiscontinuedServicesGateway" targetRef="updateSubscribersTask">
-      <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(deleteServices == false)}]]></conditionExpression>
-    </sequenceFlow>
     <sequenceFlow id="flow3" sourceRef="prepareToUndeployTask" targetRef="buildUndeployModelTask"></sequenceFlow>
     <serviceTask id="unregisterServiceUrlsTask" name="Unregister Service URLs" activiti:async="true" activiti:delegateExpression="${unregisterServiceUrlsStep}"></serviceTask>
     <serviceTask id="deleteServiceBrokersTask" name="Delete Service Brokers" activiti:async="true" activiti:delegateExpression="${deleteServiceBrokersStep}"></serviceTask>
@@ -66,9 +61,6 @@
       <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(deleteServiceBrokers == false)}]]></conditionExpression>
     </sequenceFlow>
     <sequenceFlow id="flow27" sourceRef="prepareToUndeployAppsTask" targetRef="shouldUndeployAppGateway"></sequenceFlow>
-    <sequenceFlow id="appsUndeployedFlow" sourceRef="shouldUndeployAppGateway" targetRef="shouldDeleteDiscontinuedServicesGateway">
-      <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(appsToUndeployCount == appsToUndeployIndex)}]]></conditionExpression>
-    </sequenceFlow>
     <sequenceFlow id="flow30" sourceRef="undeployAppTask" targetRef="incrementUndeployAppsIndexTask"></sequenceFlow>
     <sequenceFlow id="flow31" sourceRef="incrementUndeployAppsIndexTask" targetRef="shouldUndeployAppGateway"></sequenceFlow>
     <sequenceFlow id="undeployAppFlow" sourceRef="shouldUndeployAppGateway" targetRef="undeployAppTask"></sequenceFlow>
@@ -91,6 +83,9 @@
     <serviceTask id="incrementServiceBrokerSubscribersToRestartIndexTask" name="Increment Index" activiti:async="true" activiti:delegateExpression="${incrementIndexStep}"></serviceTask>
     <sequenceFlow id="flow37" sourceRef="updateServiceBrokerSubscriberTask" targetRef="incrementServiceBrokerSubscribersToRestartIndexTask"></sequenceFlow>
     <sequenceFlow id="flow38" sourceRef="incrementServiceBrokerSubscribersToRestartIndexTask" targetRef="areAllServiceBrokerSubscribersRestartedGateway"></sequenceFlow>
+    <sequenceFlow id="flow39" sourceRef="shouldUndeployAppGateway" targetRef="deleteServicesTask">
+      <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(appsToUndeployCount == appsToUndeployIndex)}]]></conditionExpression>
+    </sequenceFlow>
   </process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_xs2-undeploy">
     <bpmndi:BPMNPlane bpmnElement="xs2-undeploy" id="BPMNPlane_xs2-undeploy">
@@ -105,9 +100,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="deleteServicesTask" id="BPMNShape_deleteServicesTask">
         <omgdc:Bounds height="55.0" width="105.0" x="521.0" y="195.0"></omgdc:Bounds>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="shouldDeleteDiscontinuedServicesGateway" id="BPMNShape_shouldDeleteDiscontinuedServicesGateway">
-        <omgdc:Bounds height="40.0" width="40.0" x="720.0" y="202.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="unregisterServiceUrlsTask" id="BPMNShape_unregisterServiceUrlsTask">
         <omgdc:Bounds height="55.0" width="111.0" x="1037.0" y="76.0"></omgdc:Bounds>
@@ -179,16 +171,6 @@
         <omgdi:waypoint x="61.0" y="103.0"></omgdi:waypoint>
         <omgdi:waypoint x="110.0" y="103.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="deleteDiscontinuedServicesFlow" id="BPMNEdge_deleteDiscontinuedServicesFlow">
-        <omgdi:waypoint x="720.0" y="222.0"></omgdi:waypoint>
-        <omgdi:waypoint x="626.0" y="222.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="doNotDeleteDiscontinuedServicesFlow" id="BPMNEdge_doNotDeleteDiscontinuedServicesFlow">
-        <omgdi:waypoint x="740.0" y="242.0"></omgdi:waypoint>
-        <omgdi:waypoint x="740.0" y="278.0"></omgdi:waypoint>
-        <omgdi:waypoint x="404.0" y="278.0"></omgdi:waypoint>
-        <omgdi:waypoint x="404.0" y="250.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
         <omgdi:waypoint x="459.0" y="103.0"></omgdi:waypoint>
         <omgdi:waypoint x="520.0" y="103.0"></omgdi:waypoint>
@@ -219,7 +201,7 @@
         <omgdi:waypoint x="40.0" y="164.0"></omgdi:waypoint>
         <omgdi:waypoint x="40.0" y="205.0"></omgdi:waypoint>
         <bpmndi:BPMNLabel>
-          <omgdc:Bounds height="14.0" width="93.0" x="215.0" y="169.0"></omgdc:Bounds>
+          <omgdc:Bounds height="48.0" width="93.0" x="215.0" y="169.0"></omgdc:Bounds>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="mtaExistsFlow" id="BPMNEdge_mtaExistsFlow">
@@ -243,7 +225,7 @@
         <omgdi:waypoint x="156.0" y="222.0"></omgdi:waypoint>
         <omgdi:waypoint x="58.0" y="222.0"></omgdi:waypoint>
         <bpmndi:BPMNLabel>
-          <omgdc:Bounds height="42.0" width="100.0" x="70.0" y="231.0"></omgdc:Bounds>
+          <omgdc:Bounds height="48.0" width="100.0" x="70.0" y="231.0"></omgdc:Bounds>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="allServiceBrokerSubscribersWereRestartedFlow" id="BPMNEdge_allServiceBrokerSubscribersWereRestartedFlow">
@@ -272,12 +254,6 @@
       <bpmndi:BPMNEdge bpmnElement="flow27" id="BPMNEdge_flow27">
         <omgdi:waypoint x="1050.0" y="222.0"></omgdi:waypoint>
         <omgdi:waypoint x="1008.0" y="222.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="appsUndeployedFlow" id="BPMNEdge_appsUndeployedFlow">
-        <omgdi:waypoint x="988.0" y="202.0"></omgdi:waypoint>
-        <omgdi:waypoint x="988.0" y="176.0"></omgdi:waypoint>
-        <omgdi:waypoint x="740.0" y="176.0"></omgdi:waypoint>
-        <omgdi:waypoint x="740.0" y="202.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="flow30" id="BPMNEdge_flow30">
         <omgdi:waypoint x="864.0" y="250.0"></omgdi:waypoint>
@@ -327,6 +303,13 @@
         <omgdi:waypoint x="928.0" y="545.0"></omgdi:waypoint>
         <omgdi:waypoint x="361.0" y="545.0"></omgdi:waypoint>
         <omgdi:waypoint x="362.0" y="447.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow39" id="BPMNEdge_flow39">
+        <omgdi:waypoint x="988.0" y="202.0"></omgdi:waypoint>
+        <omgdi:waypoint x="987.0" y="155.0"></omgdi:waypoint>
+        <omgdi:waypoint x="781.0" y="155.0"></omgdi:waypoint>
+        <omgdi:waypoint x="574.0" y="155.0"></omgdi:waypoint>
+        <omgdi:waypoint x="573.0" y="195.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
#### Description: 
The xs/cf undeploy default behavior is that services are not deleted by default. However, there is no indication in the undeploy logs that these services are left behind. This makes it not obvious to the user what is happening. In order to improve the user experience and make it transparent what is happening we should add some progress messages indicating that there are some service left behind (in case the --delete-services flag is not used).


#### Issue: LMCROSSITXSADEPLOY-1122

