### PR TITLE
Revise task execution output

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollExecuteTaskStatusExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollExecuteTaskStatusExecution.java
@@ -74,7 +74,7 @@ public class PollExecuteTaskStatusExecution implements AsyncExecution {
 
         private void reportCurrentState(CloudTask.State currentState) {
             execution.getStepLogger()
-                .info(Messages.TASK_EXECUTION_STATUS, currentState.toString()
+                .debug(Messages.TASK_EXECUTION_STATUS, currentState.toString()
                     .toLowerCase());
         }
 


### PR DESCRIPTION
#### Description: 
When there is parallel processing of applications which have one-off tasks, the output will be mixture of "Task execution status:..." messages.
Moreover, this way is more consistent with the other output of out steps


#### Issue: https://sapjira.wdf.sap.corp/browse/LMCROSSITXSADEPLOY-1405

