### PR TITLE
Data Termination without credentials improvement

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/message/Messages.java
@@ -88,6 +88,7 @@ public final class Messages {
     public static final String INVALID_CONTROLLER_URL = "Invalid controller URL \"{0}\".";
     public static final String ERROR_SERVICE_INSTANCE_RESPONSE_WITH_MISSING_FIELD = "The response of finding a service instance should contain a \"{0}\" element";
     public static final String ERROR_SERVICE_INSTANCE_RESPONSE_WITH_MORE_THEN_ONE_RESULT = "The response of finding a service instance should not have more than one resource element";
+    public static final String MISSING_GLOBAL_AUDITOR_CREDENTIALS = "Global Auditor credentials are missing from the application ENV.";
 
     // Warning messages
     public static final String ENVIRONMENT_VARIABLE_IS_NOT_SET_USING_DEFAULT = "Environment variable \"{0}\" is not set. Using default \"{1}\"...";
@@ -140,7 +141,7 @@ public final class Messages {
     public static final String ROUTER_PORT = "Router port: {0}";
     public static final String DUMMY_TOKENS_ENABLED = "Dummy tokens enabled: {0}";
     public static final String BASIC_AUTH_ENABLED = "Basic authentication enabled: {0}";
-    public static final String ADMIN_USERNAME = "Admin username: {0}";
+    public static final String GLOBAL_AUDITOR_USERNAME = "Global Auditor username: {0}";
     public static final String USE_XS_AUDIT_LOGGING = "Use XSA audit logging: {0}";
     public static final String DB_CONNECTION_THREADS = "Database connection thread pool size: {0}";
     public static final String STEP_POLLING_INTERVAL_IN_SECONDS = "Step polling interval in seconds: {0}";

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/security/data/termination/DataTerminationService.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/security/data/termination/DataTerminationService.java
@@ -55,12 +55,19 @@ public class DataTerminationService {
     private ApplicationConfiguration configuration;
 
     public void deleteOrphanUserData() {
+        assertGlobalAuditorCredentialsExist();
         List<String> deleteSpaceEventsToBeDeleted = getDeleteSpaceEvents();
         for (String spaceId : deleteSpaceEventsToBeDeleted) {
             deleteConfigurationSubscriptionOrphanData(spaceId);
             deleteConfigurationEntryOrphanData(spaceId);
             deleteUserOperationsOrphanData(spaceId);
             deleteSpaceLeftovers(spaceId);
+        }
+    }
+
+    private void assertGlobalAuditorCredentialsExist() {
+        if (configuration.getGlobalAuditorUser() == null || configuration.getGlobalAuditorPassword() == null) {
+            throw new IllegalStateException(Messages.MISSING_GLOBAL_AUDITOR_CREDENTIALS);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfiguration.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfiguration.java
@@ -97,8 +97,6 @@ public class ApplicationConfiguration {
     public static final String DEFAULT_SPACE_ID = "";
     public static final Boolean DEFAULT_DUMMY_TOKENS_ENABLED = false;
     public static final Boolean DEFAULT_BASIC_AUTH_ENABLED = false;
-    public static final String DEFAULT_GLOBAL_AUDITOR_USER = "";
-    public static final String DEFAULT_GLOBAL_AUDITOR_PASSWORD = "";
     public static final Integer DEFAULT_DB_CONNECTION_THREADS = 30;
     public static final String DEFAULT_CRON_EXPRESSION_FOR_OLD_DATA = "0 0 0/6 * * ?"; // every 6 hours
     public static final long DEFAULT_MAX_TTL_FOR_OLD_DATA = TimeUnit.DAYS.toSeconds(5); // 5 days
@@ -666,13 +664,13 @@ public class ApplicationConfiguration {
     }
 
     private String getGlobalAuditorUserFromEnvironment() {
-        String value = environment.getString(CFG_GLOBAL_AUDITOR_USER, DEFAULT_GLOBAL_AUDITOR_USER);
-        LOGGER.info(format(Messages.ADMIN_USERNAME, value));
+        String value = environment.getString(CFG_GLOBAL_AUDITOR_USER);
+        LOGGER.info(format(Messages.GLOBAL_AUDITOR_USERNAME, value));
         return value;
     }
 
     private String getGlobalAuditorPasswordFromEnvironment() {
-        return environment.getString(CFG_GLOBAL_AUDITOR_PASSWORD, DEFAULT_GLOBAL_AUDITOR_PASSWORD);
+        return environment.getString(CFG_GLOBAL_AUDITOR_PASSWORD);
     }
 
     private Integer getDbConnectionThreadsFromEnvironment() {


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
Data Termination cleanup job should not exit faster and with a more
meaningful message when Global Auditor credentials are missing from the
ENV.