### PR TITLE
Looking in all service events for a delete event.

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceDeleteOperationsExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceDeleteOperationsExecution.java
@@ -2,6 +2,7 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.cloudfoundry.client.lib.CloudControllerClient;
@@ -43,13 +44,15 @@ public class PollServiceDeleteOperationsExecution extends PollServiceOperationsE
             return null;
         }
         boolean isServiceDeleted = isServiceDeleted(execution, service.getMeta()
-            .getGuid());
+                                                                      .getGuid());
         ServiceOperationState operationState = isServiceDeleted ? ServiceOperationState.SUCCEEDED : ServiceOperationState.IN_PROGRESS;
         return new ServiceOperation(ServiceOperationType.DELETE, ServiceOperationType.DELETE.name(), operationState);
     }
 
     private boolean isServiceDeleted(ExecutionWrapper execution, UUID uuid) {
-        CloudEvent serviceEvent = eventsGetter.getLastEvent(uuid, execution.getControllerClient());
-        return serviceEvent != null && eventsGetter.isDeleteEvent(serviceEvent.getType());
+        List<CloudEvent> serviceEvent = eventsGetter.getEvents(uuid, execution.getControllerClient());
+        return serviceEvent.stream()
+                    .filter(Objects::nonNull)
+                    .anyMatch(e -> eventsGetter.isDeleteEvent(e.getType()));
     }
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStepTest.java
@@ -120,10 +120,10 @@ public class DeleteServicesStepTest extends SyncFlowableStepTest<DeleteServicesS
         prepareClient();
     }
 
