### PR TITLE
Remove warnings for unsupported module parameters

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/v2/ApplicationCloudModelBuilder.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/v2/ApplicationCloudModelBuilder.java
@@ -1,7 +1,6 @@
 package com.sap.cloud.lm.sl.cf.core.cf.v2;
 
 import static com.sap.cloud.lm.sl.mta.util.PropertiesUtil.getPropertyValue;
-import static com.sap.cloud.lm.sl.mta.util.PropertiesUtil.mergeProperties;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -14,8 +13,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.cloudfoundry.client.lib.domain.CloudTask;
 import org.cloudfoundry.client.lib.domain.DockerInfo;
 import org.cloudfoundry.client.lib.domain.Staging;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudApplicationExtended;
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudApplicationExtended.AttributeUpdateStrategy;
@@ -24,7 +21,6 @@ import com.sap.cloud.lm.sl.cf.client.lib.domain.ServiceKeyToInject;
 import com.sap.cloud.lm.sl.cf.core.cf.DeploymentMode;
 import com.sap.cloud.lm.sl.cf.core.cf.HandlerFactory;
 import com.sap.cloud.lm.sl.cf.core.helpers.ModuleToDeployHelper;
-import com.sap.cloud.lm.sl.cf.core.message.Messages;
 import com.sap.cloud.lm.sl.cf.core.model.DeployedMta;
 import com.sap.cloud.lm.sl.cf.core.model.DeployedMtaModule;
 import com.sap.cloud.lm.sl.cf.core.model.SupportedParameters;
@@ -54,8 +50,6 @@ public class ApplicationCloudModelBuilder {
 
     public static final String DEPENDENCY_TYPE_SOFT = "soft";
     public static final String DEPENDENCY_TYPE_HARD = "hard";
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationCloudModelBuilder.class);
 
     private static final int MTA_MAJOR_VERSION = 2;
 
