### PR TITLE
fix process log sorting

### DIFF
--- a/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/query/providers/SqlFileQueryProvider.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/query/providers/SqlFileQueryProvider.java
@@ -372,7 +372,8 @@ public abstract class SqlFileQueryProvider {
         fileEntry.setNamespace(resultSet.getString(FileServiceColumnNames.NAMESPACE));
         fileEntry.setSize(getDataSourceDialect().getBigInteger(resultSet, FileServiceColumnNames.FILE_SIZE));
         fileEntry.setDigestAlgorithm(resultSet.getString(FileServiceColumnNames.DIGEST_ALGORITHM));
-        fileEntry.setModified(resultSet.getDate(FileServiceColumnNames.MODIFIED));
+        Timestamp modifiedAsTimestamp = resultSet.getTimestamp(FileServiceColumnNames.MODIFIED);
+        fileEntry.setModified(new Date(modifiedAsTimestamp.getTime()));
         return fileEntry;
     }
 

--- a/com.sap.cloud.lm.sl.cf.persistence/src/test/java/com/sap/cloud/lm/sl/cf/persistence/services/DatabaseFileServiceTest.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/test/java/com/sap/cloud/lm/sl/cf/persistence/services/DatabaseFileServiceTest.java
@@ -77,6 +77,16 @@ public class DatabaseFileServiceTest {
     }
 
     @Test
+    public void testCorrectFileEntryTimestamp() throws Exception {
+        FileEntry fileEntry = addTestFile(SPACE_1, NAMESPACE_1);
+        FileEntry fileEntryMetadata = fileService.getFile(SPACE_1, fileEntry.getId());
+        assertEquals(fileEntry.getModified()
+            .getTime(),
+            fileEntryMetadata.getModified()
+                .getTime());
+    }
+
+    @Test
     public void successfulUploadAndGetFileTest() throws Exception {
         String space = SPACE_1;
         String namespace = NAMESPACE_1;


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
Fix process log sorting by taking the modified column correctly. Previously we were taking java.sql.Date instead of java.util.Date, but the java.sql implementation actually extends the java.util one by trimming hours, minutes, seconds... This change should now take the proper timestamp from the database.

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
LMCROSSITXSADEPLOY-1462