### PR TITLE
Fix calling of AbortProcessListener

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-bg-deploy.bpmn
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-bg-deploy.bpmn
@@ -2,7 +2,7 @@
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test" id="Definitions_1" name="Definitions 1">
   <process id="xs2-bg-deploy" name="XS2 Blue Green Deploy Activiti Process" isExecutable="true">
     <extensionElements>
-      <activiti:eventListener events="ENTITY_DELETED" entityType="process-instance" delegateExpression="${abortProcessListener}"></activiti:eventListener>
+      <activiti:eventListener events="PROCESS_CANCELLED" delegateExpression="${abortProcessListener}"></activiti:eventListener>
       <activiti:eventListener events="JOB_EXECUTION_FAILURE" delegateExpression="${errorProcessListener}"></activiti:eventListener>
     </extensionElements>
     <startEvent id="startEvent" name="Start" activiti:initiator="initiator">

--- a/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-deploy.bpmn
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-deploy.bpmn
@@ -2,7 +2,7 @@
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.flowable.org/test" id="Definitions_1" name="Definitions 1">
   <process id="xs2-deploy" name="XS2 Deploy Activiti Process" isExecutable="true">
     <extensionElements>
-      <activiti:eventListener events="PROCESS_CANCELLED,ENTITY_DELETED" delegateExpression="${abortProcessListener}"></activiti:eventListener>
+      <activiti:eventListener events="PROCESS_CANCELLED" delegateExpression="${abortProcessListener}"></activiti:eventListener>
       <activiti:eventListener events="JOB_EXECUTION_FAILURE" delegateExpression="${errorProcessListener}"></activiti:eventListener>
     </extensionElements>
     <startEvent id="startEvent" name="Start" activiti:initiator="initiator">

--- a/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-undeploy.bpmn
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-undeploy.bpmn
@@ -2,7 +2,7 @@
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
   <process id="xs2-undeploy" name="XS2 Undeploy Activiti Process" isExecutable="true">
     <extensionElements>
-      <activiti:eventListener events="ENTITY_DELETED" entityType="process-instance" delegateExpression="${abortProcessListener}"></activiti:eventListener>
+      <activiti:eventListener events="PROCESS_CANCELLED" delegateExpression="${abortProcessListener}"></activiti:eventListener>
       <activiti:eventListener events="JOB_EXECUTION_FAILURE" delegateExpression="${errorProcessListener}"></activiti:eventListener>
     </extensionElements>
     <startEvent id="startEvent" name="Start" activiti:initiator="initiator">


### PR DESCRIPTION
#### Description: 
This commit is needed because of bug in flowable. See: https://forum.flowable.org/t/runtimeservice-deleteprocessinstance-does-not-trigger-the-specified-listeners/2881

#### Issue: LMCROSSITXSADEPLOY-1294