### PR TITLE
Drop activiti sequence in preparation for flowable

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/resources/com/sap/cloud/lm/sl/cf/core/db/changelog/db-changelog-prepare_for_flowable.xml
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/resources/com/sap/cloud/lm/sl/cf/core/db/changelog/db-changelog-prepare_for_flowable.xml
@@ -11,7 +11,13 @@
   		    ALTER TABLE process_log DISABLE TRIGGER delete_from_system_table_process_log;
         </sql>
     </changeSet>
-	<changeSet author="sap.com" id="drop_act_evt_log">
+    <changeSet author="sap.com" id="drop_act_evt_log_seq">
+        <preConditions onFail="MARK_RAN">
+            <sequenceExists sequenceName="act_evt_log_seq" />
+        </preConditions>
+        <dropSequence sequenceName="act_evt_log_seq" />
+    </changeSet>
+    <changeSet author="sap.com" id="drop_act_evt_log">
         <preConditions onFail="MARK_RAN">
             <tableExists tableName="act_evt_log" />
         </preConditions>


### PR DESCRIPTION
#### Description: 
ACT_EVT_LOG_SEQ must be dropped in order to avoid migration failures when migrating from older Activiti versions directly to Flowable.
