### PR TITLE
ProcessLogger drop appenders+FDs before deletion

### DIFF
--- a/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/ProcessLoggerProvider.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/ProcessLoggerProvider.java
@@ -103,6 +103,7 @@ public class ProcessLoggerProvider {
     }
 
     public void remove(ProcessLogger processLogger) {
+        processLogger.removeAllAppenders();
         loggersCache.remove(processLogger.getName());
     }
 


### PR DESCRIPTION
The process logger is caching it's process step logg on the local
file system. Upon dismissal, the process loger persists the information
to the DB after which the reference to the object is lost.
Unfortunately the process logger appender, which manages the file
descriptor to the caching file is also lost with the logger. It never
gets properly closed.
This change calls for removal of all appenders before removal
of the process logger from the loggers cache.
