### PR TITLE
move create above recreate for determineActions

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
@@ -106,6 +106,14 @@ public class DetermineServiceCreateUpdateServiceActionsStep extends SyncFlowable
             actions.add(ServiceAction.UPDATE_KEYS);
         }
 
+        if (existingService == null) {
+            getStepLogger().debug("Service should be created");
+            getStepLogger().debug("New service: " + secureSerializer.toJson(service));
+            actions.add(ServiceAction.CREATE);
+            StepsUtil.setServicesToCreate(execution.getContext(), Arrays.asList(service));
+            return actions;
+        }
+
         Map<String, Object> serviceInstanceEntity = serviceInstanceGetter.getServiceInstanceEntity(client, service.getName(), spaceId);
         // Check if the existing service should be updated or not
         if (shouldRecreate(service, existingService, serviceInstanceEntity, execution)) {
@@ -114,14 +122,6 @@ public class DetermineServiceCreateUpdateServiceActionsStep extends SyncFlowable
             getStepLogger().debug("Existing service: " + secureSerializer.toJson(existingService));
             StepsUtil.setServicesToDelete(execution.getContext(), Arrays.asList(service.getName()));
             actions.add(ServiceAction.RECREATE);
-            return actions;
-        }
-
-        if (existingService == null) {
-            getStepLogger().debug("Service should be created");
-            getStepLogger().debug("New service: " + secureSerializer.toJson(service));
-            actions.add(ServiceAction.CREATE);
-            StepsUtil.setServicesToCreate(execution.getContext(), Arrays.asList(service));
             return actions;
         }
 


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
Fix the null pointer issue when a service doesn't exist but recreate
determineAction is first trying to evaluate recreate with a null
existingService.

