### PR TITLE
Fix logging for MonitorUploadStatusCallback

### DIFF
--- a/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/ProcessLogsPersister.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/ProcessLogsPersister.java
@@ -14,8 +14,7 @@ public class ProcessLogsPersister {
     private ProcessLogsPersistenceService processLogsPersistenceService;
 
     public void persistLogs(DelegateExecution context) {
-        for (ProcessLogger processLogger : processLoggerProvider.getExistingLoggers(getCorrelationId(context),
-            context.getCurrentActivityId())) {
+        for (ProcessLogger processLogger : processLoggerProvider.getExistingLoggers(getCorrelationId(context), getTaskId(context))) {
             processLogger.persistLogFile(processLogsPersistenceService);
             processLogger.deleteLogFile();
             processLoggerProvider.remove(processLogger);
@@ -24,5 +23,10 @@ public class ProcessLogsPersister {
 
     private String getCorrelationId(DelegateExecution context) {
         return (String) context.getVariable(Constants.CORRELATION_ID);
+    }
+
+    private String getTaskId(DelegateExecution context) {
+        String taskId = (String) context.getVariable(Constants.TASK_ID);
+        return taskId != null ? taskId : context.getCurrentActivityId();
     }
 }


### PR DESCRIPTION
#### Description: 
The monitoring callback may not be called during uploadAppStep but the polling timer in which case the merging of logs would not happen because no log file for the polling timer exists.
This fix makes use of taskId to identify the task at which the call of the callback happened.