@@ -97,7 +91,6 @@ public class ApplicationCloudModelBuilder {
 
     protected CloudApplicationExtended getApplication(Module module) {
         List<Map<String, Object>> parametersList = parametersChainBuilder.buildModuleChain(module.getName());
-        warnAboutUnsupportedParameters(parametersList);
         Staging staging = parseParameters(parametersList, new StagingParametersParser());
         int diskQuota = parseParameters(parametersList, new MemoryParametersParser(SupportedParameters.DISK_QUOTA, "0"));
         int memory = parseParameters(parametersList, new MemoryParametersParser(SupportedParameters.MEMORY, "0"));
@@ -203,17 +196,6 @@ public class ApplicationCloudModelBuilder {
         app.setTasks(tasks);
         app.setDockerInfo(dockerInfo);
         return app;
-    }
-
-    protected void warnAboutUnsupportedParameters(List<Map<String, Object>> fullParametersList) {
-        Map<String, Object> merged = mergeProperties(fullParametersList);
-        applicationEnvCloudModelBuilder.removeSpecialApplicationProperties(merged);
-        applicationEnvCloudModelBuilder.removeSpecialServiceProperties(merged);
-        for (String parameterName : merged.keySet()) {
-            String warningMessage = MessageFormat.format(Messages.UNSUPPORTED_PARAMETER, parameterName);
-            stepLogger.warnWithoutProgressMessage(warningMessage);
-            LOGGER.debug(warningMessage);
-        }
     }
 
     protected Map<String, Map<String, Object>> getBindingParameters(Module module) {

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/v2/ApplicationEnvironmentCloudModelBuilder.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/v2/ApplicationEnvironmentCloudModelBuilder.java
@@ -141,22 +141,4 @@ public class ApplicationEnvironmentCloudModelBuilder {
         return new HandlerFactory(MTA_MAJOR_VERSION);
     }
 
-    public Map<String, Object> removeSpecialApplicationProperties(Map<String, Object> properties) {
-        properties.keySet()
-            .removeAll(SupportedParameters.APP_ATTRIBUTES);
-        properties.keySet()
-            .removeAll(SupportedParameters.APP_PROPS);
-        properties.keySet()
-            .removeAll(SupportedParameters.SPECIAL_MT_PROPS);
-        return properties;
-    }
-
-    public Map<String, Object> removeSpecialServiceProperties(Map<String, Object> properties) {
-        properties.keySet()
-            .removeAll(SupportedParameters.SPECIAL_RT_PROPS);
-        properties.keySet()
-            .removeAll(SupportedParameters.SERVICE_PROPS);
-        return properties;
-    }
-
 }

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/message/Messages.java
@@ -100,7 +100,6 @@ public final class Messages {
 
     public static final String INVALID_VCAP_APPLICATION = "Invalid VCAP_APPLICATION \"{0}\"";
     public static final String COULD_NOT_PARSE_ROUTER_PORT_0_USING_DEFAULT_1 = "Could not parse router port \"{0}\", using default \"{1}\"";
-    public static final String UNSUPPORTED_PARAMETER = "Parameter \"{0}\" is not supported, it will be ignored";
     public static final String IGNORING_LABEL_FOR_USER_PROVIDED_SERVICE = "Ignoring label \"{0}\" for service \"{1}\", as user-provided services do not support labels!";
     public static final String COULD_NOT_ROLLBACK_TRANSACTION = "Could not rollback transaction!";
     public static final String NOT_DESCRIBED_MODULE = "MTA module \"{0}\" is found deployed, but it is not part of MTA manifest file";

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/model/SupportedParameters.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/model/SupportedParameters.java
@@ -89,8 +89,6 @@ public class SupportedParameters {
     public static final String SERVICE_BROKER_URL = "service-broker-url";
     public static final String SERVICE_BROKER_SPACE_SCOPED = "service-broker-space-scoped";
 
-    public static final String DEFAULT_RT = "default-resource-type";
-
     // Required dependency parameters:
     public static final String SERVICE_BINDING_CONFIG = "config";
     public static final String SERVICE_BINDING_CONFIG_PATH = "config-path";
@@ -136,24 +134,10 @@ public class SupportedParameters {
     public static final Set<String> CONFIGURATION_REFERENCE_PARAMETERS = Collections.unmodifiableSet(
         new HashSet<>(Arrays.asList(PROVIDER_NID, PROVIDER_ID, TARGET, VERSION, MTA_ID, MTA_VERSION, MTA_PROVIDES_DEPENDENCY)));
 
-    public static final Set<String> APP_PROPS = Collections
-        .unmodifiableSet(new HashSet<>(Arrays.asList(APP_NAME, HOST, HOSTS, DOMAIN, DOMAINS, COMMAND, BUILDPACK, HEALTH_CHECK_TYPE,
-            HEALTH_CHECK_HTTP_ENDPOINT, ENABLE_SSH, STACK, HEALTH_CHECK_TIMEOUT, IDLE_HOST, MEMORY, INSTANCES, NO_HOSTNAME, NO_ROUTE,
-            IDLE_DOMAIN, DISK_QUOTA, IDLE_DOMAINS, IDLE_HOSTS, TASKS, RESTART_ON_ENV_CHANGE, VCAP_APPLICATION_ENV, VCAP_SERVICES_ENV,
-            USER_PROVIDED_ENV, KEEP_EXISTING_ROUTES, KEEP_EXISTING_APPLICATION_ATTRIBUTES_UPDATE_STRATEGY)));
-
-    public static final Set<String> SERVICE_PROPS = Collections
-        .unmodifiableSet(new HashSet<>(Arrays.asList(SERVICE_NAME, SERVICE, SERVICE_PLAN, SERVICE_ALTERNATIVES, SERVICE_PROVIDER,
-            SERVICE_VERSION, SERVICE_CONFIG, SERVICE_CONFIG_PATH, SERVICE_TAGS, SERVICE_KEY_NAME)));
-
     public static final Set<String> APP_ATTRIBUTES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EXECUTE_APP, SUCCESS_MARKER,
         FAILURE_MARKER, STOP_APP, CHECK_DEPLOY_ID, REGISTER_SERVICE_URL, REGISTER_SERVICE_URL_SERVICE_NAME,
         REGISTER_SERVICE_URL_SERVICE_URL, CREATE_SERVICE_BROKER, SERVICE_BROKER_NAME, SERVICE_BROKER_USERNAME, SERVICE_BROKER_PASSWORD,
         SERVICE_BROKER_URL, SERVICE_BROKER_SPACE_SCOPED, DEPENDENCY_TYPE, NO_START, UPLOAD_TIMEOUT)));
-
-    public static final Set<String> SPECIAL_MT_PROPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DEFAULT_RT)));
-
-    public static final Set<String> SPECIAL_RT_PROPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(TYPE)));
 
     public static final Map<String, String> SINGULAR_PLURAL_MAPPING;
 


### PR DESCRIPTION

#### Description: 
The warnings are misleading because these parameters are not defined in MTA deployment descriptor but are internally coming from Deploy Service.
Also it is possible to define custom parameters, that are used during deployment as a reference from other parameters.


#### Issue: Jira: LMCROSSITXSADEPLOY-1542

