### PR TITLE
change FileStorage.addFile to use File

### DIFF
--- a/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/FileService.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/FileService.java
@@ -173,12 +173,8 @@ public class FileService {
     }
 
     protected void storeFile(FileEntry fileEntry, FileInfo fileInfo) throws FileStorageException {
-        try (InputStream fileStream = fileInfo.getInputStream()) {
-            fileStorage.addFile(fileEntry, fileStream);
-            storeFileAttributes(fileEntry);
-        } catch (IOException e) {
-            logger.debug(e.getMessage(), e);
-        }
+        fileStorage.addFile(fileEntry, fileInfo.getFile());
+        storeFileAttributes(fileEntry);
     }
 
     protected boolean deleteFileAttribute(final String space, final String id) throws FileStorageException {

--- a/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/FileStorage.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/FileStorage.java
@@ -1,6 +1,6 @@
 package com.sap.cloud.lm.sl.cf.persistence.services;
 
-import java.io.InputStream;
+import java.io.File;
 import java.util.Date;
 import java.util.List;
 
@@ -9,7 +9,7 @@ import com.sap.cloud.lm.sl.cf.persistence.processors.FileDownloadProcessor;
 
 public interface FileStorage {
 
-    void addFile(FileEntry fileEntry, InputStream fileStream) throws FileStorageException;
+    void addFile(FileEntry fileEntry, File file) throws FileStorageException;
 
     List<FileEntry> getFileEntriesWithoutContent(List<FileEntry> fileEntries) throws FileStorageException;
 

--- a/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/FileSystemFileStorage.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/FileSystemFileStorage.java
@@ -42,12 +42,12 @@ public class FileSystemFileStorage implements FileStorage {
     }
 
     @Override
-    public void addFile(FileEntry fileEntry, InputStream fileStream) throws FileStorageException {
+    public void addFile(FileEntry fileEntry, File file) throws FileStorageException {
         try {
             Path filesDirectory = getFilesDirectory(fileEntry.getSpace());
             Path newFilePath = Paths.get(filesDirectory.toString(), fileEntry.getId());
             logger.trace(MessageFormat.format(Messages.STORING_FILE_TO_PATH_0, newFilePath));
-            Files.copy(fileStream, newFilePath, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(Files.newInputStream(file.toPath()), newFilePath, StandardCopyOption.REPLACE_EXISTING);
             File newFile = newFilePath.toFile();
             if (!newFile.exists()) {
                 throw new FileStorageException(

--- a/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/ObjectStoreFileStorage.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/ObjectStoreFileStorage.java
@@ -1,5 +1,6 @@
 package com.sap.cloud.lm.sl.cf.persistence.services;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.MessageFormat;
@@ -43,15 +44,14 @@ public class ObjectStoreFileStorage implements FileStorage {
     }
 
     @Override
-    public void addFile(FileEntry fileEntry, InputStream fileStream) throws FileStorageException {
+    public void addFile(FileEntry fileEntry, File file) throws FileStorageException {
         String entryName = fileEntry.getId();
         long fileSize = fileEntry.getSize()
             .longValue();
         Blob blob = blobStore.blobBuilder(entryName)
-            .payload(fileStream)
+            .payload(file)
             .contentDisposition(fileEntry.getName())
             .contentType(MediaType.OCTET_STREAM.toString())
-            .contentLength(fileSize)
             .userMetadata(createFileEntryMetadata(fileEntry))
             .build();
         try {

--- a/com.sap.cloud.lm.sl.cf.persistence/src/test/java/com/sap/cloud/lm/sl/cf/persistence/services/FileServiceFileStorageTest.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/test/java/com/sap/cloud/lm/sl/cf/persistence/services/FileServiceFileStorageTest.java
@@ -186,7 +186,7 @@ public class FileServiceFileStorageTest {
         Path testFilePath = Paths.get(pathString)
             .toAbsolutePath();
         FileEntry fileEntry = createFileEntry(space, namespace);
-        fileStorage.addFile(fileEntry, Files.newInputStream(testFilePath));
+        fileStorage.addFile(fileEntry, testFilePath.toFile());
         return fileEntry;
     }
 

--- a/com.sap.cloud.lm.sl.cf.persistence/src/test/java/com/sap/cloud/lm/sl/cf/persistence/services/FileServiceTest.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/test/java/com/sap/cloud/lm/sl/cf/persistence/services/FileServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Date;
@@ -38,7 +39,7 @@ public class FileServiceTest extends DatabaseFileServiceTest {
     public void addFileUploadFileErrorTest() throws Exception {
         Mockito.doThrow(new FileStorageException("expected exception"))
             .when(fileStorage)
-            .addFile((FileEntry) Mockito.any(), (InputStream) Mockito.any());
+            .addFile((FileEntry) Mockito.any(), (File) Mockito.any());
 
         InputStream resourceStream = getResource(PIC_RESOURCE_NAME);
         String space = SPACE_1;
@@ -48,7 +49,7 @@ public class FileServiceTest extends DatabaseFileServiceTest {
             fail("addFile should fail with exception");
         } catch (FileStorageException e) {
             Mockito.verify(fileStorage, Mockito.times(1))
-                .addFile((FileEntry) Mockito.any(), (InputStream) Mockito.any());
+                .addFile((FileEntry) Mockito.any(), (File) Mockito.any());
             List<FileEntry> listFiles = fileService.listFiles(space, namespace);
             assertEquals(0, listFiles.size());
         }
@@ -144,7 +145,7 @@ public class FileServiceTest extends DatabaseFileServiceTest {
     protected FileEntry addFile(String space, String namespace, String fileName, String resourceName) throws Exception {
         FileEntry fileEntry = super.addFile(space, namespace, fileName, resourceName);
         Mockito.verify(fileStorage, Mockito.times(1))
-            .addFile(Mockito.eq(fileEntry), (InputStream) Mockito.any());
+            .addFile(Mockito.eq(fileEntry), (File) Mockito.any());
         return fileEntry;
     }
 
@@ -156,6 +157,6 @@ public class FileServiceTest extends DatabaseFileServiceTest {
     @Override
     protected void verifyFileIsStored(FileEntry fileEntry) throws Exception {
         Mockito.verify(fileStorage, Mockito.times(1))
-            .addFile(Mockito.eq(fileEntry), (InputStream) Mockito.any());
+            .addFile(Mockito.eq(fileEntry), (File) Mockito.any());
     }
 }

--- a/com.sap.cloud.lm.sl.cf.persistence/src/test/java/com/sap/cloud/lm/sl/cf/persistence/services/ObjectStoreFileStorageTest.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/test/java/com/sap/cloud/lm/sl/cf/persistence/services/ObjectStoreFileStorageTest.java
@@ -7,7 +7,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
@@ -228,7 +227,7 @@ public class ObjectStoreFileStorageTest {
             .toAbsolutePath();
         FileEntry fileEntry = createFileEntry(space, namespace);
         enrichFileEntry(fileEntry, testFilePath, date);
-        fileStorage.addFile(fileEntry, Files.newInputStream(testFilePath));
+        fileStorage.addFile(fileEntry, testFilePath.toFile());
         return fileEntry;
     }
 


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
This changes the FileStorage addFile interface method to take File instead
of InputStream. Previously if an addFile operation failed mid-way any
retry functionality would be impossible as the stream would not be
rewinded back to the start.

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
Bug: LMCROSSITXSADEPLOY-1488
