### PR TITLE
Remove duplicate error messages

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/AddDomainsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/AddDomainsStep.java
@@ -3,16 +3,15 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.cloudfoundry.client.lib.CloudControllerClient;
 import org.cloudfoundry.client.lib.CloudControllerException;
 import org.cloudfoundry.client.lib.CloudOperationException;
-import org.cloudfoundry.client.lib.CloudControllerClient;
 import org.cloudfoundry.client.lib.domain.CloudDomain;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("addDomainsStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -40,12 +39,7 @@ public class AddDomainsStep extends SyncFlowableStep {
             getStepLogger().debug(Messages.DOMAINS_ADDED);
             return StepPhase.DONE;
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_ADDING_DOMAINS);
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_ADDING_DOMAINS);
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BlueGreenRenameStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BlueGreenRenameStep.java
@@ -13,7 +13,6 @@ import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.helpers.ApplicationColorDetector;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.common.ConflictException;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
 
 @Named("blueGreenRenameStep")
@@ -28,45 +27,39 @@ public class BlueGreenRenameStep extends SyncFlowableStep {
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
 
+        getStepLogger().debug(Messages.DETECTING_COLOR_OF_DEPLOYED_MTA);
+
+        DeploymentDescriptor descriptor = StepsUtil.getDeploymentDescriptor(execution.getContext());
+        DeployedMta deployedMta = StepsUtil.getDeployedMta(execution.getContext());
+        ApplicationColor mtaColor;
+        ApplicationColor deployedMtaColor = null;
         try {
-            getStepLogger().debug(Messages.DETECTING_COLOR_OF_DEPLOYED_MTA);
-
-            DeploymentDescriptor descriptor = StepsUtil.getDeploymentDescriptor(execution.getContext());
-            DeployedMta deployedMta = StepsUtil.getDeployedMta(execution.getContext());
-            ApplicationColor mtaColor;
-            ApplicationColor deployedMtaColor = null;
-            try {
-                deployedMtaColor = applicationColorDetector.detectSingularDeployedApplicationColor(deployedMta);
-                if (deployedMtaColor != null) {
-                    getStepLogger().info(Messages.DEPLOYED_MTA_COLOR, deployedMtaColor);
-                    mtaColor = deployedMtaColor.getAlternativeColor();
-                } else {
-                    mtaColor = DEFAULT_MTA_COLOR;
-                }
-            } catch (ConflictException e) {
-                getStepLogger().warn(e.getMessage());
-
-                ApplicationColor liveMtaColor = applicationColorDetector.detectLiveApplicationColor(deployedMta,
-                    (String) execution.getContext()
-                        .getVariable(Constants.VAR_CORRELATION_ID));
-                ApplicationColor idleMtaColor = liveMtaColor.getAlternativeColor();
-
-                getStepLogger().info(Messages.ASSUMED_LIVE_AND_IDLE_COLORS, liveMtaColor, idleMtaColor);
-                mtaColor = idleMtaColor;
+            deployedMtaColor = applicationColorDetector.detectSingularDeployedApplicationColor(deployedMta);
+            if (deployedMtaColor != null) {
+                getStepLogger().info(Messages.DEPLOYED_MTA_COLOR, deployedMtaColor);
+                mtaColor = deployedMtaColor.getAlternativeColor();
+            } else {
+                mtaColor = DEFAULT_MTA_COLOR;
             }
+        } catch (ConflictException e) {
+            getStepLogger().warn(e.getMessage());
 
-            StepsUtil.setDeployedMtaColor(execution.getContext(), deployedMtaColor);
-            StepsUtil.setMtaColor(execution.getContext(), mtaColor);
+            ApplicationColor liveMtaColor = applicationColorDetector.detectLiveApplicationColor(deployedMta, (String) execution.getContext()
+                .getVariable(Constants.VAR_CORRELATION_ID));
+            ApplicationColor idleMtaColor = liveMtaColor.getAlternativeColor();
 
-            getStepLogger().info(Messages.NEW_MTA_COLOR, mtaColor);
-
-            visit(execution, descriptor, mtaColor, deployedMtaColor);
-
-            return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_RENAMING_MODULES);
-            throw e;
+            getStepLogger().info(Messages.ASSUMED_LIVE_AND_IDLE_COLORS, liveMtaColor, idleMtaColor);
+            mtaColor = idleMtaColor;
         }
+
+        StepsUtil.setDeployedMtaColor(execution.getContext(), deployedMtaColor);
+        StepsUtil.setMtaColor(execution.getContext(), mtaColor);
+
+        getStepLogger().info(Messages.NEW_MTA_COLOR, mtaColor);
+
+        visit(execution, descriptor, mtaColor, deployedMtaColor);
+
+        return StepPhase.DONE;
     }
 
     protected void visit(ExecutionWrapper execution, DeploymentDescriptor descriptor, ApplicationColor mtaColor,

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BuildApplicationDeployModelStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BuildApplicationDeployModelStep.java
@@ -16,7 +16,6 @@ import com.sap.cloud.lm.sl.cf.core.helpers.ModuleToDeployHelper;
 import com.sap.cloud.lm.sl.cf.core.model.ConfigurationEntry;
 import com.sap.cloud.lm.sl.cf.core.security.serialization.SecureSerializationFacade;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.common.util.JsonUtil;
 import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
 import com.sap.cloud.lm.sl.mta.model.Module;
@@ -28,32 +27,27 @@ public class BuildApplicationDeployModelStep extends SyncFlowableStep {
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) throws Exception {
-        try {
-            Module module = StepsUtil.getModuleToDeploy(execution.getContext());
-            getStepLogger().debug(Messages.BUILDING_CLOUD_APP_MODEL, module.getName());
+        Module module = StepsUtil.getModuleToDeploy(execution.getContext());
+        getStepLogger().debug(Messages.BUILDING_CLOUD_APP_MODEL, module.getName());
 
-            Module applicationModule = StepsUtil.findModuleInDeploymentDescriptor(execution.getContext(), module.getName());
-            StepsUtil.setModuleToDeploy(execution.getContext(), applicationModule);
-            CloudApplicationExtended modifiedApp = getApplicationCloudModelBuilder(execution.getContext()).build(applicationModule,
-                moduleToDeployHelper);
-            modifiedApp = ImmutableCloudApplicationExtended.builder()
-                .from(modifiedApp)
-                .env(getApplicationEnv(execution.getContext(), modifiedApp))
-                .uris(getApplicationUris(execution.getContext(), modifiedApp))
-                .build();
-            SecureSerializationFacade secureSerializationFacade = new SecureSerializationFacade();
-            String appJson = secureSerializationFacade.toJson(modifiedApp);
-            getStepLogger().debug(Messages.APP_WITH_UPDATED_ENVIRONMENT, appJson);
-            StepsUtil.setApp(execution.getContext(), modifiedApp);
+        Module applicationModule = StepsUtil.findModuleInDeploymentDescriptor(execution.getContext(), module.getName());
+        StepsUtil.setModuleToDeploy(execution.getContext(), applicationModule);
+        CloudApplicationExtended modifiedApp = getApplicationCloudModelBuilder(execution.getContext()).build(applicationModule,
+            moduleToDeployHelper);
+        modifiedApp = ImmutableCloudApplicationExtended.builder()
+            .from(modifiedApp)
+            .env(getApplicationEnv(execution.getContext(), modifiedApp))
+            .uris(getApplicationUris(execution.getContext(), modifiedApp))
+            .build();
+        SecureSerializationFacade secureSerializationFacade = new SecureSerializationFacade();
+        String appJson = secureSerializationFacade.toJson(modifiedApp);
+        getStepLogger().debug(Messages.APP_WITH_UPDATED_ENVIRONMENT, appJson);
+        StepsUtil.setApp(execution.getContext(), modifiedApp);
 
-            buildConfigurationEntries(execution.getContext(), modifiedApp);
-            StepsUtil.setTasksToExecute(execution.getContext(), modifiedApp.getTasks());
+        buildConfigurationEntries(execution.getContext(), modifiedApp);
+        StepsUtil.setTasksToExecute(execution.getContext(), modifiedApp.getTasks());
 
-            getStepLogger().debug(Messages.CLOUD_APP_MODEL_BUILT);
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_BUILDING_CLOUD_APP_MODEL);
-            throw e;
-        }
+        getStepLogger().debug(Messages.CLOUD_APP_MODEL_BUILT);
         return StepPhase.DONE;
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BuildCloudUndeployModelStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BuildCloudUndeployModelStep.java
@@ -41,50 +41,44 @@ public class BuildCloudUndeployModelStep extends SyncFlowableStep {
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
         getStepLogger().debug(Messages.BUILDING_CLOUD_UNDEPLOY_MODEL);
-        try {
-            DeployedMta deployedMta = StepsUtil.getDeployedMta(execution.getContext());
+        DeployedMta deployedMta = StepsUtil.getDeployedMta(execution.getContext());
 
-            List<String> deploymentDescriptorModules = getDeploymentDescriptorModules(execution.getContext());
+        List<String> deploymentDescriptorModules = getDeploymentDescriptorModules(execution.getContext());
 
-            if (deployedMta == null) {
-                setComponentsToUndeploy(execution.getContext(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-                return StepPhase.DONE;
-            }
-
-            List<ConfigurationSubscription> subscriptionsToCreate = StepsUtil.getSubscriptionsToCreate(execution.getContext());
-            Set<String> mtaModules = StepsUtil.getMtaModules(execution.getContext());
-            List<String> appNames = StepsUtil.getAppsToDeploy(execution.getContext());
-            List<CloudApplication> deployedApps = StepsUtil.getDeployedApps(execution.getContext());
-
-            getStepLogger().debug(Messages.MTA_MODULES, mtaModules);
-
-            List<DeployedMtaModule> modulesToUndeploy = computeModulesToUndeploy(deployedMta, mtaModules, appNames,
-                deploymentDescriptorModules);
-            getStepLogger().debug(Messages.MODULES_TO_UNDEPLOY, secureSerializer.toJson(modulesToUndeploy));
-
-            List<DeployedMtaModule> modulesWithoutChange = computeModulesWithoutChange(modulesToUndeploy, mtaModules, deployedMta);
-            getStepLogger().debug(Messages.MODULES_NOT_TO_BE_CHANGED, secureSerializer.toJson(modulesWithoutChange));
-
-            List<ConfigurationSubscription> subscriptionsToDelete = computeSubscriptionsToDelete(subscriptionsToCreate, deployedMta,
-                StepsUtil.getSpaceId(execution.getContext()));
-            getStepLogger().debug(Messages.SUBSCRIPTIONS_TO_DELETE, secureSerializer.toJson(subscriptionsToDelete));
-
-            Set<String> servicesForApplications = getServicesForApplications(execution.getContext());
-            List<String> servicesToDelete = computeServicesToDelete(modulesWithoutChange, deployedMta.getServices(),
-                servicesForApplications);
-            getStepLogger().debug(Messages.SERVICES_TO_DELETE, servicesToDelete);
-
-            List<CloudApplication> appsToUndeploy = computeAppsToUndeploy(modulesToUndeploy, deployedApps);
-            getStepLogger().debug(Messages.APPS_TO_UNDEPLOY, secureSerializer.toJson(appsToUndeploy));
-
-            setComponentsToUndeploy(execution.getContext(), servicesToDelete, appsToUndeploy, subscriptionsToDelete);
-
-            getStepLogger().debug(Messages.CLOUD_UNDEPLOY_MODEL_BUILT);
+        if (deployedMta == null) {
+            setComponentsToUndeploy(execution.getContext(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
             return StepPhase.DONE;
-        } catch (Exception e) {
-            getStepLogger().error(e, Messages.ERROR_BUILDING_CLOUD_UNDEPLOY_MODEL);
-            throw e;
         }
+
+        List<ConfigurationSubscription> subscriptionsToCreate = StepsUtil.getSubscriptionsToCreate(execution.getContext());
+        Set<String> mtaModules = StepsUtil.getMtaModules(execution.getContext());
+        List<String> appNames = StepsUtil.getAppsToDeploy(execution.getContext());
+        List<CloudApplication> deployedApps = StepsUtil.getDeployedApps(execution.getContext());
+
+        getStepLogger().debug(Messages.MTA_MODULES, mtaModules);
+
+        List<DeployedMtaModule> modulesToUndeploy = computeModulesToUndeploy(deployedMta, mtaModules, appNames,
+            deploymentDescriptorModules);
+        getStepLogger().debug(Messages.MODULES_TO_UNDEPLOY, secureSerializer.toJson(modulesToUndeploy));
+
+        List<DeployedMtaModule> modulesWithoutChange = computeModulesWithoutChange(modulesToUndeploy, mtaModules, deployedMta);
+        getStepLogger().debug(Messages.MODULES_NOT_TO_BE_CHANGED, secureSerializer.toJson(modulesWithoutChange));
+
+        List<ConfigurationSubscription> subscriptionsToDelete = computeSubscriptionsToDelete(subscriptionsToCreate, deployedMta,
+            StepsUtil.getSpaceId(execution.getContext()));
+        getStepLogger().debug(Messages.SUBSCRIPTIONS_TO_DELETE, secureSerializer.toJson(subscriptionsToDelete));
+
+        Set<String> servicesForApplications = getServicesForApplications(execution.getContext());
+        List<String> servicesToDelete = computeServicesToDelete(modulesWithoutChange, deployedMta.getServices(), servicesForApplications);
+        getStepLogger().debug(Messages.SERVICES_TO_DELETE, servicesToDelete);
+
+        List<CloudApplication> appsToUndeploy = computeAppsToUndeploy(modulesToUndeploy, deployedApps);
+        getStepLogger().debug(Messages.APPS_TO_UNDEPLOY, secureSerializer.toJson(appsToUndeploy));
+
+        setComponentsToUndeploy(execution.getContext(), servicesToDelete, appsToUndeploy, subscriptionsToDelete);
+
+        getStepLogger().debug(Messages.CLOUD_UNDEPLOY_MODEL_BUILT);
+        return StepPhase.DONE;
     }
 
     private List<String> getDeploymentDescriptorModules(DelegateExecution context) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CheckForCreationConflictsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CheckForCreationConflictsStep.java
@@ -59,12 +59,7 @@ public class CheckForCreationConflictsStep extends SyncFlowableStep {
             validateApplicationsToDeploy(execution.getContext(), deployedMta, deployedApps);
             getStepLogger().debug(Messages.APPLICATIONS_VALIDATED);
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_VALIDATING_APPLICATIONS);
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_VALIDATING_APPLICATIONS);
-            throw e;
+            throw new CloudControllerException(coe);
         }
 
         return StepPhase.DONE;

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CollectSystemParametersStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CollectSystemParametersStep.java
@@ -25,7 +25,6 @@ import com.sap.cloud.lm.sl.cf.core.util.ApplicationConfiguration;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.common.ContentException;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
 import com.sap.cloud.lm.sl.mta.model.DeploymentType;
 import com.sap.cloud.lm.sl.mta.model.Version;
@@ -66,12 +65,7 @@ public class CollectSystemParametersStep extends SyncFlowableStep {
 
             StepsUtil.setDeploymentDescriptorWithSystemParameters(execution.getContext(), descriptor);
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_COLLECTING_SYSTEM_PARAMETERS);
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_COLLECTING_SYSTEM_PARAMETERS);
-            throw e;
+            throw new CloudControllerException(coe);
         }
         getStepLogger().debug(Messages.SYSTEM_PARAMETERS_COLLECTED);
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
@@ -88,12 +88,7 @@ public class CreateOrUpdateAppStep extends SyncFlowableStep {
 
             return StepPhase.DONE;
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_CREATING_OR_UPDATING_APP, app.getName());
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_CREATING_OR_UPDATING_APP, app.getName());
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateServiceBrokerStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateServiceBrokerStep.java
@@ -24,7 +24,6 @@ import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.common.ContentException;
 import com.sap.cloud.lm.sl.common.NotFoundException;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("createOrUpdateServiceBrokerStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -58,12 +57,7 @@ public class CreateOrUpdateServiceBrokerStep extends SyncFlowableStep {
             getStepLogger().debug(Messages.SERVICE_BROKERS_CREATED);
             return StepPhase.DONE;
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_CREATING_SERVICE_BROKERS);
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_CREATING_SERVICE_BROKERS);
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateSubscriptionsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateSubscriptionsStep.java
@@ -13,7 +13,6 @@ import com.sap.cloud.lm.sl.cf.core.dao.ConfigurationSubscriptionDao;
 import com.sap.cloud.lm.sl.cf.core.model.ConfigurationSubscription;
 import com.sap.cloud.lm.sl.cf.core.model.ConfigurationSubscription.ResourceDto;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("createSubscriptionsStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -24,22 +23,17 @@ public class CreateSubscriptionsStep extends SyncFlowableStep {
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
-        try {
-            getStepLogger().debug(Messages.CREATING_SUBSCRIPTIONS);
+        getStepLogger().debug(Messages.CREATING_SUBSCRIPTIONS);
 
-            List<ConfigurationSubscription> subscriptions = StepsUtil.getSubscriptionsToCreate(execution.getContext());
+        List<ConfigurationSubscription> subscriptions = StepsUtil.getSubscriptionsToCreate(execution.getContext());
 
-            for (ConfigurationSubscription subscription : subscriptions) {
-                createSubscription(subscription);
-                getStepLogger().debug(Messages.CREATED_SUBSCRIPTION, subscription.getId());
-            }
-
-            getStepLogger().debug(Messages.SUBSCRIPTIONS_CREATED);
-            return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_CREATING_SUBSCRIPTIONS);
-            throw e;
+        for (ConfigurationSubscription subscription : subscriptions) {
+            createSubscription(subscription);
+            getStepLogger().debug(Messages.CREATED_SUBSCRIPTION, subscription.getId());
         }
+
+        getStepLogger().debug(Messages.SUBSCRIPTIONS_CREATED);
+        return StepPhase.DONE;
     }
 
     private ConfigurationSubscription detectSubscription(String mtaId, String applicationName, String spaceId, String resourceName) {
@@ -69,7 +63,7 @@ public class CreateSubscriptionsStep extends SyncFlowableStep {
         }
         dao.add(subscription);
     }
