### PR TITLE
Add PartialModuleReferenceResolver to support hooks customization

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/resolvers/v3/PartialDescriptorReferenceResolver.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/resolvers/v3/PartialDescriptorReferenceResolver.java
@@ -2,13 +2,12 @@ package com.sap.cloud.lm.sl.cf.core.resolvers.v3;
 
 import java.util.List;
 
-import com.sap.cloud.lm.sl.cf.core.resolvers.v2.PartialModuleReferenceResolver;
 import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
 import com.sap.cloud.lm.sl.mta.model.Module;
 import com.sap.cloud.lm.sl.mta.model.Resource;
 import com.sap.cloud.lm.sl.mta.resolvers.ResolverBuilder;
-import com.sap.cloud.lm.sl.mta.resolvers.v2.ModuleReferenceResolver;
 import com.sap.cloud.lm.sl.mta.resolvers.v3.DescriptorReferenceResolver;
+import com.sap.cloud.lm.sl.mta.resolvers.v3.ModuleReferenceResolver;
 import com.sap.cloud.lm.sl.mta.resolvers.v3.ResourceReferenceResolver;
 
 public class PartialDescriptorReferenceResolver extends DescriptorReferenceResolver {

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/resolvers/v3/PartialModuleReferenceResolver.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/resolvers/v3/PartialModuleReferenceResolver.java
@@ -1,0 +1,37 @@
+package com.sap.cloud.lm.sl.cf.core.resolvers.v3;
+
+import java.util.List;
+import java.util.Map;
+
+import com.sap.cloud.lm.sl.cf.core.resolvers.v2.PartialModulePropertiesReferenceResolver;
+import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
+import com.sap.cloud.lm.sl.mta.model.Module;
+import com.sap.cloud.lm.sl.mta.model.RequiredDependency;
+import com.sap.cloud.lm.sl.mta.resolvers.ResolverBuilder;
+import com.sap.cloud.lm.sl.mta.resolvers.v2.ModulePropertiesReferenceResolver;
+import com.sap.cloud.lm.sl.mta.resolvers.v3.ModuleReferenceResolver;
+
+public class PartialModuleReferenceResolver extends ModuleReferenceResolver {
+
+    private List<String> dependenciesToIgnore;
+
+    public PartialModuleReferenceResolver(DeploymentDescriptor descriptor, Module module, String prefix,
+        List<String> dependenciesToIgnore) {
+        super(descriptor, module, prefix, new ResolverBuilder(), new ResolverBuilder());
+        this.dependenciesToIgnore = dependenciesToIgnore;
+    }
+
+    @Override
+    protected ModulePropertiesReferenceResolver createModulePropertiesReferenceResolver(Map<String, Object> properties) {
+        return new PartialModulePropertiesReferenceResolver(descriptor, module, properties, prefix, dependenciesToIgnore);
+    }
+
+    @Override
+    protected RequiredDependency resolveRequiredDependency(RequiredDependency dependency) {
+        if (!dependenciesToIgnore.contains(dependency.getName())) {
+            return createRequiredDependencyResolver(dependency).resolve();
+        }
+        return dependency;
+    }
+
+}


### PR DESCRIPTION
This change is necessary to add reference and placeholder resolvers for
hooks parameters

JIRA:LMCROSSITXSADEPLOY-1556 Support hooks customization in extension
descriptors

