### PR TITLE
cherry-pick: Fix release of MTA locks in process listeners

### DIFF
--- a/com.sap.cloud.lm.sl.cf.api/pom.xml
+++ b/com.sap.cloud.lm.sl.cf.api/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.lm.sl.cf</groupId>
         <artifactId>com.sap.cloud.lm.sl.cf.parent</artifactId>
-        <version>1.72.4</version>
+        <version>1.72.5</version>
     </parent>
 
     <dependencies>

--- a/com.sap.cloud.lm.sl.cf.client/pom.xml
+++ b/com.sap.cloud.lm.sl.cf.client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.sap.cloud.lm.sl.cf</groupId>
         <artifactId>com.sap.cloud.lm.sl.cf.parent</artifactId>
-        <version>1.72.4</version>
+        <version>1.72.5</version>
     </parent>
 
     <dependencies>

--- a/com.sap.cloud.lm.sl.cf.core/pom.xml
+++ b/com.sap.cloud.lm.sl.cf.core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.lm.sl.cf</groupId>
         <artifactId>com.sap.cloud.lm.sl.cf.parent</artifactId>
-        <version>1.72.4</version>
+        <version>1.72.5</version>
     </parent>
 
     <build>

--- a/com.sap.cloud.lm.sl.cf.persistence/pom.xml
+++ b/com.sap.cloud.lm.sl.cf.persistence/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.sap.cloud.lm.sl.cf</groupId>
         <artifactId>com.sap.cloud.lm.sl.cf.parent</artifactId>
-        <version>1.72.4</version>
+        <version>1.72.5</version>
     </parent>
 
     <build>

--- a/com.sap.cloud.lm.sl.cf.process/pom.xml
+++ b/com.sap.cloud.lm.sl.cf.process/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.sap.cloud.lm.sl.cf</groupId>
         <artifactId>com.sap.cloud.lm.sl.cf.parent</artifactId>
