### PR TITLE
fix plural params to override singular

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/parser/UriParametersParser.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/parser/UriParametersParser.java
@@ -1,6 +1,6 @@
 package com.sap.cloud.lm.sl.cf.core.parser;
 
-import static com.sap.cloud.lm.sl.mta.util.PropertiesUtil.getAll;
+import static com.sap.cloud.lm.sl.mta.util.PropertiesUtil.getPluralOrSingular;
 import static com.sap.cloud.lm.sl.mta.util.PropertiesUtil.getPropertyValue;
 
 import java.util.ArrayList;
@@ -171,7 +171,7 @@ public class UriParametersParser implements ParametersParser<List<String>> {
 
     private static <T> List<T> getValuesFromSingularName(String singularParameterName, List<Map<String, Object>> parametersList) {
         String pluralParameterName = SupportedParameters.SINGULAR_PLURAL_MAPPING.get(singularParameterName);
-        return getAll(parametersList, singularParameterName, pluralParameterName);
+        return getPluralOrSingular(parametersList, pluralParameterName, singularParameterName);
     }
 
     private String appendRoutePathIfPresent(String uri) {


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
this fixes the bug with host/hosts and domain/domains where the plural
parameter was merged with the singular, causing non-specified
hosts/domains to appear for apps with only the plural parameter defined.

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
Bug: LMCROSSITXSADEPLOY-1558
