### PR TITLE
Fix upload status monitoring

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UploadAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UploadAppStep.java
@@ -170,7 +170,7 @@ public class UploadAppStep extends TimeoutAsyncFlowableStep {
 
     class MonitorUploadStatusCallback implements UploadStatusCallbackExtended {
 
-        static final String FINISHED_STATUS = "finished";
+        static final String READY_STATUS = "ready";
 
         private final CloudApplication app;
         private final File file;
@@ -200,7 +200,7 @@ public class UploadAppStep extends TimeoutAsyncFlowableStep {
         @Override
         public boolean onProgress(String status) {
             getStepLogger().debug(Messages.UPLOAD_STATUS_0, status);
-            if (status.equals(FINISHED_STATUS)) {
+            if (status.equals(READY_STATUS)) {
                 cleanUp(file.toPath());
                 getProcessLogsPersister().persistLogs(context);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <jackson-asl.version>1.9.13</jackson-asl.version>
         <liquibase.version>3.4.1</liquibase.version>
         <liquibase-slf4j.version>1.2.1</liquibase-slf4j.version>
-        <cloudfoundry.client.version>1.3.0</cloudfoundry.client.version>
+        <cloudfoundry.client.version>1.4.0</cloudfoundry.client.version>
         <protobuf-java.version>3.1.0</protobuf-java.version>
         <semver4j.version>2.2.0</semver4j.version>
         <jgit.version>4.0.1.201506240215-r</jgit.version>


### PR DESCRIPTION
#### Description: 
An issue introduced with adoption of v3 cf java client did not call onProgress method resulting in application binaries not being deleted.


#### Issue: <!-- Link to a Github Issue, delete if not applicable -->