-        <version>1.72.4</version>
+        <version>1.72.5</version>
     </parent>
 
     <dependencies>

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -183,8 +183,8 @@ public class Messages {
     public static final String MTA_NOT_FOUND = "An MTA with id \"{0}\" does not exist";
     public static final String ACQUIRING_LOCK = "Process \"{0}\" attempting to acquire lock for operation on MTA \"{1}\"";
     public static final String ACQUIRED_LOCK = "Process \"{0}\" acquired lock for operation on MTA \"{1}\"";
-    public static final String RELEASING_LOCK = "Process \"{0}\" attempting to release lock for operation on MTA \"{1}\"";
-    public static final String RELEASED_LOCK = "Process \"{0}\" released lock for operation on MTA \"{1}\"";
+    public static final String PROCESS_0_RELEASING_LOCK_FOR_MTA_1_IN_SPACE_2 = "Process \"{0}\" releasing lock for MTA \"{1}\" in space {2}";
+    public static final String PROCESS_0_RELEASED_LOCK = "Process \"{0}\" released lock successfully!";
     public static final String DELETING_FILE_FROM_SPACE = "Deleting file with ID \"{0}\" from space with ID \"{1}\"";
     public static final String BINDING_APP_TO_SERVICE_WITH_PARAMETERS = "Binding application \"{0}\" to service \"{1}\" with parameters \"{2}\"";
     public static final String BINDING_APP_TO_SERVICE = "Binding application \"{0}\" to service \"{1}\"";

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareToUndeployStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareToUndeployStep.java
@@ -46,7 +46,7 @@ public class PrepareToUndeployStep extends SyncFlowableStep {
             StepsUtil.setSubscriptionsToCreate(execution.getContext(), Collections.emptyList());
 
             conflictPreventerSupplier.apply(operationDao)
-                .attemptToAcquireLock(mtaId, StepsUtil.getSpaceId(execution.getContext()), execution.getContext()
+                .acquireLock(mtaId, StepsUtil.getSpaceId(execution.getContext()), execution.getContext()
                     .getProcessInstanceId());
 
             getStepLogger().debug(Messages.COMPONENTS_TO_UNDEPLOY_DETECTED);

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessMtaArchiveStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessMtaArchiveStep.java
@@ -106,7 +106,7 @@ public class ProcessMtaArchiveStep extends SyncFlowableStep {
         String mtaId = deploymentDescriptor.getId();
         context.setVariable(Constants.PARAM_MTA_ID, mtaId);
         conflictPreventerSupplier.apply(operationDao)
-            .attemptToAcquireLock(mtaId, StepsUtil.getSpaceId(context), StepsUtil.getCorrelationId(context));
+            .acquireLock(mtaId, StepsUtil.getSpaceId(context), StepsUtil.getCorrelationId(context));
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/ProcessConflictPreventer.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/ProcessConflictPreventer.java
@@ -24,7 +24,7 @@ public class ProcessConflictPreventer {
         this.dao = dao;
     }
 
-    public synchronized void attemptToAcquireLock(String mtaId, String spaceId, String processId) {
+    public synchronized void acquireLock(String mtaId, String spaceId, String processId) {
         LOGGER.info(format(Messages.ACQUIRING_LOCK, processId, mtaId));
 
         validateNoConflictingOperationsExist(mtaId, spaceId);
@@ -60,16 +60,6 @@ public class ProcessConflictPreventer {
             .withAcquiredLock()
             .build();
         return dao.find(filter);
-    }
-
-    public synchronized void attemptToReleaseLock(String processId) {
-        Operation currentOperation = dao.findRequired(processId);
-        String mtaId = currentOperation.getMtaId();
-
-        LOGGER.info(format(Messages.RELEASING_LOCK, processId, mtaId));
-        currentOperation.acquiredLock(false);
-        dao.merge(currentOperation);
-        LOGGER.info(format(Messages.RELEASED_LOCK, processId, mtaId));
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/util/ProcessConflictPreventerTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/util/ProcessConflictPreventerTest.java
@@ -31,7 +31,7 @@ public class ProcessConflictPreventerTest {
     }
 
     @Test
-    public void testAttemptToAcquireLock() {
+    public void testAcquireLock() {
         try {
             Operation operation = new Operation().processId(testProcessId)
                 .processType(ProcessType.DEPLOY)
@@ -43,7 +43,7 @@ public class ProcessConflictPreventerTest {
                 .withAcquiredLock()
                 .build();
             when(daoMock.find(expectedFilter)).thenReturn(Arrays.asList(operation));
-            processConflictPreventerMock.attemptToAcquireLock(testMtaId, testSpaceId, testProcessId);
+            processConflictPreventerMock.acquireLock(testMtaId, testSpaceId, testProcessId);
             verify(daoMock).merge(daoMock.findRequired(testProcessId));
         } catch (SLException e) {
             assertEquals("Conflicting process \"test-process-id\" found for MTA \"test-mta-id\"", e.getMessage());
@@ -51,14 +51,8 @@ public class ProcessConflictPreventerTest {
     }
 
     @Test
-    public void testAttemptToAcquireLockWithNoConflictingOperations() throws SLException {
-        processConflictPreventerMock.attemptToAcquireLock(testMtaId, testSpaceId, testProcessId);
-    }
-
-    @Test
-    public void testAttemptToReleaseLock() throws SLException {
-        processConflictPreventerMock.attemptToReleaseLock(testProcessId);
-        verify(daoMock).merge(daoMock.findRequired(testProcessId));
+    public void testAcquireLockWithNoConflictingOperations() throws SLException {
+        processConflictPreventerMock.acquireLock(testMtaId, testSpaceId, testProcessId);
     }
 
     private OperationDao getOperationDaoMock() throws SLException {

--- a/com.sap.cloud.lm.sl.cf.web/pom.xml
+++ b/com.sap.cloud.lm.sl.cf.web/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.lm.sl.cf</groupId>
         <artifactId>com.sap.cloud.lm.sl.cf.parent</artifactId>
-        <version>1.72.4</version>
+        <version>1.72.5</version>
     </parent>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.lm.sl.cf</groupId>
     <artifactId>com.sap.cloud.lm.sl.cf.parent</artifactId>
-    <version>1.72.4</version>
+    <version>1.72.5</version>
     <packaging>pom</packaging>
     <name>LM SL CF Parent</name>
     <description>Multi-Target Application (MTA) deployment service for Cloud Foundry</description>


### PR DESCRIPTION
#### Description: 
    Fix release of MTA locks in process listeners

    Previously, the release of the MTA lock was done separately from the
    update of the operation's state. This sometimes lead to operations having
    an acquired lock despite being finished/aborted.



#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
NGPBUG-76267

