### PR TITLE
Add cache to space/{UUID}/developers calls

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/message/Messages.java
@@ -180,6 +180,7 @@ public final class Messages {
     public static final String PURGE_DELETE_REQUEST_SPACE_FROM_CONFIGURATION_TABLES = "All delete request spaces after date: {0} will be deleted from configuration tables.";
     public static final String RETRIEVED_USER_TOKEN = "Retrieved token for user: {0} with expiration time: {1}";
     public static final String FSS_CACHE_UPDATE_TIMEOUT = "Fss cache update timeout: {0} minutes";
+    public static final String SPACE_DEVELOPERS_CACHE_TIME_IN_SECONDS = "Cache for list of space developers per SpaceGUID: {0} seconds";
     public static final String APP_SHUTDOWN_REQUEST = "Application with id:\"{0}\", instance id:\"{1}\", instance index:\"{2}\", is requested to shutdown. Timeout to wait before shutdown of Flowable job executor:\"{3}\" seconds.";
     public static final String APP_SHUTDOWNED = "Application with id:\"{0}\", instance id:\"{1}\", instance index:\"{2}\", is shutdowned. Timeout to wait before shutdown of Flowable job executor:\"{3}\" seconds.";
     public static final String APP_SHUTDOWN_STATUS_MONITOR = "Monitor shutdown status of application with id:\"{0}\", instance id:\"{1}\", instance index:\"{2}\". Status:\"{3}\".";

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/model/CachedMap.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/model/CachedMap.java
@@ -1,0 +1,40 @@
+package com.sap.cloud.lm.sl.cf.core.model;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength;
+import org.apache.commons.collections4.map.ReferenceMap;
+
+public class CachedMap<K, V> {
+
+    private long expirationTimeInSeconds;
+    private Supplier<Long> currentTimeSupplier = System::currentTimeMillis;
+
+    private Map<K, CachedObject<V>> referenceMap = Collections
+        .synchronizedMap(new ReferenceMap<>(ReferenceStrength.HARD, ReferenceStrength.SOFT));
+
+    public CachedMap(long expirationTimeInSeconds) {
+        this.expirationTimeInSeconds = expirationTimeInSeconds;
+    }
+
+    public synchronized V get(K key, Supplier<V> refreshFunction) {
+        CachedObject<V> value = referenceMap.get(key);
+        if (value == null) {
+            value = new CachedObject<V>(expirationTimeInSeconds, currentTimeSupplier);
+            referenceMap.put(key, value);
+        }
+        return value.get(refreshFunction);
+    }
+
+    public synchronized V forceRefresh(K key, Supplier<V> refreshFunction) {
+        CachedObject<V> value = referenceMap.get(key);
+        if (value == null) {
+            value = new CachedObject<V>(expirationTimeInSeconds, currentTimeSupplier);
+            referenceMap.put(key, value);
+        }
+        return value.forceRefresh(refreshFunction);
+    }
+
+}

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/model/CachedObject.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/model/CachedObject.java
@@ -30,4 +30,10 @@ public class CachedObject<T> {
         return object;
     }
 
+    public synchronized T forceRefresh(Supplier<T> refreshFunction) {
+        lastRefreshTime = currentTimeSupplier.get();
+        object = refreshFunction.get();
+        return object;
+    }
+
 }

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfiguration.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfiguration.java
@@ -89,6 +89,7 @@ public class ApplicationConfiguration {
     static final String CFG_AUDIT_LOG_CLIENT_QUEUE_CAPACITY = "AUDIT_LOG_CLIENT_QUEUE_CAPACITY";
     static final String CFG_AUDIT_LOG_CLIENT_KEEP_ALIVE = "AUDIT_LOG_CLIENT_KEEP_ALIVE";
     static final String CFG_FSS_CACHE_UPDATE_TIMEOUT_MINUTES = "FSS_CACHE_UPDATE_TIMEOUT_MINUTES";
+    static final String CFG_SPACE_DEVELOPER_CACHE_TIME_IN_SECONDS = "SPACE_DEVELOPER_CACHE_TIME_IN_SECONDS";
 
     private static final List<String> VCAP_APPLICATION_URIS_KEYS = Arrays.asList("full_application_uris", "application_uris", "uris");
 
@@ -136,6 +137,7 @@ public class ApplicationConfiguration {
     public static final Integer DEFAULT_AUDIT_LOG_CLIENT_QUEUE_CAPACITY = 8;
     public static final Integer DEFAULT_AUDIT_LOG_CLIENT_KEEP_ALIVE = 60;
     public static final Integer DEFAULT_FSS_CACHE_UPDATE_TIMEOUT_MINUTES = 30;
+    public static final Integer DEFAULT_SPACE_DEVELOPER_CACHE_TIME_IN_SECONDS = 20;
 
     // Type names
     private static final Map<String, PlatformType> TYPE_NAMES = createTypeNames();
@@ -188,6 +190,7 @@ public class ApplicationConfiguration {
     private Integer auditLogClientQueueCapacity;
     private Integer auditLogClientKeepAlive;
     private Integer fssCacheUpdateTimeoutMinutes;
+    private Integer spaceDeveloperCacheTimeInSeconds;
 
     public ApplicationConfiguration() {
         this(new Environment());
@@ -545,6 +548,13 @@ public class ApplicationConfiguration {
             fssCacheUpdateTimeoutMinutes = getFssCacheUpdateTimeoutMinutesFromEnvironment();
         }
         return fssCacheUpdateTimeoutMinutes;
+    }
+
+    public Integer getSpaceDeveloperCacheExpirationInSeconds() {
+        if (spaceDeveloperCacheTimeInSeconds == null) {
+            spaceDeveloperCacheTimeInSeconds = getSpaceDeveloperCacheTimeInSecondsFromEnvironment();
+        }
+        return spaceDeveloperCacheTimeInSeconds;
     }
 
     private PlatformType getPlatformTypeFromEnvironment() {
@@ -917,6 +927,13 @@ public class ApplicationConfiguration {
     private Integer getFssCacheUpdateTimeoutMinutesFromEnvironment() {
         Integer value = environment.getPositiveInteger(CFG_FSS_CACHE_UPDATE_TIMEOUT_MINUTES, DEFAULT_FSS_CACHE_UPDATE_TIMEOUT_MINUTES);
         LOGGER.info(format(Messages.FSS_CACHE_UPDATE_TIMEOUT, value));
+        return value;
+    }
+
+    private Integer getSpaceDeveloperCacheTimeInSecondsFromEnvironment() {
+        Integer value = environment.getPositiveInteger(CFG_SPACE_DEVELOPER_CACHE_TIME_IN_SECONDS,
+            DEFAULT_SPACE_DEVELOPER_CACHE_TIME_IN_SECONDS);
+        LOGGER.info(format(Messages.SPACE_DEVELOPERS_CACHE_TIME_IN_SECONDS, value));
         return value;
     }
 

--- a/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/model/CachedObjectTest.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/model/CachedObjectTest.java
@@ -30,6 +30,25 @@ public class CachedObjectTest {
         assertEquals("b", cachedName.get(refreshFunction));
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testForceRefresh() {
+        Supplier<Long> currentTimeSupplier = Mockito.mock(Supplier.class);
+        Mockito.when(currentTimeSupplier.get())
+            .thenReturn(0L, toMillis(5), toMillis(10), toMillis(15), toMillis(25));
+
+        Supplier<String> refreshFunction = Mockito.mock(Supplier.class);
+        Mockito.when(refreshFunction.get())
+            .thenReturn("a", "b", "c");
+
+        CachedObject<String> cachedName = new CachedObject<>(20, currentTimeSupplier);
+
+        assertEquals("a", cachedName.get(refreshFunction));
+        assertEquals("a", cachedName.get(refreshFunction));
+        assertEquals("b", cachedName.forceRefresh(refreshFunction));
+        assertEquals("b", cachedName.get(refreshFunction));
+    }
+
     private Long toMillis(int seconds) {
         return TimeUnit.SECONDS.toMillis(seconds);
     }


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
This commit adds a cache that stores the result per spaceGuid for the list
of developers in the AuthenticationChecker to reduce the number of calls
done to the controller.

If the user is not found in the list of developers, the cache will be
force refreshed to get fresh data from the controller, regardless of
expiration time.

#### Issue:
LMCROSSITXSADEPLOY-1429