### PR TITLE
Change the polling task to be found directly by guid

### DIFF
--- a/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/ResilientCloudControllerClient.java
+++ b/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/ResilientCloudControllerClient.java
@@ -438,7 +438,8 @@ public class ResilientCloudControllerClient implements CloudControllerClientSupp
     }
 
     @Override
-    public UploadToken asyncUploadApplication(String appName, ApplicationArchive archive, UploadStatusCallback callback) throws IOException {
+    public UploadToken asyncUploadApplication(String appName, ApplicationArchive archive, UploadStatusCallback callback)
+        throws IOException {
         return executeWithRetry(() -> {
             try {
                 return cc.asyncUploadApplication(appName, archive, callback);
@@ -955,6 +956,11 @@ public class ResilientCloudControllerClient implements CloudControllerClientSupp
     }
 
     @Override
+    public CloudTask getTask(UUID taskGuid) {
+        return executeWithRetry(() -> cc.getTask(taskGuid));
+    }
+
+    @Override
     public List<CloudTask> getTasks(String applicationName) {
         return executeWithRetry(() -> cc.getTasks(applicationName), HttpStatus.NOT_FOUND);
     }
@@ -994,7 +1000,7 @@ public class ResilientCloudControllerClient implements CloudControllerClientSupp
     }
 
     @Override
-    public void bindDropletToApp(UUID dropletGuid,UUID appGuid) {
+    public void bindDropletToApp(UUID dropletGuid, UUID appGuid) {
         executeWithRetry(() -> cc.bindDropletToApp(dropletGuid, appGuid));
     }
 }

--- a/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/message/Messages.java
@@ -73,10 +73,11 @@ public class Messages {
     public static final String CANT_GET_SERVICE_TAGS = "Cloud not retrieve tags for service \"{0}\"";
     public static final String TIMEOUT_EXECUTOR_IS_NOT_SET_UP = "TimeoutExecutor is not set up";
     public static final String CANT_GET_TASKS_FOR_APP = "Could not get tasks for application \"{0}\"";
+    public static final String CANT_GET_TASK_WITH_GUID = "Could not get task with guid \"{0}\"";
     public static final String CANT_RUN_TASK_ON_APP = "Could not run task \"{0}\" on application \"{1}\"";
     public static final String CANT_CANCEL_TASK = "Could not cancel task with GUID \"{0}\"";
     public static final String CANT_UPDATE_SERVICE_PLAN = "Could not update service plan of service \"{0}\": \"{1}\"";
-    
+
     public static final String SAVING_INPUT_STREAM_TEMP_FILE = "Saving input stream to temporary file \"{0}\"...";
     public static final String INPUT_STREAM_SAVED_IN_TEMP_FILE = "Input stream saved to temporary file \"{0}\"";
     public static final String SAVING_INPUT_STREAM_TO_TMP_DIR = "Saving input stream to temporary directory \"{0}\"...";

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -49,7 +49,6 @@ public class Messages {
     public static final String ERROR_DELETING_ARCHIVE_PARTS_CONTENT = "Error deleting archive parts content";
     public static final String SUB_PROCESS_HAS_FAILED = "Sub-process with id {0} has failed.";
     public static final String SUB_PROCESS_HAS_BEEN_ABORTED = "Sub-process with id {0} has been aborted.";
-    public static final String COULD_NOT_FIND_TASK_WITH_GUID = "Could not find task with GUID \"{0}\"!";
     public static final String COULD_NOT_COLLECT_PROCESS_STATISTICS = "Could not collect statistics for process with ID \"{0}\"";
     public static final String UNSUPPORTED_PROCESS_TYPE = "Process type \"{0}\" is not supported";
     public static final String FAILED_SERVICE_UPDATE = "Updating service {0} failed: {1}";
@@ -177,7 +176,6 @@ public class Messages {
     public static final String COULD_NOT_ABORT_OPERATION_0 = "Could not abort operation \"{0}\"";
     public static final String SKIP_SERVICES_DELETION = "Skipping deletion of services, because the command line option \"--delete-services\" is not specified.";
     public static final String UNSUPPORTED_MINOR_VERSION = "Used verion \"{0}\" is higher than the supported ones. Some features might not be implemented.";
-
 
     // INFO log messages
     public static final String MTA_NOT_FOUND = "An MTA with id \"{0}\" does not exist";

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollExecuteTaskStatusExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollExecuteTaskStatusExecution.java
@@ -1,8 +1,5 @@
 package com.sap.cloud.lm.sl.cf.process.steps;
 
-import java.text.MessageFormat;
-import java.util.List;
-import java.util.UUID;
 import java.util.function.Supplier;
 
 import org.cloudfoundry.client.lib.CloudControllerClient;
@@ -70,19 +67,9 @@ public class PollExecuteTaskStatusExecution implements AsyncExecution {
 
         private CloudTask.State getCurrentState() {
             CloudControllerClient client = execution.getControllerClient();
-            List<CloudTask> allTasksForApp = client.getTasks(app.getName());
-
-            return findTaskWithGuid(allTasksForApp, taskToPoll.getMeta()
-                .getGuid()).getState();
-        }
-
-        private CloudTask findTaskWithGuid(List<CloudTask> allTasksForApp, UUID guid) {
-            return allTasksForApp.stream()
-                .filter(task -> task.getMeta()
-                    .getGuid()
-                    .equals(guid))
-                .findAny()
-                .orElseThrow(() -> new IllegalStateException(MessageFormat.format(Messages.COULD_NOT_FIND_TASK_WITH_GUID, guid)));
+            return client.getTask(taskToPoll.getMeta()
+                .getGuid())
+                .getState();
         }
 
         private void reportCurrentState(CloudTask.State currentState) {

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/PollExecuteTaskStatusStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/PollExecuteTaskStatusStepTest.java
@@ -111,7 +111,7 @@ public class PollExecuteTaskStatusStepTest extends AsyncStepOperationTest<Execut
     private void prepareClientExtensions() {
         CloudTask taskWithState = StepsTestUtil.copy(task);
         taskWithState.setState(currentTaskState);
-        when(client.getTasks(APPLICATION_NAME)).thenReturn(Arrays.asList(taskWithState));
+        when(client.getTask(TASK_UUID)).thenReturn(taskWithState);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <jackson-asl.version>1.9.13</jackson-asl.version>
         <liquibase.version>3.4.1</liquibase.version>
         <liquibase-slf4j.version>1.2.1</liquibase-slf4j.version>
-        <cloudfoundry.client.version>1.4.0</cloudfoundry.client.version>
+        <cloudfoundry.client.version>1.5.0</cloudfoundry.client.version>
         <protobuf-java.version>3.1.0</protobuf-java.version>
         <semver4j.version>2.2.0</semver4j.version>
         <jgit.version>4.0.1.201506240215-r</jgit.version>


### PR DESCRIPTION
#### Description: 
The tasks were retrieved using the allTasks method. However, this method is using the v3 CF API which has a different pagination structure than v2 -> when there are a lot of tasks there could be some errors which state that the task is not found. This commit replaces the logic with getTask(guid) which is searching for the task directly by its id.


#### Issue: https://jtrack.wdf.sap.corp/browse/NGPBUG-77197

