### PR TITLE
Graceful shutdown REST API for multiapps-controller.

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/flowable/FlowableFacade.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/flowable/FlowableFacade.java
@@ -17,6 +17,8 @@ import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.job.api.Job;
+import org.flowable.job.service.impl.asyncexecutor.AsyncExecutor;
+import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
 import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -328,4 +330,20 @@ public class FlowableFacade {
         return processInstance != null && processInstance.isSuspended();
     }
 
+    public void shutdownJobExecutor(long secondsToWaitOnShutdown) {
+        setSecondsToWaitOnJobExecutorShutdown(secondsToWaitOnShutdown);
+        LOGGER.info(Messages.SHUTTING_DOWN_FLOWABLE_JOB_EXECUTOR);
+        AsyncExecutor asyncExecutor = processEngine.getProcessEngineConfiguration().getAsyncExecutor();
+        asyncExecutor.shutdown();
+    }
+
+    private void setSecondsToWaitOnJobExecutorShutdown(long secondsToWaitOnShutdown) {
+        LOGGER.info(format(Messages.SETTING_SECONDS_TO_WAIT_BEFORE_FLOWABLE_JOB_EXECUTOR_SHUTDOWN, secondsToWaitOnShutdown));
+        AsyncExecutor asyncExecutor = processEngine.getProcessEngineConfiguration().getAsyncExecutor();
+        ((DefaultAsyncJobExecutor) asyncExecutor).setSecondsToWaitOnShutdown(secondsToWaitOnShutdown);
+    }
+
+    public boolean isJobExecutorActive() {
+        return processEngine.getProcessEngineConfiguration().getAsyncExecutor().isActive();
+    }
 }

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/flowable/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/flowable/Messages.java
@@ -18,6 +18,8 @@ public class Messages {
 
     public static final String SETTING_VARIABLE = "Setting variable \"{0}\" to \"{1}\"...";
     public static final String SET_SUCCESSFULLY = "Variable \"{0}\" set successfully";
+    public static final String SETTING_SECONDS_TO_WAIT_BEFORE_FLOWABLE_JOB_EXECUTOR_SHUTDOWN = "Setting \"{0}\" seconds to wait before shutdown of Flowable job executor...";
+    public static final String SHUTTING_DOWN_FLOWABLE_JOB_EXECUTOR = "Shutting down Flowable job executor...";
 
     // ERROR log messages:
 

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/message/Messages.java
@@ -174,6 +174,9 @@ public final class Messages {
     public static final String PURGE_DELETE_REQUEST_SPACE_FROM_CONFIGURATION_TABLES = "All delete request spaces after date: {0} will be deleted from configuration tables.";
     public static final String RETRIEVED_USER_TOKEN = "Retrieved token for user: {0} with expiration time: {1}";
     public static final String FSS_CACHE_UPDATE_TIMEOUT = "Fss cache update timeout: {0} minutes";
+    public static final String APP_SHUTDOWN_REQUEST = "Application with id:\"{0}\", instance id:\"{1}\", instance index:\"{2}\", is requested to shutdown. Timeout to wait before shutdown of Flowable job executor:\"{3}\" seconds.";
+    public static final String APP_SHUTDOWNED = "Application with id:\"{0}\", instance id:\"{1}\", instance index:\"{2}\", is shutdowned. Timeout to wait before shutdown of Flowable job executor:\"{3}\" seconds.";
+    public static final String APP_SHUTDOWN_STATUS_MONITOR = "Monitor shutdown status of application with id:\"{0}\", instance id:\"{1}\", instance index:\"{2}\". Status:\"{3}\".";
 
     // Debug messages
     public static final String EXTENSION_DESCRIPTOR = "Extension descriptor \"{0}\": {1}";

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/shutdown/model/ApplicationShutdownDto.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/shutdown/model/ApplicationShutdownDto.java
@@ -1,0 +1,81 @@
+package com.sap.cloud.lm.sl.cf.core.shutdown.model;
+
+public class ApplicationShutdownDto {
+    private Status status = Status.RUNNING;
+    private String appId;
+    private String appInstanceId;
+    private String appInstanceIndex;
+    private long cooldownTimeoutInSeconds;
+
+    private ApplicationShutdownDto(Status status, String appId,
+        String appInstanceId, String appInstanceIndex, long cooldownTimeoutInSeconds) {
+        this.status = status;
+        this.appId = appId;
+        this.appInstanceId = appInstanceId;
+        this.appInstanceIndex = appInstanceIndex;
+        this.cooldownTimeoutInSeconds = cooldownTimeoutInSeconds;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public String getAppInstanceId() {
+        return appInstanceId;
+    }
+
+    public String getAppInstanceIndex() {
+        return appInstanceIndex;
+    }
+
+    public long getCooldownTimeoutInSeconds() {
+        return cooldownTimeoutInSeconds;
+    }
+
+    public static class Builder {
+        private boolean isActive = true;
+        private String appId;
+        private String appInstanceId;
+        private String appInstanceIndex;
+        private long cooldownTimeoutInSeconds;
+
+        public ApplicationShutdownDto build(){
+            return new ApplicationShutdownDto(isActive ? Status.RUNNING : Status.FINISHED, appId, appInstanceId,
+                appInstanceIndex,
+                cooldownTimeoutInSeconds);
+        }
+
+        public Builder isActive(boolean isActive) {
+            this.isActive = isActive;
+            return this;
+        }
+
+        public Builder appId(String appId) {
+            this.appId = appId;
+            return this;
+        }
+
+        public Builder appInstanceId(String appInstanceId) {
+            this.appInstanceId = appInstanceId;
+            return this;
+        }
+
+        public Builder appInstanceIndex(String appInstanceIndex) {
+            this.appInstanceIndex = appInstanceIndex;
+            return this;
+        }
+
+        public Builder cooldownTimeoutInSeconds(long cooldownTimeoutInSeconds) {
+            this.cooldownTimeoutInSeconds = cooldownTimeoutInSeconds;
+            return this;
+        }
+    }
+
+    public static enum Status {
+        FINISHED, RUNNING;
+    }
+}

--- a/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/flowable/FlowableFacadeTest.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/flowable/FlowableFacadeTest.java
@@ -1,0 +1,43 @@
+package com.sap.cloud.lm.sl.cf.core.flowable;
+
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.ProcessEngineConfiguration;
+import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+class FlowableFacadeTest {
+
+    private FlowableFacade flowableFacade;
+
+    @Mock
+    DefaultAsyncJobExecutor mockedAsyncExecutor;
+
+    @Mock
+    ProcessEngine mockedProcessEngine;
+
+    @Mock
+    ProcessEngineConfiguration mockedProcessEngineConfiguration;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        Mockito.when(mockedProcessEngineConfiguration.getAsyncExecutor()).thenReturn(mockedAsyncExecutor);
+        Mockito.when(mockedProcessEngine.getProcessEngineConfiguration()).thenReturn(mockedProcessEngineConfiguration);
+
+        flowableFacade = new FlowableFacade(mockedProcessEngine);
+    }
+
+    @Test
+    void testAsyncExecutorMethodsAreCalled() {
+        long secondsToWaitOnShutdown = 10;
+        flowableFacade.shutdownJobExecutor(secondsToWaitOnShutdown);
+        Mockito.verify(mockedAsyncExecutor, Mockito.times(1)).setSecondsToWaitOnShutdown(secondsToWaitOnShutdown);
+        Mockito.verify(mockedAsyncExecutor, Mockito.times(1)).shutdown();
+    }
+
+}

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/app/CFApplication.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/app/CFApplication.java
@@ -5,10 +5,12 @@ import java.util.Set;
 
 import javax.ws.rs.core.Application;
 
+import com.sap.cloud.lm.sl.cf.web.resources.AdminResource;
 import com.sap.cloud.lm.sl.cf.web.resources.CFExceptionMapper;
 import com.sap.cloud.lm.sl.cf.web.resources.ConfigurationEntriesResource;
 import com.sap.cloud.lm.sl.cf.web.resources.ConfigurationSubscriptionsResource;
 import com.sap.cloud.lm.sl.cf.web.resources.CsrfTokenResource;
+import com.sap.cloud.lm.sl.cf.web.resources.ApplicationShutdownResource;
 
 public class CFApplication extends Application {
 
@@ -22,4 +24,11 @@ public class CFApplication extends Application {
         return classes;
     }
 
+    @Override
+    public Set<Object> getSingletons() {
+        Set<Object> singletons = new HashSet<>();
+        singletons.add(new AdminResource());
+        singletons.add(new ApplicationShutdownResource());
+        return singletons;
+    }
 }

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/resources/AdminResource.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/resources/AdminResource.java
@@ -1,0 +1,40 @@
+package com.sap.cloud.lm.sl.cf.web.resources;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+
+import org.springframework.stereotype.Component;
+
+import com.sap.cloud.lm.sl.cf.core.util.ApplicationConfiguration;
+import com.sap.cloud.lm.sl.cf.web.security.AuthorizationChecker;
+import com.sap.cloud.lm.sl.cf.web.util.SecurityContextUtil;
+
+@Path("/admin")
+@Component
+public class AdminResource {
+
+    @Inject
+    private ApplicationShutdownResource appShutdownResource;
+
+    @Inject
+    private AuthorizationChecker authorizationChecker;
+
+    @Inject
+    private ApplicationConfiguration appConfiguration;
+
+    @Context
+    private HttpServletRequest request;
+
+    @Path("/shutdown")
+    public ApplicationShutdownResource getApplicationShutdownResource() {
+        ensureUserIsAuthorized(ApplicationShutdownResource.ACTION);
+        return appShutdownResource;
+    }
+
+    private void ensureUserIsAuthorized(String resourceAction) {
+        authorizationChecker.ensureUserIsAuthorized(request, SecurityContextUtil.getUserInfo(), appConfiguration.getSpaceId(), resourceAction);
+    }
+
+}

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/resources/ApplicationShutdownResource.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/resources/ApplicationShutdownResource.java
@@ -1,0 +1,83 @@
+package com.sap.cloud.lm.sl.cf.web.resources;
+
+import java.text.MessageFormat;
+import java.util.concurrent.CompletableFuture;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sap.cloud.lm.sl.cf.core.flowable.FlowableFacade;
+import com.sap.cloud.lm.sl.cf.core.message.Messages;
+import com.sap.cloud.lm.sl.cf.core.shutdown.model.ApplicationShutdownDto;
+
+@Component
+@Produces(MediaType.APPLICATION_JSON)
+public class ApplicationShutdownResource {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationShutdownResource.class);
+
+    private static final long DEFAULT_COOLDOWN_TIMEOUT_IN_SECONDS = 300L; // 5 mins
+
+    public static final String ACTION = "shutdown";
+
+    @Inject
+    private FlowableFacade flowableFacade;
+
+    @POST
+    public ApplicationShutdownDto shutdownFlowableJobExecutor(@HeaderParam("x-cf-applicationid") String appId,
+        @HeaderParam("x-cf-instanceid") String appInstanceId, @HeaderParam("x-cf-instanceindex") String appInstanceIndex,
+        @QueryParam("cooldownTimeoutInSeconds") String cooldownTimeoutInSecondsParam) {
+
+        long cooldownTimeoutInSeconds = getCooldownTimeoutInSeconds(cooldownTimeoutInSecondsParam);
+
+        CompletableFuture.runAsync(() -> {
+            LOGGER.info(MessageFormat.format(Messages.APP_SHUTDOWN_REQUEST, appId, appInstanceId, appInstanceIndex,
+                cooldownTimeoutInSeconds));
+            flowableFacade.shutdownJobExecutor(cooldownTimeoutInSeconds);
+        })
+            .thenRun(() -> {
+                LOGGER.info(MessageFormat.format(Messages.APP_SHUTDOWNED, appId, appInstanceId, appInstanceIndex,
+                    cooldownTimeoutInSeconds));
+            });
+
+        return new ApplicationShutdownDto.Builder().isActive(flowableFacade.isJobExecutorActive())
+            .appId(appId)
+            .appInstanceId(appInstanceId)
+            .appInstanceIndex(appInstanceIndex)
+            .cooldownTimeoutInSeconds(cooldownTimeoutInSeconds)
+            .build();
+    }
+
+    @GET
+    public ApplicationShutdownDto getFlowableJobExecutorShutdownStatus(@HeaderParam("x-cf-applicationid") String appId,
+        @HeaderParam("x-cf-instanceid") String appInstanceId, @HeaderParam("x-cf-instanceindex") String appInstanceIndex) {
+
+        ApplicationShutdownDto appShutdownDto = new ApplicationShutdownDto.Builder().isActive(flowableFacade.isJobExecutorActive())
+            .appId(appId)
+            .appInstanceId(appInstanceId)
+            .appInstanceIndex(appInstanceIndex)
+            .build();
+
+        LOGGER.info(
+            MessageFormat.format(Messages.APP_SHUTDOWN_STATUS_MONITOR, appId, appInstanceId, appInstanceIndex, appShutdownDto.getStatus()));
+
+        return appShutdownDto;
+    }
+
+    private long getCooldownTimeoutInSeconds(String cooldownTimeoutInSecondsParam) {
+        if (cooldownTimeoutInSecondsParam == null) {
+            return DEFAULT_COOLDOWN_TIMEOUT_IN_SECONDS;
+        }
+        return Long.parseLong(cooldownTimeoutInSecondsParam);
+    }
+
+}


### PR DESCRIPTION
#### Description: 
Expose REST API for graceful shutdown of the multiapps-controller. It is available on "rest/admin/shutdown" endpoint. It is intended to be called for concrete application instance by provision of "X-CF-APP-INSTANCE=<app-id>:<app-instance-index>" header. The API triggers shutdown on the Flowable async executor and waits for it to shutdown until cool down timeout is reached, which can be configured via query param "cooldownTimeoutInSeconds".

#### JIRA: LMCROSSITXSADEPLOY-1190

