### PR TITLE
add test for plural override of singular

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/cf/v2/CloudModelBuilderTest.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/cf/v2/CloudModelBuilderTest.java
@@ -450,6 +450,16 @@ public class CloudModelBuilderTest {
                 new Expectation("[]"), //services
                 new Expectation(Expectation.Type.JSON, "apps-13.json"),  //applications
             },
+            // (38) Test plural priority over singular for hosts and domains
+            {
+                "mtad-14.yaml", "config-01.mtaext", "/mta/cf-platform.json", null,
+                false, false,
+                new String[] { "foo", }, // mtaArchiveModules
+                new String[] { "foo", }, // mtaModules
+                new String[] {}, // deployedApps
+                new Expectation("[]"), //services
+                new Expectation(Expectation.Type.JSON, "apps-14.json"),  //applications
+            },
 // @formatter:on
         });
     }

--- a/com.sap.cloud.lm.sl.cf.core/src/test/resources/com/sap/cloud/lm/sl/cf/core/cf/v2/apps-14.json
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/resources/com/sap/cloud/lm/sl/cf/core/cf/v2/apps-14.json
@@ -1,0 +1,47 @@
+[
+  {
+    "moduleName": "foo",
+    "idleUris": [],
+    "tasks": [],
+    "serviceKeysToInject": [],
+    "domains": [
+      "cfapps.domain.com", 
+      "cfapps.domain.moc"
+    ],
+    "restartParameters": {
+      "shouldRestartOnVcapAppChange": true,
+      "shouldRestartOnVcapServicesChange": true,
+      "shouldRestartOnUserProvidedChange": true
+    },
+    "attributesUpdateStrategy": {
+      "shouldKeepExistingEnv": false,
+      "shouldKeepExistingServiceBindings": false,
+      "shouldKeepExistingRoutes": false
+    },
+    "memory": 0,
+    "diskQuota": 0,
+    "instances": 0,
+    "runningInstances": 0,
+    "staging": {
+      "buildpackUrl": "git://github.example.com/xs2-java/java-buildpack.git"
+    },
+    "uris": [
+       "abc.cfapps.domain.com", 
+       "cba.cfapps.domain.com", 
+       "abc.cfapps.domain.moc", 
+       "cba.cfapps.domain.moc" 
+    ],
+    "services": [],
+    "env": {
+      "DEPLOY_ATTRIBUTES": "{\"dependency-type\":\"soft\"}",
+      "MTA_METADATA": "{\"id\":\"com.sap.sample.mta\",\"version\":\"1.0.0\"}",
+      "MTA_MODULE_METADATA": "{\"name\":\"foo\"}",
+      "MTA_MODULE_PROVIDED_DEPENDENCIES": "[\"foo\"]",
+      "MTA_SERVICES": "[]",
+      "TARGET_RUNTIME": "tomee"
+    },
+    "name": "foo",
+    "bindingParameters" : {},
+    "routes": []
+  }
+]

--- a/com.sap.cloud.lm.sl.cf.core/src/test/resources/com/sap/cloud/lm/sl/cf/core/cf/v2/mtad-14.yaml
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/resources/com/sap/cloud/lm/sl/cf/core/cf/v2/mtad-14.yaml
@@ -1,0 +1,16 @@
+_schema-version: "2.0.0"
+ID: com.sap.sample.mta
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: java.tomee
+    parameters:
+      hosts: 
+        - "abc"
+        - "cba"
+      domains:
+        - "cfapps.domain.com"
+        - "cfapps.domain.moc"
+      host: not-in-use
+      domain: default-unused


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
adds a unit test to ensure that when routes are calculated from hosts and
domains, the plurals (hosts/domains) always override the singulars (host/domain)

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
Bug: LMCROSSITXSADEPLOY-1558