-    
+
     private void infoSubscriptionCreation(ConfigurationSubscription subscription) {
         if (subscription.getModuleDto() != null && subscription.getResourceDto() != null) {
             getStepLogger().info(MessageFormat.format(Messages.CREATING_SUBSCRIPTION_FROM_0_MODULE_TO_1_RESOURCE,

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteIdleRoutesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteIdleRoutesStep.java
@@ -44,9 +44,7 @@ public class DeleteIdleRoutesStep extends SyncFlowableStep {
             getStepLogger().debug(Messages.IDLE_URIS_DELETED);
             return StepPhase.DONE;
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_DELETING_IDLE_ROUTES);
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServiceBrokersStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServiceBrokersStep.java
@@ -18,7 +18,6 @@ import com.sap.cloud.lm.sl.cf.core.helpers.ApplicationAttributes;
 import com.sap.cloud.lm.sl.cf.core.model.SupportedParameters;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("deleteServiceBrokersStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -40,12 +39,7 @@ public class DeleteServiceBrokersStep extends SyncFlowableStep {
             getStepLogger().debug(Messages.SERVICE_BROKERS_DELETED);
             return StepPhase.DONE;
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_DELETING_SERVICE_BROKERS);
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_DELETING_SERVICE_BROKERS);
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
@@ -47,39 +47,34 @@ public class DeleteServicesStep extends AsyncFlowableStep {
 
     @Override
     protected StepPhase executeAsyncStep(ExecutionWrapper execution) throws Exception {
-        try {
-            getStepLogger().debug(Messages.DELETING_SERVICES);
+        getStepLogger().debug(Messages.DELETING_SERVICES);
 
-            CloudControllerClient client = execution.getControllerClient();
+        CloudControllerClient client = execution.getControllerClient();
 
-            List<String> servicesToDelete = new ArrayList<>(StepsUtil.getServicesToDelete(execution.getContext()));
+        List<String> servicesToDelete = new ArrayList<>(StepsUtil.getServicesToDelete(execution.getContext()));
 
-            if (servicesToDelete.isEmpty()) {
-                getStepLogger().debug(Messages.MISSING_SERVICES_TO_DELETE);
-                return StepPhase.DONE;
-            }
-
-            Map<String, CloudServiceExtended> servicesData = getServicesData(servicesToDelete, execution);
-            List<String> servicesWithoutData = getServicesWithoutData(servicesToDelete, servicesData);
-            if (!servicesWithoutData.isEmpty()) {
-                execution.getStepLogger()
-                    .info(Messages.SERVICES_ARE_ALREADY_DELETED, servicesWithoutData);
-                servicesToDelete.removeAll(servicesWithoutData);
-            }
-            StepsUtil.setServicesData(execution.getContext(), servicesData);
-
-            Map<String, ServiceOperationType> triggeredServiceOperations = deleteServices(client, servicesToDelete);
-
-            execution.getStepLogger()
-                .debug(Messages.TRIGGERED_SERVICE_OPERATIONS, JsonUtil.toJson(triggeredServiceOperations, true));
-            StepsUtil.setTriggeredServiceOperations(execution.getContext(), triggeredServiceOperations);
-
-            getStepLogger().debug(Messages.SERVICES_DELETED);
-            return StepPhase.POLL;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_DELETING_SERVICES);
-            throw e;
+        if (servicesToDelete.isEmpty()) {
+            getStepLogger().debug(Messages.MISSING_SERVICES_TO_DELETE);
+            return StepPhase.DONE;
         }
+
+        Map<String, CloudServiceExtended> servicesData = getServicesData(servicesToDelete, execution);
+        List<String> servicesWithoutData = getServicesWithoutData(servicesToDelete, servicesData);
+        if (!servicesWithoutData.isEmpty()) {
+            execution.getStepLogger()
+                .info(Messages.SERVICES_ARE_ALREADY_DELETED, servicesWithoutData);
+            servicesToDelete.removeAll(servicesWithoutData);
+        }
+        StepsUtil.setServicesData(execution.getContext(), servicesData);
+
+        Map<String, ServiceOperationType> triggeredServiceOperations = deleteServices(client, servicesToDelete);
+
+        execution.getStepLogger()
+            .debug(Messages.TRIGGERED_SERVICE_OPERATIONS, JsonUtil.toJson(triggeredServiceOperations, true));
+        StepsUtil.setTriggeredServiceOperations(execution.getContext(), triggeredServiceOperations);
+
+        getStepLogger().debug(Messages.SERVICES_DELETED);
+        return StepPhase.POLL;
     }
 
     private Map<String, CloudServiceExtended> getServicesData(List<String> serviceNames, ExecutionWrapper execution) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetectDeployedMtaStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetectDeployedMtaStep.java
@@ -18,7 +18,6 @@ import com.sap.cloud.lm.sl.cf.core.model.DeployedMta;
 import com.sap.cloud.lm.sl.cf.core.security.serialization.SecureSerializationFacade;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.common.util.JsonUtil;
 
 @Component("detectDeployedMtaStep")
@@ -48,18 +47,16 @@ public class DetectDeployedMtaStep extends SyncFlowableStep {
                 getStepLogger().info(Messages.NO_DEPLOYED_MTA_DETECTED);
             } else {
                 getStepLogger().debug(Messages.DEPLOYED_MTA, JsonUtil.toJson(deployedMta, true));
-                getStepLogger().info(MessageFormat.format(Messages.DEPLOYED_MTA_DETECTED_WITH_VERSION, deployedMta.getMetadata().getId(), deployedMta.getMetadata().getVersion()));
+                getStepLogger().info(MessageFormat.format(Messages.DEPLOYED_MTA_DETECTED_WITH_VERSION, deployedMta.getMetadata()
+                    .getId(),
+                    deployedMta.getMetadata()
+                        .getVersion()));
             }
             StepsUtil.setDeployedMta(execution.getContext(), deployedMta);
             getStepLogger().debug(Messages.DEPLOYED_APPS, secureSerializer.toJson(deployedApps));
             return StepPhase.DONE;
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_DETECTING_DEPLOYED_MTA);
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_DETECTING_DEPLOYED_MTA);
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetectMtaSchemaVersionStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetectMtaSchemaVersionStep.java
@@ -25,28 +25,23 @@ public class DetectMtaSchemaVersionStep extends SyncFlowableStep {
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
         getStepLogger().debug(Messages.DETECTING_MTA_MAJOR_SCHEMA_VERSION);
-        try {
-            DeploymentDescriptor deploymentDescriptor = StepsUtil.getDeploymentDescriptor(execution.getContext());
-            List<ExtensionDescriptor> extensionDescriptors = StepsUtil.getExtensionDescriptorChain(execution.getContext());
+        DeploymentDescriptor deploymentDescriptor = StepsUtil.getDeploymentDescriptor(execution.getContext());
+        List<ExtensionDescriptor> extensionDescriptors = StepsUtil.getExtensionDescriptorChain(execution.getContext());
 
-            SchemaVersionDetector detector = detectorSupplier.get();
-            Version schemaVersion = detector.detect(deploymentDescriptor, extensionDescriptors);
-            if (!SupportedVersions.isSupported(schemaVersion)) {
-                throw new SLException(com.sap.cloud.lm.sl.mta.message.Messages.UNSUPPORTED_VERSION, schemaVersion);
-            }
-            if (!SupportedVersions.isFullySupported(schemaVersion)) {
-               getStepLogger().warn(Messages.UNSUPPORTED_MINOR_VERSION, schemaVersion);
-            }
-            execution.getContext()
-                .setVariable(Constants.VAR_MTA_MAJOR_SCHEMA_VERSION, schemaVersion.getMajor());
-
-            getStepLogger().info(Messages.MTA_SCHEMA_VERSION_DETECTED_AS, schemaVersion.getMajor());
-
-            return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_DETECTING_MTA_MAJOR_SCHEMA_VERSION);
-            throw e;
+        SchemaVersionDetector detector = detectorSupplier.get();
+        Version schemaVersion = detector.detect(deploymentDescriptor, extensionDescriptors);
+        if (!SupportedVersions.isSupported(schemaVersion)) {
+            throw new SLException(com.sap.cloud.lm.sl.mta.message.Messages.UNSUPPORTED_VERSION, schemaVersion);
         }
+        if (!SupportedVersions.isFullySupported(schemaVersion)) {
+            getStepLogger().warn(Messages.UNSUPPORTED_MINOR_VERSION, schemaVersion);
+        }
+        execution.getContext()
+            .setVariable(Constants.VAR_MTA_MAJOR_SCHEMA_VERSION, schemaVersion.getMajor());
+
+        getStepLogger().info(Messages.MTA_SCHEMA_VERSION_DETECTED_AS, schemaVersion.getMajor());
+
+        return StepPhase.DONE;
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineDesiredStateAchievingActionsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineDesiredStateAchievingActionsStep.java
@@ -25,7 +25,6 @@ import com.sap.cloud.lm.sl.cf.core.util.ApplicationConfiguration;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.cf.process.util.ApplicationStager;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("determineDesiredStateAchievingActionsStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -38,17 +37,10 @@ public class DetermineDesiredStateAchievingActionsStep extends SyncFlowableStep 
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper context) {
-        CloudApplication app = StepsUtil.getApp(context.getContext());
-
         try {
             return attemptToExecuteStep(context);
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_DETERMINING_ACTIONS_TO_EXECUTE_ON_APP, app.getName());
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_DETERMINING_ACTIONS_TO_EXECUTE_ON_APP, app.getName());
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 
@@ -87,8 +79,7 @@ public class DetermineDesiredStateAchievingActionsStep extends SyncFlowableStep 
     }
 
     private boolean determineAppRestart(DelegateExecution context) {
-        String appContentChangedString = StepsUtil.getString(context, Constants.VAR_APP_CONTENT_CHANGED,
-            Boolean.toString(false));
+        String appContentChangedString = StepsUtil.getString(context, Constants.VAR_APP_CONTENT_CHANGED, Boolean.toString(false));
         if (Boolean.valueOf(appContentChangedString)) {
             return true;
         }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ExecuteTaskStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ExecuteTaskStep.java
@@ -20,7 +20,6 @@ import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudApplicationExtended;
 import com.sap.cloud.lm.sl.cf.core.cf.clients.RecentLogsRetriever;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("executeTaskStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -38,12 +37,7 @@ public class ExecuteTaskStep extends TimeoutAsyncFlowableStep {
         try {
             return attemptToExecuteTask(execution, app, taskToExecute);
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_EXECUTING_TASK_ON_APP, taskToExecute.getName(), app.getName());
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_EXECUTING_TASK_ON_APP, taskToExecute.getName(), app.getName());
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/MergeDescriptorsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/MergeDescriptorsStep.java
@@ -12,7 +12,6 @@ import com.sap.cloud.lm.sl.cf.core.cf.HandlerFactory;
 import com.sap.cloud.lm.sl.cf.core.helpers.MtaDescriptorMerger;
 import com.sap.cloud.lm.sl.cf.core.util.ApplicationConfiguration;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
 import com.sap.cloud.lm.sl.mta.model.ExtensionDescriptor;
 import com.sap.cloud.lm.sl.mta.model.Platform;
@@ -31,20 +30,15 @@ public class MergeDescriptorsStep extends SyncFlowableStep {
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
         getStepLogger().debug(Messages.MERGING_DESCRIPTORS);
-        try {
-            DeploymentDescriptor deploymentDescriptor = StepsUtil.getDeploymentDescriptor(execution.getContext());
-            List<ExtensionDescriptor> extensionDescriptors = StepsUtil.getExtensionDescriptorChain(execution.getContext());
+        DeploymentDescriptor deploymentDescriptor = StepsUtil.getDeploymentDescriptor(execution.getContext());
+        List<ExtensionDescriptor> extensionDescriptors = StepsUtil.getExtensionDescriptorChain(execution.getContext());
 
-            HandlerFactory handlerFactory = StepsUtil.getHandlerFactory(execution.getContext());
-            Platform platform = configuration.getPlatform();
-            DeploymentDescriptor descriptor = getMtaDescriptorMerger(handlerFactory, platform).merge(deploymentDescriptor,
-                extensionDescriptors);
+        HandlerFactory handlerFactory = StepsUtil.getHandlerFactory(execution.getContext());
+        Platform platform = configuration.getPlatform();
+        DeploymentDescriptor descriptor = getMtaDescriptorMerger(handlerFactory, platform).merge(deploymentDescriptor,
+            extensionDescriptors);
 
-            StepsUtil.setDeploymentDescriptor(execution.getContext(), descriptor);
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_MERGING_DESCRIPTORS);
-            throw e;
-        }
+        StepsUtil.setDeploymentDescriptor(execution.getContext(), descriptor);
         getStepLogger().debug(Messages.DESCRIPTORS_MERGED);
 
         return StepPhase.DONE;

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollExecuteAppStatusExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollExecuteAppStatusExecution.java
@@ -24,7 +24,6 @@ import com.sap.cloud.lm.sl.cf.core.model.SupportedParameters;
 import com.sap.cloud.lm.sl.cf.persistence.services.ProcessLoggerProvider;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.common.util.Pair;
 
 public class PollExecuteAppStatusExecution implements AsyncExecution {
@@ -56,18 +55,12 @@ public class PollExecuteAppStatusExecution implements AsyncExecution {
             CloudControllerClient client = execution.getControllerClient();
             ApplicationAttributes appAttributes = ApplicationAttributes.fromApplication(app);
             Pair<AppExecutionStatus, String> status = getAppExecutionStatus(execution.getContext(), client, appAttributes, app);
-            ProcessLoggerProvider processLoggerProvider = execution.getStepLogger().getProcessLoggerProvider();
+            ProcessLoggerProvider processLoggerProvider = execution.getStepLogger()
+                .getProcessLoggerProvider();
             StepsUtil.saveAppLogs(execution.getContext(), client, recentLogsRetriever, app, LOGGER, processLoggerProvider);
             return checkAppExecutionStatus(execution, client, app, appAttributes, status);
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            execution.getStepLogger()
-                .error(e, Messages.ERROR_EXECUTING_APP_1, app.getName());
-            throw e;
-        } catch (SLException e) {
-            execution.getStepLogger()
-                .error(e, Messages.ERROR_EXECUTING_APP_1, app.getName());
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareToExecuteTasksStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareToExecuteTasksStep.java
@@ -12,8 +12,6 @@ import org.springframework.stereotype.Component;
 
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudApplicationExtended;
 import com.sap.cloud.lm.sl.cf.process.Constants;
-import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("prepareToExecuteTasksStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -26,12 +24,7 @@ public class PrepareToExecuteTasksStep extends SyncFlowableStep {
         try {
             return attemptToPrepareExecutionOfTasks(execution, tasksToExecute);
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_PREPARING_TO_EXECUTE_TASKS_ON_APP, app.getName());
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_PREPARING_TO_EXECUTE_TASKS_ON_APP, app.getName());
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareToUndeployStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareToUndeployStep.java
@@ -20,7 +20,6 @@ import com.sap.cloud.lm.sl.cf.core.model.DeployedMtaModule;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.cf.process.util.ProcessConflictPreventer;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("prepareToUndeployStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -55,12 +54,7 @@ public class PrepareToUndeployStep extends SyncFlowableStep {
 
             return StepPhase.DONE;
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_DETECTING_COMPONENTS_TO_UNDEPLOY);
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_DETECTING_COMPONENTS_TO_UNDEPLOY);
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessDescriptorStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessDescriptorStep.java
@@ -19,7 +19,6 @@ import com.sap.cloud.lm.sl.cf.core.model.ConfigurationSubscription;
 import com.sap.cloud.lm.sl.cf.core.security.serialization.SecureSerializationFacade;
 import com.sap.cloud.lm.sl.cf.core.util.ApplicationConfiguration;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
 import com.sap.cloud.lm.sl.mta.model.Module;
 
@@ -38,39 +37,34 @@ public class ProcessDescriptorStep extends SyncFlowableStep {
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
         DelegateExecution context = execution.getContext();
-        try {
-            getStepLogger().debug(Messages.RESOLVING_DESCRIPTOR_PROPERTIES);
+        getStepLogger().debug(Messages.RESOLVING_DESCRIPTOR_PROPERTIES);
 
-            DeploymentDescriptor descriptor = StepsUtil.getDeploymentDescriptorWithSystemParameters(context);
-            MtaDescriptorPropertiesResolver resolver = getMtaDescriptorPropertiesResolver(context);
+        DeploymentDescriptor descriptor = StepsUtil.getDeploymentDescriptorWithSystemParameters(context);
+        MtaDescriptorPropertiesResolver resolver = getMtaDescriptorPropertiesResolver(context);
 
-            descriptor = resolver.resolve(descriptor);
+        descriptor = resolver.resolve(descriptor);
 
-            List<ConfigurationSubscription> subscriptions = resolver.getSubscriptions();
-            StepsUtil.setSubscriptionsToCreate(context, subscriptions);
+        List<ConfigurationSubscription> subscriptions = resolver.getSubscriptions();
+        StepsUtil.setSubscriptionsToCreate(context, subscriptions);
 
-            StepsUtil.setCompleteDeploymentDescriptor(context, descriptor);
-            // Set MTA modules in the context
-            List<String> modulesForDeployment = StepsUtil.getModulesForDeployment(context);
-            List<String> invalidModulesSpecifiedForDeployment = findInvalidModulesSpecifiedForDeployment(descriptor, modulesForDeployment);
-            if (!invalidModulesSpecifiedForDeployment.isEmpty()) {
-                throw new IllegalStateException(
-                    MessageFormat.format(Messages.MODULES_0_SPECIFIED_FOR_DEPLOYMENT_ARE_NOT_PART_OF_DEPLOYMENT_DESCRIPTOR_MODULES,
-                        StringUtils.join(invalidModulesSpecifiedForDeployment, ", ")));
-            }
-            Set<String> mtaModules = getModuleNames(descriptor, modulesForDeployment);
-            getStepLogger().debug("MTA Modules: {0}", mtaModules);
-            StepsUtil.setMtaModules(context, mtaModules);
-
-            getStepLogger().debug(com.sap.cloud.lm.sl.cf.core.message.Messages.RESOLVED_DEPLOYMENT_DESCRIPTOR,
-                secureSerializer.toJson(descriptor));
-            getStepLogger().debug(Messages.DESCRIPTOR_PROPERTIES_RESOVED);
-
-            return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_RESOLVING_DESCRIPTOR_PROPERTIES);
-            throw e;
+        StepsUtil.setCompleteDeploymentDescriptor(context, descriptor);
+        // Set MTA modules in the context
+        List<String> modulesForDeployment = StepsUtil.getModulesForDeployment(context);
+        List<String> invalidModulesSpecifiedForDeployment = findInvalidModulesSpecifiedForDeployment(descriptor, modulesForDeployment);
+        if (!invalidModulesSpecifiedForDeployment.isEmpty()) {
+            throw new IllegalStateException(
+                MessageFormat.format(Messages.MODULES_0_SPECIFIED_FOR_DEPLOYMENT_ARE_NOT_PART_OF_DEPLOYMENT_DESCRIPTOR_MODULES,
+                    StringUtils.join(invalidModulesSpecifiedForDeployment, ", ")));
         }
+        Set<String> mtaModules = getModuleNames(descriptor, modulesForDeployment);
+        getStepLogger().debug("MTA Modules: {0}", mtaModules);
+        StepsUtil.setMtaModules(context, mtaModules);
+
+        getStepLogger().debug(com.sap.cloud.lm.sl.cf.core.message.Messages.RESOLVED_DEPLOYMENT_DESCRIPTOR,
+            secureSerializer.toJson(descriptor));
+        getStepLogger().debug(Messages.DESCRIPTOR_PROPERTIES_RESOVED);
+
+        return StepPhase.DONE;
     }
 
     protected MtaDescriptorPropertiesResolver getMtaDescriptorPropertiesResolver(DelegateExecution context) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessGitSourceStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessGitSourceStep.java
@@ -96,11 +96,7 @@ public class ProcessGitSourceStep extends SyncFlowableStep {
                 }
             }
             return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e.getMessage());
-            throw e;
         } catch (GitAPIException | IOException | FileStorageException e) {
-            getStepLogger().error(e, Messages.ERROR_DOWNLOADING_DEPLOYABLE_FROM_GIT);
             throw new SLException(e, Messages.ERROR_PROCESSING_GIT_MTA_SOURCE);
         }
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessMtaArchiveStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessMtaArchiveStep.java
@@ -49,12 +49,7 @@ public class ProcessMtaArchiveStep extends SyncFlowableStep {
             getStepLogger().debug(Messages.MTA_ARCHIVE_PROCESSED);
             return StepPhase.DONE;
         } catch (FileStorageException fse) {
-            SLException e = new SLException(fse, fse.getMessage());
-            getStepLogger().error(e, Messages.ERROR_PROCESSING_MTA_ARCHIVE);
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_PROCESSING_MTA_ARCHIVE);
-            throw e;
+            throw new SLException(fse, fse.getMessage());
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessMtaExtensionDescriptorsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessMtaExtensionDescriptorsStep.java
@@ -35,19 +35,14 @@ public class ProcessMtaExtensionDescriptorsStep extends SyncFlowableStep {
         DelegateExecution context = execution.getContext();
         getStepLogger().debug(Messages.PROCESSING_MTA_EXTENSION_DESCRIPTORS);
         List<String> extensionDescriptorFileIds = getExtensionDescriptorFileIds(context);
-        try {
-            String spaceId = StepsUtil.getSpaceId(context);
-            DeploymentDescriptor deploymentDescriptor = StepsUtil.getDeploymentDescriptor(context);
+        String spaceId = StepsUtil.getSpaceId(context);
+        DeploymentDescriptor deploymentDescriptor = StepsUtil.getDeploymentDescriptor(context);
 
-            List<ExtensionDescriptor> extensionDescriptors = parseExtensionDescriptors(spaceId, extensionDescriptorFileIds);
-            List<ExtensionDescriptor> extensionDescriptorChain = extensionDescriptorChainBuilder.build(deploymentDescriptor,
-                extensionDescriptors);
+        List<ExtensionDescriptor> extensionDescriptors = parseExtensionDescriptors(spaceId, extensionDescriptorFileIds);
+        List<ExtensionDescriptor> extensionDescriptorChain = extensionDescriptorChainBuilder.build(deploymentDescriptor,
+            extensionDescriptors);
 
-            StepsUtil.setExtensionDescriptorChain(context, extensionDescriptorChain);
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_PROCESSING_MTA_EXTENSION_DESCRIPTORS);
-            throw e;
-        }
+        StepsUtil.setExtensionDescriptorChain(context, extensionDescriptorChain);
         getStepLogger().debug(Messages.MTA_EXTENSION_DESCRIPTORS_PROCESSED);
         return StepPhase.DONE;
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessStepHelper.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessStepHelper.java
@@ -79,7 +79,7 @@ public class ProcessStepHelper {
         LOGGER.error(Messages.EXCEPTION_CAUGHT, t);
         getProcessLogger().error(Messages.EXCEPTION_CAUGHT, t);
 
-        storeExceptionInProgressMessageService(context, t);
+//        storeExceptionInProgressMessageService(context, t);
 
         if (t instanceof ContentException) {
             StepsUtil.setErrorType(context, ErrorType.CONTENT_ERROR);

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PublishConfigurationEntriesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PublishConfigurationEntriesStep.java
@@ -17,7 +17,6 @@ import com.sap.cloud.lm.sl.cf.core.dao.ConfigurationEntryDao;
 import com.sap.cloud.lm.sl.cf.core.model.ConfigurationEntry;
 import com.sap.cloud.lm.sl.cf.core.security.serialization.SecureSerializationFacade;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.common.util.CommonUtil;
 
 @Component("publishProvidedDependenciesStep")
@@ -33,28 +32,23 @@ public class PublishConfigurationEntriesStep extends SyncFlowableStep {
     protected StepPhase executeStep(ExecutionWrapper execution) {
         CloudApplicationExtended app = StepsUtil.getApp(execution.getContext());
 
-        try {
-            getStepLogger().debug(MessageFormat.format(Messages.PUBLISHING_PUBLIC_PROVIDED_DEPENDENCIES, app.getName()));
+        getStepLogger().debug(MessageFormat.format(Messages.PUBLISHING_PUBLIC_PROVIDED_DEPENDENCIES, app.getName()));
 
-            List<ConfigurationEntry> entriesToPublish = StepsUtil.getConfigurationEntriesToPublish(execution.getContext());
+        List<ConfigurationEntry> entriesToPublish = StepsUtil.getConfigurationEntriesToPublish(execution.getContext());
 
-            if (CollectionUtils.isEmpty(entriesToPublish)) {
-                StepsUtil.setPublishedEntries(execution.getContext(), Collections.emptyList());
-                getStepLogger().debug(Messages.NO_PUBLIC_PROVIDED_DEPENDENCIES_FOR_PUBLISHING);
-                return StepPhase.DONE;
-            }
-
-            List<ConfigurationEntry> publishedEntries = publish(entriesToPublish);
-
-            getStepLogger().debug(Messages.PUBLISHED_ENTRIES, secureSerializer.toJson(publishedEntries));
-            StepsUtil.setPublishedEntries(execution.getContext(), publishedEntries);
-
-            getStepLogger().debug(Messages.PUBLIC_PROVIDED_DEPENDENCIES_PUBLISHED);
+        if (CollectionUtils.isEmpty(entriesToPublish)) {
+            StepsUtil.setPublishedEntries(execution.getContext(), Collections.emptyList());
+            getStepLogger().debug(Messages.NO_PUBLIC_PROVIDED_DEPENDENCIES_FOR_PUBLISHING);
             return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_PUBLISHING_PUBLIC_PROVIDED_DEPENDENCIES);
-            throw e;
         }
+
+        List<ConfigurationEntry> publishedEntries = publish(entriesToPublish);
+
+        getStepLogger().debug(Messages.PUBLISHED_ENTRIES, secureSerializer.toJson(publishedEntries));
+        StepsUtil.setPublishedEntries(execution.getContext(), publishedEntries);
+
+        getStepLogger().debug(Messages.PUBLIC_PROVIDED_DEPENDENCIES_PUBLISHED);
+        return StepPhase.DONE;
     }
 
     private List<ConfigurationEntry> publish(List<ConfigurationEntry> entriesToPublish) {
@@ -77,7 +71,7 @@ public class PublishConfigurationEntriesStep extends SyncFlowableStep {
     }
 
     private void infoConfigurationPublishment(ConfigurationEntry entry) {
-        if(!CommonUtil.isNullOrEmpty(entry.getContent())) {
+        if (!CommonUtil.isNullOrEmpty(entry.getContent())) {
             getStepLogger().info(MessageFormat.format(Messages.PUBLISHING_PUBLIC_PROVIDED_DEPENDENCY, entry.getProviderId()));
         }
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ScaleAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ScaleAppStep.java
@@ -37,12 +37,7 @@ public class ScaleAppStep extends SyncFlowableStep {
             getStepLogger().debug(Messages.APP_SCALED, app.getName());
             return StepPhase.DONE;
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_SCALING_APP, app.getName());
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_SCALING_APP, app.getName());
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StageAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StageAppStep.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Component;
 
 import com.sap.cloud.lm.sl.cf.core.cf.clients.RecentLogsRetriever;
 import com.sap.cloud.lm.sl.cf.process.Constants;
-import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.cf.process.util.ApplicationStager;
 
 @Component("stageAppStep")
@@ -32,9 +31,7 @@ public class StageAppStep extends TimeoutAsyncFlowableStep {
             ApplicationStager applicationStager = new ApplicationStager();
             return applicationStager.stageApp(execution.getContext(), execution.getControllerClient(), app, getStepLogger());
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_STAGING_APP_1, app.getName());
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StopAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StopAppStep.java
@@ -16,7 +16,6 @@ import com.sap.cloud.lm.sl.cf.core.model.HookPhase;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.cf.process.util.ProcessTypeParser;
 import com.sap.cloud.lm.sl.cf.web.api.model.ProcessType;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("stopAppStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -51,12 +50,7 @@ public class StopAppStep extends SyncFlowableStepWithHooks {
 
             return StepPhase.DONE;
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_STOPPING_APP, app.getName());
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_STOPPING_APP, app.getName());
-            throw e;
+            throw new CloudControllerException(coe);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UploadAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UploadAppStep.java
@@ -79,12 +79,7 @@ public class UploadAppStep extends TimeoutAsyncFlowableStep {
             getStepLogger().debug(Messages.STARTED_ASYNC_UPLOAD_OF_APP_0, app.getName());
             StepsUtil.setUploadToken(uploadToken, execution.getContext());
         } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_UPLOADING_APP, app.getName());
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_UPLOADING_APP, app.getName());
-            throw e;
+            throw new CloudControllerException(coe);
         }
         return StepPhase.POLL;
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ValidateDeployParametersStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ValidateDeployParametersStep.java
@@ -39,20 +39,15 @@ public class ValidateDeployParametersStep extends SyncFlowableStep {
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
-        try {
-            getStepLogger().debug(Messages.VALIDATING_PARAMETERS);
+        getStepLogger().debug(Messages.VALIDATING_PARAMETERS);
 
-            validateParameters(execution.getContext());
-            String space = StepsUtil.getSpace(execution.getContext());
-            String org = StepsUtil.getOrg(execution.getContext());
-            getStepLogger().info(Messages.DEPLOYING_IN_ORG_0_AND_SPACE_1, org, space);
+        validateParameters(execution.getContext());
+        String space = StepsUtil.getSpace(execution.getContext());
+        String org = StepsUtil.getOrg(execution.getContext());
+        getStepLogger().info(Messages.DEPLOYING_IN_ORG_0_AND_SPACE_1, org, space);
 
-            getStepLogger().debug(Messages.PARAMETERS_VALIDATED);
-            return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_VALIDATING_PARAMS);
-            throw e;
-        }
+        getStepLogger().debug(Messages.PARAMETERS_VALIDATED);
+        return StepPhase.DONE;
     }
 
     private void validateParameters(DelegateExecution context) {
@@ -67,8 +62,8 @@ public class ValidateDeployParametersStep extends SyncFlowableStep {
         try {
             VersionRule.value(versionRuleString);
         } catch (IllegalArgumentException e) {
-            throw new SLException(e, Messages.ERROR_PARAMETER_1_IS_NOT_VALID_VALID_VALUES_ARE_2, versionRuleString, Constants.PARAM_VERSION_RULE,
-                Arrays.asList(VersionRule.values()));
+            throw new SLException(e, Messages.ERROR_PARAMETER_1_IS_NOT_VALID_VALID_VALUES_ARE_2, versionRuleString,
+                Constants.PARAM_VERSION_RULE, Arrays.asList(VersionRule.values()));
         }
     }
 


### PR DESCRIPTION
#### Description: 
Deploy service returns duplicated error messages.
All of them are presented to the customer in CLI which worse the user experience.
Only one error message should be provided to the customer

#### Issue: 
Jira: LMCROSSITXSADEPLOY-1536