-    @Test 
+    @Test
     public void testExecute() throws Exception {
         if (StepsUtil.getServicesToDelete(context)
-            .isEmpty()) {
+                     .isEmpty()) {
             return;
         }
         prepareResponses(STEP_EXECUTION);
@@ -148,8 +148,8 @@ public class DeleteServicesStepTest extends SyncFlowableStepTest<DeleteServicesS
 
     private void loadParameters() {
         servicesToDelete = stepInput.servicesToDelete.stream()
-            .map((service) -> service.name)
-            .collect(Collectors.toList());
+                                                     .map((service) -> service.name)
+                                                     .collect(Collectors.toList());
         servicesData = stepInput.servicesToDelete.stream()
             .collect(Collectors.toMap(e -> e.name, e -> new CloudServiceExtended(new Meta(UUID.fromString(e.guid), null, null), e.name)));
 
@@ -171,24 +171,24 @@ public class DeleteServicesStepTest extends SyncFlowableStepTest<DeleteServicesS
     private void prepareClient() {
         for (SimpleService service : stepInput.servicesToDelete) {
             Mockito.when(client.getService(Matchers.eq(service.name), Matchers.anyBoolean()))
-                .thenReturn(createCloudService(service));
+                   .thenReturn(createCloudService(service));
             Mockito.when(client.getService(service.name))
-                .thenReturn(createCloudService(service));
+                   .thenReturn(createCloudService(service));
             Mockito.when(client.getServiceInstance(service.name))
-                .thenReturn(createServiceInstance(service));
+                   .thenReturn(createServiceInstance(service));
             if (service.hasBoundApplications) {
                 Mockito.when(client.getApplications())
-                    .thenReturn(Arrays.asList(new CloudApplication(meta, null)));
+                       .thenReturn(Arrays.asList(new CloudApplication(meta, null)));
             }
             if (service.hasServiceKeys) {
                 Mockito.when(client.getServiceKeys(service.name))
-                    .thenReturn(Arrays.asList(new ServiceKey(meta, null)));
+                       .thenReturn(Arrays.asList(new ServiceKey(meta, null)));
             }
             if (service.httpErrorCodeToReturnOnDelete != null) {
                 HttpStatus httpStatusToReturnOnDelete = HttpStatus.valueOf(service.httpErrorCodeToReturnOnDelete);
                 Mockito.doThrow(new CloudOperationException(httpStatusToReturnOnDelete))
-                    .when(client)
-                    .deleteService(service.name);
+                       .when(client)
+                       .deleteService(service.name);
             }
         }
     }
@@ -210,23 +210,24 @@ public class DeleteServicesStepTest extends SyncFlowableStepTest<DeleteServicesS
         Mockito.reset(eventsGetter);
         Map<String, Map<String, Boolean>> eventsResponse = (Map<String, Map<String, Boolean>>) stepPhaseResponse.get("eventsResponse");
         stepInput.servicesToDelete.stream()
-            .filter(service -> eventsResponse.get(service.name)
-                .containsKey("containsDeleteEvent"))
-            .filter(service -> eventsResponse.get(service.name)
-                .get("containsDeleteEvent")
-                .equals(true))
-            .forEach(service -> {
-                CloudEvent deleteEvent = createDeleteServiceCloudEvent(service);
-                List<CloudEvent> events = createOlderServiceCloudEvents(deleteEvent, 5);
-                events.add(deleteEvent);
-
-                Mockito.when(eventsGetter.getEvents(UUID.fromString(service.guid), client))
-                    .thenReturn(events);
-                Mockito.when(eventsGetter.getLastEvent(UUID.fromString(service.guid), client))
-                    .thenReturn(deleteEvent);
-            });
+                                  .filter(service -> eventsResponse.get(service.name)
+                                                                   .containsKey("containsDeleteEvent"))
+                                  .filter(service -> eventsResponse.get(service.name)
+                                                                   .get("containsDeleteEvent")
+                                                                   .equals(true))
+                                  .forEach(service -> {
+                                      CloudEvent deleteEvent = createDeleteServiceCloudEvent(service);
+                                      List<CloudEvent> events = createOlderServiceCloudEvents(deleteEvent, 5);
+                                      events.add(deleteEvent);
+                                      Collections.shuffle(events);
+                                      
+                                      Mockito.when(eventsGetter.getEvents(UUID.fromString(service.guid), client))
+                                             .thenReturn(events);
+                                      Mockito.when(eventsGetter.getLastEvent(UUID.fromString(service.guid), client))
+                                             .thenReturn(deleteEvent);
+                                  });
         Mockito.when(eventsGetter.isDeleteEvent(SERVICE_EVENT_TYPE_DELETE))
-            .thenCallRealMethod();
+               .thenCallRealMethod();
     }
 
     private CloudServiceInstance createServiceInstance(SimpleService service) {
@@ -279,11 +280,11 @@ public class DeleteServicesStepTest extends SyncFlowableStepTest<DeleteServicesS
     private Date getOlderDateFromEvent(CloudEvent lastEvent) {
         ZoneId systemDefaultZone = ZoneId.systemDefault();
         Instant lastEventInstant = lastEvent.getTimestamp()
-            .toInstant();
+                                            .toInstant();
         LocalDateTime lastEventDateTime = LocalDateTime.ofInstant(lastEventInstant, systemDefaultZone);
         LocalDateTime secondBefore = lastEventDateTime.minusSeconds(1);
         Instant secondBeforeInstant = secondBefore.atZone(systemDefaultZone)
-            .toInstant();
+                                                  .toInstant();
         return Date.from(secondBeforeInstant);
     }
 
@@ -291,7 +292,7 @@ public class DeleteServicesStepTest extends SyncFlowableStepTest<DeleteServicesS
         for (SimpleService service : stepInput.servicesToDelete) {
             if (!service.hasBoundApplications) {
                 Mockito.verify(client, Mockito.times(1))
-                    .deleteService(service.name);
+                       .deleteService(service.name);
             }
         }
     }
@@ -300,7 +301,7 @@ public class DeleteServicesStepTest extends SyncFlowableStepTest<DeleteServicesS
         for (SimpleService service : stepInput.servicesToDelete) {
             if (service.hasBoundApplications) {
                 Mockito.verify(client, Mockito.atLeastOnce())
-                    .unbindService(Mockito.anyString(), Mockito.eq(service.name));
+                       .unbindService(Mockito.anyString(), Mockito.eq(service.name));
             }
         }
     }
@@ -309,7 +310,7 @@ public class DeleteServicesStepTest extends SyncFlowableStepTest<DeleteServicesS
         for (SimpleService service : stepInput.servicesToDelete) {
             if (service.hasServiceKeys) {
                 Mockito.verify(client, Mockito.atLeastOnce())
-                    .deleteServiceKey(Mockito.eq(service.name), Mockito.anyString());
+                       .deleteServiceKey(Mockito.eq(service.name), Mockito.anyString());
             }
         }
     }


### PR DESCRIPTION
Before, the service deletion was acknowledged by looking at the last service event. Because multiple unordered events can occur in the same moment, we are now looking in all service instance events and searching for a deletion.