### PR TITLE
make deploy fail if service can't be recreated

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/ServiceUpdater.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/clients/ServiceUpdater.java
@@ -42,7 +42,8 @@ public class ServiceUpdater extends CloudServiceOperator {
     }
 
     public MethodExecution<String> updateServicePlan(CloudControllerClient client, String serviceName, String servicePlan) {
-        return new CustomControllerClientErrorHandler().handleErrorsOrReturnResult(() -> attemptToUpdateServicePlan(client, serviceName, servicePlan));
+        return new CustomControllerClientErrorHandler()
+            .handleErrorsOrReturnResult(() -> attemptToUpdateServicePlan(client, serviceName, servicePlan));
     }
 
     public MethodExecution<String> updateServiceTagsQuietly(CloudControllerClient client, String serviceName, List<String> serviceTags) {
@@ -50,26 +51,33 @@ public class ServiceUpdater extends CloudServiceOperator {
     }
 
     public MethodExecution<String> updateServiceTags(CloudControllerClient client, String serviceName, List<String> serviceTags) {
-        return new CustomControllerClientErrorHandler().handleErrorsOrReturnResult(() -> attemptToUpdateServiceTags(client, serviceName, serviceTags));
+        return new CustomControllerClientErrorHandler()
+            .handleErrorsOrReturnResult(() -> attemptToUpdateServiceTags(client, serviceName, serviceTags));
     }
 
-    public MethodExecution<String> updateServiceParametersQuietly(CloudControllerClient client, String serviceName, Map<String, Object> parameters) {
+    public MethodExecution<String> updateServiceParametersQuietly(CloudControllerClient client, String serviceName,
+        Map<String, Object> parameters) {
         return ignoreBadGatewayErrors(() -> updateServiceParameters(client, serviceName, parameters));
     }
 
-    public MethodExecution<String> updateServiceParameters(CloudControllerClient client, String serviceName, Map<String, Object> parameters) {
-        return new CustomControllerClientErrorHandler().handleErrorsOrReturnResult(() -> attemptToUpdateServiceParameters(client, serviceName, parameters));
+    public MethodExecution<String> updateServiceParameters(CloudControllerClient client, String serviceName,
+        Map<String, Object> parameters) {
+        return new CustomControllerClientErrorHandler()
+            .handleErrorsOrReturnResult(() -> attemptToUpdateServiceParameters(client, serviceName, parameters));
     }
 
     private MethodExecution<String> attemptToUpdateServicePlan(CloudControllerClient client, String serviceName, String servicePlanName) {
         CloudService service = client.getService(serviceName);
         CloudServicePlan servicePlan = findPlanForService(client, service, servicePlanName);
-        String servicePlanGuid = servicePlan.getMeta().getGuid().toString();
-        return attemptToUpdateServiceParameter(client, serviceName, SERVICE_INSTANCES_URL, SERVICE_PLAN_GUID, servicePlanGuid);
+        String servicePlanGuid = servicePlan.getMeta()
+            .getGuid()
+            .toString();
+        return attemptToUpdateServiceParameter(client, service, SERVICE_INSTANCES_URL, SERVICE_PLAN_GUID, servicePlanGuid);
     }
 
     private MethodExecution<String> attemptToUpdateServiceTags(CloudControllerClient client, String serviceName, List<String> serviceTags) {
-        return attemptToUpdateServiceParameter(client, serviceName, SERVICE_INSTANCES_URL, SERVICE_TAGS, serviceTags);
+        CloudService service = client.getService(serviceName);
+        return attemptToUpdateServiceParameter(client, service, SERVICE_INSTANCES_URL, SERVICE_TAGS, serviceTags);
     }
 
     private String getCloudControllerUrl(CloudControllerClient client) {
@@ -77,23 +85,20 @@ public class ServiceUpdater extends CloudServiceOperator {
             .toString();
     }
 
-
-    private MethodExecution<String> attemptToUpdateServiceParameters(CloudControllerClient client, String serviceName, Map<String, Object> parameters) {
+    private MethodExecution<String> attemptToUpdateServiceParameters(CloudControllerClient client, String serviceName,
+        Map<String, Object> parameters) {
         assertServiceAttributes(serviceName, parameters);
         CloudService service = client.getService(serviceName);
 
         if (service.isUserProvided()) {
-            return attemptToUpdateServiceParameter(client, serviceName, USER_PROVIDED_SERVICE_INSTANCES_URL, SERVICE_CREDENTIALS, parameters);
+            return attemptToUpdateServiceParameter(client, service, USER_PROVIDED_SERVICE_INSTANCES_URL, SERVICE_CREDENTIALS, parameters);
         }
 
-        return attemptToUpdateServiceParameter(client, serviceName, SERVICE_INSTANCES_URL, SERVICE_PARAMETERS, parameters);
+        return attemptToUpdateServiceParameter(client, service, SERVICE_INSTANCES_URL, SERVICE_PARAMETERS, parameters);
     }
 
-    private MethodExecution<String> attemptToUpdateServiceParameter(CloudControllerClient client, String serviceName, String serviceUrl, String parameterName,
-        Object parameter) {
-
-        CloudService service = client.getService(serviceName);
-
+    private MethodExecution<String> attemptToUpdateServiceParameter(CloudControllerClient client, CloudService service, String serviceUrl,
+        String parameterName, Object parameter) {
         RestTemplate restTemplate = getRestTemplate(client);
         String cloudControllerUrl = getCloudControllerUrl(client);
         String updateServiceUrl = getUrl(cloudControllerUrl, getUpdateServiceUrl(serviceUrl, service.getMeta()

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -18,6 +18,7 @@ public class Messages {
     public static final String ERROR_MODULE_NOT_FOUND = "Module with name \"{0}\" not found";
     public static final String ERROR_DELETING_APP_TEMP_FILE = "Error deleting temp application file \"{0}\"";
     public static final String ERROR_RETRIEVING_MTA_RESOURCE_CONTENT = "Error retrieving content of MTA resource \"{0}\"";
+    public static final String ERROR_SERVICE_NEEDS_TO_BE_RECREATED_BUT_FLAG_NOT_SET = "Service described by MTA resource \"{0}\" does not match already existing service \"{1}\" of type [{2}] and needs to be recreated. Use command line option \"--delete-services\" to enable the deletion of the existing one.";
     public static final String MODULE_CONTENT_NA = "The content of MTA module \"{0}\" is not available";
     public static final String SIZE_OF_APP_EXCEEDS_MAX_SIZE_LIMIT = "The size of the application exceeds max size limit \"{0}\"";
     public static final String CF_ERROR = "Controller operation failed: {0}";
@@ -178,7 +179,7 @@ public class Messages {
     public static final String SKIP_SERVICES_DELETION = "Skipping deletion of services, because the command line option \"--delete-services\" is not specified.";
     public static final String UNSUPPORTED_MINOR_VERSION = "Used verion \"{0}\" is higher than the supported ones. Some features might not be implemented.";
     public static final String APPLICATION_NOT_STAGED_CORRECTLY = "Application \"{0}\" was not staged correctly during the previous deployment";
-    
+
     // INFO log messages
     public static final String MTA_NOT_FOUND = "An MTA with id \"{0}\" does not exist";
     public static final String ACQUIRING_LOCK = "Process \"{0}\" attempting to acquire lock for operation on MTA \"{1}\"";

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineServiceCreateUpdateServiceActionsStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineServiceCreateUpdateServiceActionsStepTest.java
@@ -2,6 +2,7 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 
 import static org.junit.Assert.assertEquals;
 
+import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -16,6 +17,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -28,6 +30,7 @@ import com.sap.cloud.lm.sl.cf.core.cf.clients.ServiceGetter;
 import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperation;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.analytics.model.ServiceAction;
+import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.common.util.JsonUtil;
 import com.sap.cloud.lm.sl.common.util.TestUtil;
 
@@ -43,7 +46,10 @@ public class DetermineServiceCreateUpdateServiceActionsStepTest
     @Rule
     public ErrorCollector collector = new ErrorCollector();
 
-    @Parameters(name="{0}")
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Parameters(name = "{0}")
     public static Iterable<Object[]> getParameters() {
         return Arrays.asList(new Object[][] {
 // @formatter:off
@@ -53,9 +59,9 @@ public class DetermineServiceCreateUpdateServiceActionsStepTest
             {
                 "determine-actions-create-or-update-services-step-input-2-no-action.json", null,
             },
-//            {
-//                "determine-actions-create-or-update-services-step-input-3-recreate-service.json", null,
-//            },
+            {
+                "determine-actions-create-or-update-services-step-input-3-recreate-service.json", null,
+            },
             {
                 "determine-actions-create-or-update-services-step-input-4-update-plan.json", null,
             },
@@ -68,9 +74,12 @@ public class DetermineServiceCreateUpdateServiceActionsStepTest
             {
                 "determine-actions-create-or-update-services-step-input-7-update-credentials.json", null,
             },
-//            {
-//                "determine-actions-create-or-update-services-step-input-8-recreate-service-failure.json", null,
-//            },
+//          {
+//          "determine-actions-create-or-update-services-step-input-8-recreate-service-failure.json", null,
+//          },
+            {
+                "determine-actions-create-or-update-services-step-input-9-recreate-service-error.json", MessageFormat.format(Messages.ERROR_SERVICE_NEEDS_TO_BE_RECREATED_BUT_FLAG_NOT_SET, "service-1", "service-1", "label-1-old/plan-3"),
+            },
          // @formatter:on
         });
     }
@@ -78,6 +87,9 @@ public class DetermineServiceCreateUpdateServiceActionsStepTest
     public DetermineServiceCreateUpdateServiceActionsStepTest(String stepInput, String expectedExceptionMessage) throws Exception {
         this.stepInput = JsonUtil
             .fromJson(TestUtil.getResourceAsString(stepInput, DetermineServiceCreateUpdateServiceActionsStepTest.class), StepInput.class);
+        if (expectedExceptionMessage != null) {
+            expectedException.expectMessage(expectedExceptionMessage);
+        }
     }
 
     @Before
@@ -97,7 +109,7 @@ public class DetermineServiceCreateUpdateServiceActionsStepTest
         StepsUtil.setServiceKeysToCreate(context, stepInput.getServiceKeysToCreate());
         context.setVariable(Constants.VAR_SERVICE_TO_PROCESS, JsonUtil.toJson(stepInput.service));
         context.setVariable(Constants.PARAM_DELETE_SERVICE_KEYS, true);
-        context.setVariable(Constants.PARAM_DELETE_SERVICES, true);
+        context.setVariable(Constants.PARAM_DELETE_SERVICES, stepInput.shouldDeleteServices);
     }
 
     @Test
@@ -158,6 +170,7 @@ public class DetermineServiceCreateUpdateServiceActionsStepTest
 
         // ServiceData - Expectation
         boolean shouldCreateService;
+        boolean shouldDeleteServices;
         boolean shouldRecreateService;
         boolean shouldUpdateServicePlan;
         boolean shouldUpdateServiceKeys;
@@ -194,7 +207,7 @@ public class DetermineServiceCreateUpdateServiceActionsStepTest
         }
 
         public Map<String, Object> getServiceInstanceEntity(CloudServiceExtendedForTest service) {
-            if(service == null) {
+            if (service == null) {
                 return null;
             }
             Map<String, Object> result = new HashMap<>();
@@ -206,7 +219,7 @@ public class DetermineServiceCreateUpdateServiceActionsStepTest
                     .toString());
                 result.put("last_operation", operation);
             }
-            if(service.getTags() != null) {
+            if (service.getTags() != null) {
                 result.put("tags", service.getTags());
             }
             return result;

--- a/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/determine-actions-create-or-update-services-step-input-9-recreate-service-error.json
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/determine-actions-create-or-update-services-step-input-9-recreate-service-error.json
@@ -13,5 +13,5 @@
 		"tags": []
 	},
 	"shouldRecreateService": true,
-	"shouldDeleteServices": true
+	"shouldDeleteServices": false
 }


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
This change fixes the issue where
DetermineServiceCreateUpdateServiceActionsStep incorrectly picks the
ServiceAction when the service would fit recreate criteria, but the
delete-services cmd option is not provided by the user.

An example of such case would be if the existing service has a label of
postresql and the new one is mondodb. Instead of failing the deployment
because the service can't be recreated into the new label the step
incorrectly determined that an update of plans could be possible.

This should also fix cases where the existing service is broken and is
missing label/plan.

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
Bug: NGPBUG-83966
