### PR TITLE
Fix discontinued service calculation

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -452,7 +452,7 @@ public class Messages {
     public static final String UPDATING_SUBSCRIBER_0 = "Updating subscriber: {0} ";
     public static final String DELETED_APP_ROUTES = "App routes for applications \"{0}\" deleted";
     public static final String MODULES_TO_UNDEPLOY = "Modules to undeploy: {0}";
-    public static final String MODULES_TO_KEEP = "Modules to keep: {0}";
+    public static final String MODULES_NOT_TO_BE_CHANGED = "Modules that won't be changed: {0}";
     public static final String PROCESS_WAS_ABORTED = "Process was aborted";
     public static final String EXCEPTION_CAUGHT = "Exception caught";
     public static final String UNEXPECTED_ERROR = "Unexpected error: {0}";

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/BuildCloudUndeployModelStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/BuildCloudUndeployModelStepTest.java
@@ -4,11 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -20,7 +17,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 
 import com.google.gson.reflect.TypeToken;
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudApplicationExtended;
@@ -76,7 +72,7 @@ public class BuildCloudUndeployModelStepTest extends SyncFlowableStepTest<BuildC
             },
             // (6) There are no obsolete services:
             {
-                new StepInput("apps-to-deploy-01.json", Collections.emptyList(), "deployed-apps-04.json", new TreeSet<>(Arrays.asList("a", "b", "c", "d", "e")), "deployed-mta-08.json", "empty-list.json", "empty-list.json", new TreeSet<>(Arrays.asList("a", "b", "c", "d", "e"))),
+                new StepInput("apps-to-deploy-01.json", Arrays.asList("s-1", "s-2", "s-3"), "deployed-apps-04.json", new TreeSet<>(Arrays.asList("a", "b", "c", "d", "e")), "deployed-mta-08.json", "empty-list.json", "empty-list.json", new TreeSet<>(Arrays.asList("a", "b", "c", "d", "e"))),
                 new StepOutput(Arrays.asList("d", "e"), Collections.emptyList(), new Expectation(Expectation.Type.RESOURCE, "empty-list.json")),
             },
             // (7) There are no obsolete modules:
@@ -103,6 +99,11 @@ public class BuildCloudUndeployModelStepTest extends SyncFlowableStepTest<BuildC
             {
                 new StepInput("apps-to-deploy-01.json", Collections.emptyList(),"deployed-apps-04.json", new TreeSet<>(Arrays.asList("a", "b", "c", "d", "e")), "deployed-mta-03.json", "empty-list.json",  "existing-subscriptions-01.json", new TreeSet<>(Arrays.asList("a", "b", "c", "d", "e"))),
                 new StepOutput(Arrays.asList("d", "e"), Collections.emptyList(), new Expectation(Expectation.Type.RESOURCE, "subscriptions-to-delete-02.json")),
+            },
+            // (12) There are obsolete services because they are all unbound
+            {
+                new StepInput("apps-to-deploy-01.json", Collections.emptyList(), "deployed-apps-04.json", new TreeSet<>(Arrays.asList("a", "b", "c", "d", "e")), "deployed-mta-08.json", "empty-list.json", "empty-list.json", new TreeSet<>(Arrays.asList("a", "b", "c", "d", "e"))),
+                new StepOutput(Arrays.asList("d", "e"), Arrays.asList("s-1", "s-2", "s-3"), new Expectation(Expectation.Type.RESOURCE, "empty-list.json")),
             },
 // @formatter:on
         });
@@ -143,7 +144,9 @@ public class BuildCloudUndeployModelStepTest extends SyncFlowableStepTest<BuildC
 
     private void prepareDeploymentDescriptor() {
         DeploymentDescriptor.Builder builder = new DeploymentDescriptor.Builder();
-        List<Module>  modules = input.deploymentDescriptorModules.stream().map(this::getModuleFromName).collect(Collectors.toList());
+        List<Module> modules = input.deploymentDescriptorModules.stream()
+            .map(this::getModuleFromName)
+            .collect(Collectors.toList());
         builder.setModules2(modules);
         builder.setSchemaVersion("1");
         builder.setId("id");
@@ -238,7 +241,8 @@ public class BuildCloudUndeployModelStepTest extends SyncFlowableStepTest<BuildC
         public Set<String> deploymentDescriptorModules;
 
         public StepInput(String appsToDeployLocation, List<String> services, String deployedAppsLocation, Set<String> mtaModules,
-            String deployedMtaLocation, String subscriptionsToCreateLocation, String existingSubscriptionsLocation, Set<String> deploymentDescriptorModules) {
+            String deployedMtaLocation, String subscriptionsToCreateLocation, String existingSubscriptionsLocation,
+            Set<String> deploymentDescriptorModules) {
             this.appsToDeployLocation = appsToDeployLocation;
             this.services = services;
             this.deployedAppsLocation = deployedAppsLocation;


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
When deploying a new version of an MTA that contains the same applications, but a different set of services bound to them, no services get deleted even if the --delete-services flag is passed to the deploy process. This change fixes that issue.

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
LMCROSSITXSADEPLOY-1423

