### PR TITLE
Rename hook type

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -72,6 +72,7 @@ public class Messages {
     public static final String SERVICE_BROKER_0_DOES_NOT_EXIST = "Service broker \"{0}\" does not exist";
     public static final String COULD_NOT_FIND_APPLICATION_WITH_GUID_0 = "Could not find application with guid \"{0}\"";
     public static final String GIT_URI_IS_NOT_SPECIFIED = "Git URI is not specified";
+    public static final String PARAMETERS_OF_TASK_HOOK_0_ARE_INCOMPLETE = "Parameters of hook {0} with type \"task\" are incomplete. Expected at least \"command\".";
 
     // Audit log messages
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineTasksFromHookStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineTasksFromHookStep.java
@@ -1,6 +1,6 @@
 package com.sap.cloud.lm.sl.cf.process.steps;
 
-import java.util.List;
+import java.util.Arrays;
 
 import org.cloudfoundry.client.lib.domain.CloudTask;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -8,21 +8,23 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.cf.process.util.TasksHookParser;
+import com.sap.cloud.lm.sl.cf.process.util.TaskHookParser;
 import com.sap.cloud.lm.sl.mta.model.Hook;
 
 @Component("determineTasksFromHookStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
 public class DetermineTasksFromHookStep extends SyncFlowableStep {
 
+    protected TaskHookParser hookParser = new TaskHookParser();
+
     @Override
-    protected StepPhase executeStep(ExecutionWrapper execution) throws Exception {
-        Hook hookForExecution = StepsUtil.getHookForExecution(execution.getContext());
+    protected StepPhase executeStep(ExecutionWrapper execution) {
+        Hook hook = StepsUtil.getHookForExecution(execution.getContext());
 
-        getStepLogger().info(Messages.EXECUTING_HOOK_0, hookForExecution.getName());
+        getStepLogger().info(Messages.EXECUTING_HOOK_0, hook.getName());
 
-        List<CloudTask> tasksFromHook = new TasksHookParser().parse(hookForExecution);
-        StepsUtil.setTasksToExecute(execution.getContext(), tasksFromHook);
+        CloudTask task = hookParser.parse(hook);
+        StepsUtil.setTasksToExecute(execution.getContext(), Arrays.asList(task));
 
         return StepPhase.DONE;
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/HookProcessGetter.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/HookProcessGetter.java
@@ -13,7 +13,7 @@ public class HookProcessGetter {
 
     public String get(String hookForExecutionString) {
         Hook hookForExecution = JsonUtil.fromJson(hookForExecutionString, Hook.class);
-        if (TasksHookParser.HOOK_TYPE_TASKS.equals(hookForExecution.getType())) {
+        if (TaskHookParser.HOOK_TYPE_TASK.equals(hookForExecution.getType())) {
             return Constants.EXECUTE_HOOK_TASKS_SUB_PROCESS_ID;
         }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/TaskHookParser.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/TaskHookParser.java
@@ -1,24 +1,24 @@
 package com.sap.cloud.lm.sl.cf.process.util;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import org.cloudfoundry.client.lib.domain.CloudTask;
 
 import com.sap.cloud.lm.sl.cf.core.parser.TaskParametersParser;
+import com.sap.cloud.lm.sl.cf.process.message.Messages;
+import com.sap.cloud.lm.sl.common.ContentException;
 import com.sap.cloud.lm.sl.mta.model.Hook;
 
-public class TasksHookParser {
+public class TaskHookParser {
 
-    public static final String HOOK_TYPE_TASKS = "tasks";
+    public static final String HOOK_TYPE_TASK = "task";
 
-    public List<CloudTask> parse(Hook hook) {
+    public CloudTask parse(Hook hook) {
         Map<String, Object> hookParameters = hook.getParameters();
         if (hookParameters.isEmpty()) {
-            throw new IllegalStateException("Hook task parameters must not be empty");
+            throw new ContentException(Messages.PARAMETERS_OF_TASK_HOOK_0_ARE_INCOMPLETE, hook.getName());
         }
-        return Arrays.asList(getHookTask(hookParameters));
+        return getHookTask(hookParameters);
     }
 
     private CloudTask getHookTask(Map<String, Object> hookParameters) {


### PR DESCRIPTION
One hook always maps to a single task, so it makes more sense to call the type "task".
