### PR TITLE
Avoid duplication of error messages

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -95,8 +95,10 @@ public class Messages {
     public static final String ERROR_BUILDING_CLOUD_UNDEPLOY_MODEL = "Error building cloud undeployment model";
     public static final String ERROR_DELETING_UNUSED_RESERVED_ROUTES = "Error deleting unused reserved routes";
     public static final String ERROR_ADDING_DOMAINS = "Error adding domains";
+    public static final String ERROR_COMPUTING_NEXT_MODULES_FOR_PARALLEL_ITERATION = "Error computing modules for next parallel iteration";
     public static final String ERROR_CREATING_SERVICES = "Error creating services";
     public static final String ERROR_DELETING_SERVICES = "Error deleting services";
+    public static final String ERROR_DELETING_SUBSCRIPTIONS = "Error deleting discontinued subscriptions";
     public static final String ERROR_UNDEPLOYING_APPS = "Error undeploying applications";
     public static final String ERROR_BUILDING_CLOUD_APP_MODEL = "Error building cloud application deploy model";
     public static final String ERROR_SETTING_APP = "Error setting application from module \"{0}\"";
@@ -281,7 +283,7 @@ public class Messages {
     public static final String UPDATING_APP_ENVIRONMENT = "Updating apps environments...";
     public static final String STAGING_FAILED = "Staging failed. Please check the application logs for details.";
     public static final String SERVICE_BROKER_DOES_NOT_EXIST = "Service broker with name \"{0}\" does not exist";
-    public static final String EXCEPTION_OCCURED_ERROR_MSG = "Exception occured during execution: \"{0}\"";
+    public static final String PROCESS_FAILED = "Process failed: \"{0}\"";
     public static final String EXECUTING_HOOK_0 = "Executing hook \"{0}\"";
 
     // DEBUG log messages

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/AsyncExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/AsyncExecution.java
@@ -3,5 +3,7 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 public interface AsyncExecution {
 
     AsyncExecutionState execute(ExecutionWrapper execution);
+    
+    void onPollingError(ExecutionWrapper execution, Exception e) throws Exception;
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/AsyncFlowableStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/AsyncFlowableStep.java
@@ -21,11 +21,26 @@ public abstract class AsyncFlowableStep extends SyncFlowableStep {
         return executeAsyncStep(execution);
     }
 
+    @Override
+    protected void onError(ExecutionWrapper execution, Exception e) throws Exception {
+        StepPhase stepPhase = StepsUtil.getStepPhase(execution.getContext());
+        if (stepPhase == StepPhase.POLL) {
+            onPollingError(execution, e);
+        } else {
+            onStepError(execution.getContext(), e);
+        }
+    }
+
     private StepPhase executeStepExecution(ExecutionWrapper execution) throws Exception {
         List<AsyncExecution> stepExecutions = getAsyncStepExecutions(execution);
 
         AsyncExecutionState stepExecutionStatus = getStepExecution(execution, stepExecutions).execute(execution);
         return handleStepExecutionStatus(execution, stepExecutionStatus, stepExecutions);
+    }
+
+    private void onPollingError(ExecutionWrapper execution, Exception e) throws Exception {
+        List<AsyncExecution> stepExecutions = getAsyncStepExecutions(execution);
+        getStepExecution(execution, stepExecutions).onPollingError(execution, e);
     }
 
     private AsyncExecution getStepExecution(ExecutionWrapper execution, List<AsyncExecution> stepOperations) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BlueGreenRenameStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BlueGreenRenameStep.java
@@ -3,6 +3,7 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 
@@ -13,7 +14,6 @@ import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.helpers.ApplicationColorDetector;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.common.ConflictException;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
 
 @Named("blueGreenRenameStep")
@@ -27,46 +27,45 @@ public class BlueGreenRenameStep extends SyncFlowableStep {
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
+        getStepLogger().debug(Messages.DETECTING_COLOR_OF_DEPLOYED_MTA);
 
+        DeploymentDescriptor descriptor = StepsUtil.getDeploymentDescriptor(execution.getContext());
+        DeployedMta deployedMta = StepsUtil.getDeployedMta(execution.getContext());
+        ApplicationColor mtaColor;
+        ApplicationColor deployedMtaColor = null;
         try {
-            getStepLogger().debug(Messages.DETECTING_COLOR_OF_DEPLOYED_MTA);
-
-            DeploymentDescriptor descriptor = StepsUtil.getDeploymentDescriptor(execution.getContext());
-            DeployedMta deployedMta = StepsUtil.getDeployedMta(execution.getContext());
-            ApplicationColor mtaColor;
-            ApplicationColor deployedMtaColor = null;
-            try {
-                deployedMtaColor = applicationColorDetector.detectSingularDeployedApplicationColor(deployedMta);
-                if (deployedMtaColor != null) {
-                    getStepLogger().info(Messages.DEPLOYED_MTA_COLOR, deployedMtaColor);
-                    mtaColor = deployedMtaColor.getAlternativeColor();
-                } else {
-                    mtaColor = DEFAULT_MTA_COLOR;
-                }
-            } catch (ConflictException e) {
-                getStepLogger().warn(e.getMessage());
-
-                ApplicationColor liveMtaColor = applicationColorDetector.detectLiveApplicationColor(deployedMta,
-                    (String) execution.getContext()
-                        .getVariable(Constants.VAR_CORRELATION_ID));
-                ApplicationColor idleMtaColor = liveMtaColor.getAlternativeColor();
-
-                getStepLogger().info(Messages.ASSUMED_LIVE_AND_IDLE_COLORS, liveMtaColor, idleMtaColor);
-                mtaColor = idleMtaColor;
+            deployedMtaColor = applicationColorDetector.detectSingularDeployedApplicationColor(deployedMta);
+            if (deployedMtaColor != null) {
+                getStepLogger().info(Messages.DEPLOYED_MTA_COLOR, deployedMtaColor);
+                mtaColor = deployedMtaColor.getAlternativeColor();
+            } else {
+                mtaColor = DEFAULT_MTA_COLOR;
             }
+        } catch (ConflictException e) {
+            getStepLogger().warn(e.getMessage());
 
-            StepsUtil.setDeployedMtaColor(execution.getContext(), deployedMtaColor);
-            StepsUtil.setMtaColor(execution.getContext(), mtaColor);
+            ApplicationColor liveMtaColor = applicationColorDetector.detectLiveApplicationColor(deployedMta, (String) execution.getContext()
+                .getVariable(Constants.VAR_CORRELATION_ID));
+            ApplicationColor idleMtaColor = liveMtaColor.getAlternativeColor();
 
-            getStepLogger().info(Messages.NEW_MTA_COLOR, mtaColor);
-
-            visit(execution, descriptor, mtaColor, deployedMtaColor);
-
-            return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_RENAMING_MODULES);
-            throw e;
+            getStepLogger().info(Messages.ASSUMED_LIVE_AND_IDLE_COLORS, liveMtaColor, idleMtaColor);
+            mtaColor = idleMtaColor;
         }
+
+        StepsUtil.setDeployedMtaColor(execution.getContext(), deployedMtaColor);
+        StepsUtil.setMtaColor(execution.getContext(), mtaColor);
+
+        getStepLogger().info(Messages.NEW_MTA_COLOR, mtaColor);
+
+        visit(execution, descriptor, mtaColor, deployedMtaColor);
+
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_RENAMING_MODULES);
+        throw e;
     }
 
     protected void visit(ExecutionWrapper execution, DeploymentDescriptor descriptor, ApplicationColor mtaColor,

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BuildCloudDeployModelStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BuildCloudDeployModelStep.java
@@ -34,7 +34,6 @@ import com.sap.cloud.lm.sl.cf.core.util.CloudModelBuilderUtil;
 import com.sap.cloud.lm.sl.cf.core.util.NameUtil;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.mta.handlers.v2.DescriptorHandler;
 import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
 import com.sap.cloud.lm.sl.mta.model.Module;
@@ -50,79 +49,79 @@ public class BuildCloudDeployModelStep extends SyncFlowableStep {
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
-        try {
-            getStepLogger().debug(Messages.BUILDING_CLOUD_MODEL);
-            DeploymentDescriptor deploymentDescriptor = StepsUtil.getCompleteDeploymentDescriptor(execution.getContext());
+        getStepLogger().debug(Messages.BUILDING_CLOUD_MODEL);
+        DeploymentDescriptor deploymentDescriptor = StepsUtil.getCompleteDeploymentDescriptor(execution.getContext());
 
-            // Get module sets:
-            DeployedMta deployedMta = StepsUtil.getDeployedMta(execution.getContext());
-            List<DeployedMtaModule> deployedModules = (deployedMta != null) ? deployedMta.getModules() : Collections.emptyList();
-            Set<String> mtaArchiveModules = StepsUtil.getMtaArchiveModules(execution.getContext());
-            getStepLogger().debug(Messages.MTA_ARCHIVE_MODULES, mtaArchiveModules);
-            Set<String> deployedModuleNames = CloudModelBuilderUtil.getDeployedModuleNames(deployedModules);
-            getStepLogger().debug(Messages.DEPLOYED_MODULES, deployedModuleNames);
-            Set<String> mtaModules = StepsUtil.getMtaModules(execution.getContext());
-            getStepLogger().debug(Messages.MTA_MODULES, mtaModules);
+        // Get module sets:
+        DeployedMta deployedMta = StepsUtil.getDeployedMta(execution.getContext());
+        List<DeployedMtaModule> deployedModules = (deployedMta != null) ? deployedMta.getModules() : Collections.emptyList();
+        Set<String> mtaArchiveModules = StepsUtil.getMtaArchiveModules(execution.getContext());
+        getStepLogger().debug(Messages.MTA_ARCHIVE_MODULES, mtaArchiveModules);
+        Set<String> deployedModuleNames = CloudModelBuilderUtil.getDeployedModuleNames(deployedModules);
+        getStepLogger().debug(Messages.DEPLOYED_MODULES, deployedModuleNames);
+        Set<String> mtaModules = StepsUtil.getMtaModules(execution.getContext());
+        getStepLogger().debug(Messages.MTA_MODULES, mtaModules);
 
-            StepsUtil.setNewMtaVersion(execution.getContext(), deploymentDescriptor.getVersion());
+        StepsUtil.setNewMtaVersion(execution.getContext(), deploymentDescriptor.getVersion());
 
-            // Build a map of service keys and save them in the context:
-            Map<String, List<CloudServiceKey>> serviceKeys = getServiceKeysCloudModelBuilder(execution.getContext()).build();
-            getStepLogger().debug(Messages.SERVICE_KEYS_TO_CREATE, secureSerializer.toJson(serviceKeys));
+        // Build a map of service keys and save them in the context:
+        Map<String, List<CloudServiceKey>> serviceKeys = getServiceKeysCloudModelBuilder(execution.getContext()).build();
+        getStepLogger().debug(Messages.SERVICE_KEYS_TO_CREATE, secureSerializer.toJson(serviceKeys));
 
-            StepsUtil.setServiceKeysToCreate(execution.getContext(), serviceKeys);
+        StepsUtil.setServiceKeysToCreate(execution.getContext(), serviceKeys);
 
-            // Build a list of applications for deployment and save them in the context:
-            List<Module> modulesCalculatedForDeployment = calculateModulesForDeployment(execution, deploymentDescriptor, mtaArchiveModules,
-                deployedModuleNames, mtaModules);
+        // Build a list of applications for deployment and save them in the context:
+        List<Module> modulesCalculatedForDeployment = calculateModulesForDeployment(execution, deploymentDescriptor, mtaArchiveModules,
+            deployedModuleNames, mtaModules);
 
-            getStepLogger().debug(Messages.MODULES_TO_DEPLOY, secureSerializer.toJson(modulesCalculatedForDeployment));
-            StepsUtil.setAllModulesToDeploy(execution.getContext(), modulesCalculatedForDeployment);
-            StepsUtil.setModulesToDeploy(execution.getContext(), modulesCalculatedForDeployment);
+        getStepLogger().debug(Messages.MODULES_TO_DEPLOY, secureSerializer.toJson(modulesCalculatedForDeployment));
+        StepsUtil.setAllModulesToDeploy(execution.getContext(), modulesCalculatedForDeployment);
+        StepsUtil.setModulesToDeploy(execution.getContext(), modulesCalculatedForDeployment);
 
-            ApplicationCloudModelBuilder applicationCloudModelBuilder = getApplicationCloudModelBuilder(execution.getContext());
+        ApplicationCloudModelBuilder applicationCloudModelBuilder = getApplicationCloudModelBuilder(execution.getContext());
 
-            StepsUtil.setAppsToDeploy(execution.getContext(), getAppNames(applicationCloudModelBuilder, modulesCalculatedForDeployment));
+        StepsUtil.setAppsToDeploy(execution.getContext(), getAppNames(applicationCloudModelBuilder, modulesCalculatedForDeployment));
 
-            StepsUtil.setDeploymentMode(execution.getContext(), applicationCloudModelBuilder.getDeploymentMode());
-            StepsUtil.setServiceKeysCredentialsToInject(execution.getContext(), new HashMap<>());
-            StepsUtil.setUseIdleUris(execution.getContext(), false);
+        StepsUtil.setDeploymentMode(execution.getContext(), applicationCloudModelBuilder.getDeploymentMode());
+        StepsUtil.setServiceKeysCredentialsToInject(execution.getContext(), new HashMap<>());
+        StepsUtil.setUseIdleUris(execution.getContext(), false);
 
-            // Build a list of custom domains and save them in the context:
-            List<String> customDomainsFromApps = StepsUtil.getDomainsFromApps(execution.getContext(), deploymentDescriptor,
-                applicationCloudModelBuilder, modulesCalculatedForDeployment, moduleToDeployHelper);
-            StepsUtil.setCustomDomains(execution.getContext(), customDomainsFromApps);
-            getStepLogger().debug(Messages.CUSTOM_DOMAINS, customDomainsFromApps);
+        // Build a list of custom domains and save them in the context:
+        List<String> customDomainsFromApps = StepsUtil.getDomainsFromApps(execution.getContext(), deploymentDescriptor,
+            applicationCloudModelBuilder, modulesCalculatedForDeployment, moduleToDeployHelper);
+        StepsUtil.setCustomDomains(execution.getContext(), customDomainsFromApps);
+        getStepLogger().debug(Messages.CUSTOM_DOMAINS, customDomainsFromApps);
 
-            ServicesCloudModelBuilder servicesCloudModelBuilder = getServicesCloudModelBuilder(execution.getContext());
+        ServicesCloudModelBuilder servicesCloudModelBuilder = getServicesCloudModelBuilder(execution.getContext());
 
-            List<Resource> resourcesUsedForBindings = calculateResourcesUsedForBindings(deploymentDescriptor,
-                modulesCalculatedForDeployment);
-            List<CloudServiceExtended> servicesForBindings = servicesCloudModelBuilder.build(resourcesUsedForBindings);
+        List<Resource> resourcesUsedForBindings = calculateResourcesUsedForBindings(deploymentDescriptor, modulesCalculatedForDeployment);
+        List<CloudServiceExtended> servicesForBindings = servicesCloudModelBuilder.build(resourcesUsedForBindings);
 
-            // Build a list of services for binding and save them in the context:
-            StepsUtil.setServicesToBind(execution.getContext(), servicesForBindings);
+        // Build a list of services for binding and save them in the context:
+        StepsUtil.setServicesToBind(execution.getContext(), servicesForBindings);
 
-            List<Resource> resourcesForDeployment = calculateResourcesForDeployment(execution, deploymentDescriptor);
-            List<CloudServiceExtended> servicesCalculatedForDeployment = servicesCloudModelBuilder.build(resourcesForDeployment);
+        List<Resource> resourcesForDeployment = calculateResourcesForDeployment(execution, deploymentDescriptor);
+        List<CloudServiceExtended> servicesCalculatedForDeployment = servicesCloudModelBuilder.build(resourcesForDeployment);
 
-            // Build a list of services for creation and save them in the context:
-            List<CloudServiceExtended> servicesToCreate = servicesCalculatedForDeployment.stream()
-                .filter(CloudServiceExtended::isManaged)
-                .collect(Collectors.toList());
-            getStepLogger().debug(Messages.SERVICES_TO_CREATE, secureSerializer.toJson(servicesToCreate));
-            StepsUtil.setServicesToCreate(execution.getContext(), servicesToCreate);
+        // Build a list of services for creation and save them in the context:
+        List<CloudServiceExtended> servicesToCreate = servicesCalculatedForDeployment.stream()
+            .filter(CloudServiceExtended::isManaged)
+            .collect(Collectors.toList());
+        getStepLogger().debug(Messages.SERVICES_TO_CREATE, secureSerializer.toJson(servicesToCreate));
+        StepsUtil.setServicesToCreate(execution.getContext(), servicesToCreate);
 
-            // Needed by CreateOrUpdateServicesStep, as it is used as an iteration variable:
-            execution.getContext()
-                .setVariable(Constants.VAR_SERVICES_TO_CREATE_COUNT, servicesToCreate.size());
+        // Needed by CreateOrUpdateServicesStep, as it is used as an iteration variable:
+        execution.getContext()
+            .setVariable(Constants.VAR_SERVICES_TO_CREATE_COUNT, servicesToCreate.size());
 
-            getStepLogger().debug(Messages.CLOUD_MODEL_BUILT);
-            return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_BUILDING_CLOUD_MODEL);
-            throw e;
-        }
+        getStepLogger().debug(Messages.CLOUD_MODEL_BUILT);
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_BUILDING_CLOUD_MODEL);
+        throw e;
     }
 
     private List<String> getAppNames(ApplicationCloudModelBuilder applicationCloudModelBuilder,

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BuildCloudUndeployModelStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BuildCloudUndeployModelStep.java
@@ -41,50 +41,50 @@ public class BuildCloudUndeployModelStep extends SyncFlowableStep {
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
         getStepLogger().debug(Messages.BUILDING_CLOUD_UNDEPLOY_MODEL);
-        try {
-            DeployedMta deployedMta = StepsUtil.getDeployedMta(execution.getContext());
+        DeployedMta deployedMta = StepsUtil.getDeployedMta(execution.getContext());
 
-            List<String> deploymentDescriptorModules = getDeploymentDescriptorModules(execution.getContext());
+        List<String> deploymentDescriptorModules = getDeploymentDescriptorModules(execution.getContext());
 
-            if (deployedMta == null) {
-                setComponentsToUndeploy(execution.getContext(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-                return StepPhase.DONE;
-            }
-
-            List<ConfigurationSubscription> subscriptionsToCreate = StepsUtil.getSubscriptionsToCreate(execution.getContext());
-            Set<String> mtaModules = StepsUtil.getMtaModules(execution.getContext());
-            List<String> appNames = StepsUtil.getAppsToDeploy(execution.getContext());
-            List<CloudApplication> deployedApps = StepsUtil.getDeployedApps(execution.getContext());
-
-            getStepLogger().debug(Messages.MTA_MODULES, mtaModules);
-
-            List<DeployedMtaModule> modulesToUndeploy = computeModulesToUndeploy(deployedMta, mtaModules, appNames,
-                deploymentDescriptorModules);
-            getStepLogger().debug(Messages.MODULES_TO_UNDEPLOY, secureSerializer.toJson(modulesToUndeploy));
-
-            List<DeployedMtaModule> modulesWithoutChange = computeModulesWithoutChange(modulesToUndeploy, mtaModules, deployedMta);
-            getStepLogger().debug(Messages.MODULES_NOT_TO_BE_CHANGED, secureSerializer.toJson(modulesWithoutChange));
-
-            List<ConfigurationSubscription> subscriptionsToDelete = computeSubscriptionsToDelete(subscriptionsToCreate, deployedMta,
-                StepsUtil.getSpaceId(execution.getContext()));
-            getStepLogger().debug(Messages.SUBSCRIPTIONS_TO_DELETE, secureSerializer.toJson(subscriptionsToDelete));
-
-            Set<String> servicesForApplications = getServicesForApplications(execution.getContext());
-            List<String> servicesToDelete = computeServicesToDelete(modulesWithoutChange, deployedMta.getServices(),
-                servicesForApplications);
-            getStepLogger().debug(Messages.SERVICES_TO_DELETE, servicesToDelete);
-
-            List<CloudApplication> appsToUndeploy = computeAppsToUndeploy(modulesToUndeploy, deployedApps);
-            getStepLogger().debug(Messages.APPS_TO_UNDEPLOY, secureSerializer.toJson(appsToUndeploy));
-
-            setComponentsToUndeploy(execution.getContext(), servicesToDelete, appsToUndeploy, subscriptionsToDelete);
-
-            getStepLogger().debug(Messages.CLOUD_UNDEPLOY_MODEL_BUILT);
+        if (deployedMta == null) {
+            setComponentsToUndeploy(execution.getContext(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
             return StepPhase.DONE;
-        } catch (Exception e) {
-            getStepLogger().error(e, Messages.ERROR_BUILDING_CLOUD_UNDEPLOY_MODEL);
-            throw e;
         }
+
+        List<ConfigurationSubscription> subscriptionsToCreate = StepsUtil.getSubscriptionsToCreate(execution.getContext());
+        Set<String> mtaModules = StepsUtil.getMtaModules(execution.getContext());
+        List<String> appNames = StepsUtil.getAppsToDeploy(execution.getContext());
+        List<CloudApplication> deployedApps = StepsUtil.getDeployedApps(execution.getContext());
+
+        getStepLogger().debug(Messages.MTA_MODULES, mtaModules);
+
+        List<DeployedMtaModule> modulesToUndeploy = computeModulesToUndeploy(deployedMta, mtaModules, appNames,
+            deploymentDescriptorModules);
+        getStepLogger().debug(Messages.MODULES_TO_UNDEPLOY, secureSerializer.toJson(modulesToUndeploy));
+
+        List<DeployedMtaModule> modulesWithoutChange = computeModulesWithoutChange(modulesToUndeploy, mtaModules, deployedMta);
+        getStepLogger().debug(Messages.MODULES_NOT_TO_BE_CHANGED, secureSerializer.toJson(modulesWithoutChange));
+
+        List<ConfigurationSubscription> subscriptionsToDelete = computeSubscriptionsToDelete(subscriptionsToCreate, deployedMta,
+            StepsUtil.getSpaceId(execution.getContext()));
+        getStepLogger().debug(Messages.SUBSCRIPTIONS_TO_DELETE, secureSerializer.toJson(subscriptionsToDelete));
+
+        Set<String> servicesForApplications = getServicesForApplications(execution.getContext());
+        List<String> servicesToDelete = computeServicesToDelete(modulesWithoutChange, deployedMta.getServices(), servicesForApplications);
+        getStepLogger().debug(Messages.SERVICES_TO_DELETE, servicesToDelete);
+
+        List<CloudApplication> appsToUndeploy = computeAppsToUndeploy(modulesToUndeploy, deployedApps);
+        getStepLogger().debug(Messages.APPS_TO_UNDEPLOY, secureSerializer.toJson(appsToUndeploy));
+
+        setComponentsToUndeploy(execution.getContext(), servicesToDelete, appsToUndeploy, subscriptionsToDelete);
+
+        getStepLogger().debug(Messages.CLOUD_UNDEPLOY_MODEL_BUILT);
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_BUILDING_CLOUD_UNDEPLOY_MODEL);
+        throw e;
     }
 
     private List<String> getDeploymentDescriptorModules(DelegateExecution context) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CheckForCreationConflictsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CheckForCreationConflictsStep.java
@@ -69,6 +69,12 @@ public class CheckForCreationConflictsStep extends SyncFlowableStep {
 
         return StepPhase.DONE;
     }
+    
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_VALIDATING_APPLICATIONS);
+        throw e;
+    }
 
     private void validateServicesToCreate(CloudControllerClient client, DelegateExecution context, DeployedMta deployedMta,
         List<CloudApplication> deployedApps) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ComputeNextModulesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ComputeNextModulesStep.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.ListUtils;
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -45,6 +46,12 @@ public class ComputeNextModulesStep extends SyncFlowableStep {
         return StepPhase.DONE;
     }
 
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_COMPUTING_NEXT_MODULES_FOR_PARALLEL_ITERATION);
+        throw e;
+    }
+
     private List<Module> computeApplicationsForNextIteration(List<Module> allModulesToDeploy, ModuleDependencyChecker dependencyChecker) {
         allModulesToDeploy.removeIf(module -> dependencyChecker.getAlreadyDeployedModules()
             .contains(module.getName()));
@@ -53,4 +60,5 @@ public class ComputeNextModulesStep extends SyncFlowableStep {
             .filter(dependencyChecker::areAllDependenciesSatisfied)
             .collect(Collectors.toList());
     }
+
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
@@ -18,7 +18,6 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.cloudfoundry.client.lib.ApplicationServicesUpdateCallback;
 import org.cloudfoundry.client.lib.CloudControllerClient;
-import org.cloudfoundry.client.lib.CloudControllerException;
 import org.cloudfoundry.client.lib.CloudOperationException;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
 import org.flowable.engine.delegate.DelegateExecution;
@@ -70,31 +69,29 @@ public class CreateOrUpdateAppStep extends SyncFlowableStep {
     protected StepPhase executeStep(ExecutionWrapper execution) throws FileStorageException {
         CloudApplicationExtended app = StepsUtil.getApp(execution.getContext());
 
-        try {
-            CloudControllerClient client = execution.getControllerClient();
-            CloudApplication existingApp = client.getApplication(app.getName(), false);
-            StepsUtil.setExistingApp(execution.getContext(), existingApp);
+        CloudControllerClient client = execution.getControllerClient();
+        CloudApplication existingApp = client.getApplication(app.getName(), false);
+        StepsUtil.setExistingApp(execution.getContext(), existingApp);
 
-            StepFlowHandler flowHandler = createStepFlowHandler(execution, client, app, existingApp);
+        StepFlowHandler flowHandler = createStepFlowHandler(execution, client, app, existingApp);
 
-            flowHandler.printStepStartMessage();
+        flowHandler.printStepStartMessage();
 
-            flowHandler.handleApplicationAttributes();
-            flowHandler.injectServiceKeysCredentialsInAppEnv();
-            flowHandler.handleApplicationServices();
-            flowHandler.handleApplicationEnv();
+        flowHandler.handleApplicationAttributes();
+        flowHandler.injectServiceKeysCredentialsInAppEnv();
+        flowHandler.handleApplicationServices();
+        flowHandler.handleApplicationEnv();
 
-            flowHandler.printStepEndMessage();
+        flowHandler.printStepEndMessage();
 
-            return StepPhase.DONE;
-        } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_CREATING_OR_UPDATING_APP, app.getName());
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_CREATING_OR_UPDATING_APP, app.getName());
-            throw e;
-        }
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_CREATING_OR_UPDATING_APP, StepsUtil.getApp(context)
+            .getName());
+        throw e;
     }
 
     private StepFlowHandler createStepFlowHandler(ExecutionWrapper execution, CloudControllerClient client, CloudApplicationExtended app,

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateServiceStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateServiceStep.java
@@ -21,7 +21,6 @@ import com.sap.cloud.lm.sl.cf.core.exec.MethodExecution;
 import com.sap.cloud.lm.sl.cf.core.exec.MethodExecution.ExecutionState;
 import com.sap.cloud.lm.sl.cf.persistence.services.FileStorageException;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("createServiceStep")
 public class CreateServiceStep extends ServiceStep {
@@ -31,11 +30,12 @@ public class CreateServiceStep extends ServiceStep {
 
     @Override
     protected MethodExecution<String> executeOperation(DelegateExecution execution, CloudControllerClient controllerClient,
-        CloudServiceExtended service) {
+        CloudServiceExtended service) throws FileStorageException {
         return createService(execution, controllerClient, service);
     }
 
-    private MethodExecution<String> createService(DelegateExecution context, CloudControllerClient client, CloudServiceExtended service) {
+    private MethodExecution<String> createService(DelegateExecution context, CloudControllerClient client, CloudServiceExtended service)
+        throws FileStorageException {
         getStepLogger().info(Messages.CREATING_SERVICE_FROM_MTA_RESOURCE, service.getName(), service.getResourceName());
 
         try {
@@ -44,8 +44,6 @@ public class CreateServiceStep extends ServiceStep {
             return createServiceMethodExecution;
         } catch (CloudOperationException e) {
             processServiceCreationFailure(service, e);
-        } catch (FileStorageException e) {
-            throw new SLException(e, e.getMessage());
         }
 
         return new MethodExecution<>(null, ExecutionState.FINISHED);
@@ -70,6 +68,7 @@ public class CreateServiceStep extends ServiceStep {
         if (!service.isOptional()) {
             String detailedDescription = MessageFormat.format(Messages.ERROR_CREATING_SERVICE, service.getName(), service.getLabel(),
                 service.getPlan(), e.getDescription());
+//            getStepLogger().error(e, detailedDescription);
             if (e.getStatusCode() == HttpStatus.BAD_GATEWAY) {
                 throw new CloudServiceBrokerException(e.getStatusCode(), e.getStatusText(), detailedDescription);
             }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateSubscriptionsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateSubscriptionsStep.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,6 @@ import com.sap.cloud.lm.sl.cf.core.dao.ConfigurationSubscriptionDao;
 import com.sap.cloud.lm.sl.cf.core.model.ConfigurationSubscription;
 import com.sap.cloud.lm.sl.cf.core.model.ConfigurationSubscription.ResourceDto;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("createSubscriptionsStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -24,22 +24,23 @@ public class CreateSubscriptionsStep extends SyncFlowableStep {
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
-        try {
-            getStepLogger().debug(Messages.CREATING_SUBSCRIPTIONS);
+        getStepLogger().debug(Messages.CREATING_SUBSCRIPTIONS);
 
-            List<ConfigurationSubscription> subscriptions = StepsUtil.getSubscriptionsToCreate(execution.getContext());
+        List<ConfigurationSubscription> subscriptions = StepsUtil.getSubscriptionsToCreate(execution.getContext());
 
-            for (ConfigurationSubscription subscription : subscriptions) {
-                createSubscription(subscription);
-                getStepLogger().debug(Messages.CREATED_SUBSCRIPTION, subscription.getId());
-            }
-
-            getStepLogger().debug(Messages.SUBSCRIPTIONS_CREATED);
-            return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_CREATING_SUBSCRIPTIONS);
-            throw e;
+        for (ConfigurationSubscription subscription : subscriptions) {
+            createSubscription(subscription);
+            getStepLogger().debug(Messages.CREATED_SUBSCRIPTION, subscription.getId());
         }
+
+        getStepLogger().debug(Messages.SUBSCRIPTIONS_CREATED);
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_CREATING_SUBSCRIPTIONS);
+        throw e;
     }
 
     private ConfigurationSubscription detectSubscription(String mtaId, String applicationName, String spaceId, String resourceName) {
@@ -69,7 +70,7 @@ public class CreateSubscriptionsStep extends SyncFlowableStep {
         }
         dao.add(subscription);
     }
-    
+
     private void infoSubscriptionCreation(ConfigurationSubscription subscription) {
         if (subscription.getModuleDto() != null && subscription.getResourceDto() != null) {
             getStepLogger().info(MessageFormat.format(Messages.CREATING_SUBSCRIPTION_FROM_0_MODULE_TO_1_RESOURCE,

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteDiscontinuedConfigurationEntriesForAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteDiscontinuedConfigurationEntriesForAppStep.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -64,6 +65,11 @@ public class DeleteDiscontinuedConfigurationEntriesForAppStep extends SyncFlowab
 
         getStepLogger().debug(Messages.DISCONTINUED_CONFIGURATION_ENTRIES_FOR_APP_DELETED, existingApp.getName());
         return StepPhase.DONE;
+    }
+    
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        throw e;
     }
 
     private List<ConfigurationEntry> getEntriesToDelete(String mtaId, String mtaVersion, CloudTarget target,

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteDiscontinuedConfigurationEntriesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteDiscontinuedConfigurationEntriesStep.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -55,6 +56,11 @@ public class DeleteDiscontinuedConfigurationEntriesStep extends SyncFlowableStep
 
         getStepLogger().debug(Messages.PUBLISHED_DEPENDENCIES_DELETED);
         return StepPhase.DONE;
+    }
+    
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        throw e;
     }
 
     private List<ConfigurationEntry> getEntriesToDelete(String mtaId, CloudTarget target, List<ConfigurationEntry> publishedEntries) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteIdleRoutesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteIdleRoutesStep.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 import org.apache.commons.collections4.ListUtils;
 import org.cloudfoundry.client.lib.CloudControllerClient;
-import org.cloudfoundry.client.lib.CloudControllerException;
 import org.cloudfoundry.client.lib.CloudOperationException;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
@@ -21,33 +21,33 @@ public class DeleteIdleRoutesStep extends SyncFlowableStep {
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
-        try {
-            boolean deleteIdleRoutes = StepsUtil.getDeleteIdleUris(execution.getContext());
-            CloudApplication existingApp = StepsUtil.getExistingApp(execution.getContext());
-            if (!deleteIdleRoutes || existingApp == null) {
-                return StepPhase.DONE;
-            }
-
-            getStepLogger().debug(Messages.DELETING_IDLE_URIS);
-            CloudControllerClient client = execution.getControllerClient();
-
-            CloudApplication app = StepsUtil.getApp(execution.getContext());
-
-            List<String> idleUris = ListUtils.subtract(existingApp.getUris(), app.getUris());
-            getStepLogger().debug(Messages.IDLE_URIS_FOR_APPLICATION, idleUris);
-
-            for (String idleUri : idleUris) {
-                deleteRoute(idleUri, client);
-                getStepLogger().debug(Messages.ROUTE_DELETED, idleUri);
-            }
-
-            getStepLogger().debug(Messages.IDLE_URIS_DELETED);
+        boolean deleteIdleRoutes = StepsUtil.getDeleteIdleUris(execution.getContext());
+        CloudApplication existingApp = StepsUtil.getExistingApp(execution.getContext());
+        if (!deleteIdleRoutes || existingApp == null) {
             return StepPhase.DONE;
-        } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_DELETING_IDLE_ROUTES);
-            throw e;
         }
+
+        getStepLogger().debug(Messages.DELETING_IDLE_URIS);
+        CloudControllerClient client = execution.getControllerClient();
+
+        CloudApplication app = StepsUtil.getApp(execution.getContext());
+
+        List<String> idleUris = ListUtils.subtract(existingApp.getUris(), app.getUris());
+        getStepLogger().debug(Messages.IDLE_URIS_FOR_APPLICATION, idleUris);
+
+        for (String idleUri : idleUris) {
+            deleteRoute(idleUri, client);
+            getStepLogger().debug(Messages.ROUTE_DELETED, idleUri);
+        }
+
+        getStepLogger().debug(Messages.IDLE_URIS_DELETED);
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_DELETING_IDLE_ROUTES);
+        throw e;
     }
 
     private void deleteRoute(String uri, CloudControllerClient client) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServiceBrokersStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServiceBrokersStep.java
@@ -4,7 +4,6 @@ import java.text.MessageFormat;
 import java.util.List;
 
 import org.cloudfoundry.client.lib.CloudControllerClient;
-import org.cloudfoundry.client.lib.CloudControllerException;
 import org.cloudfoundry.client.lib.CloudOperationException;
 import org.cloudfoundry.client.lib.CloudServiceBrokerException;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
@@ -18,7 +17,6 @@ import com.sap.cloud.lm.sl.cf.core.helpers.ApplicationAttributes;
 import com.sap.cloud.lm.sl.cf.core.model.SupportedParameters;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("deleteServiceBrokersStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -26,27 +24,24 @@ public class DeleteServiceBrokersStep extends SyncFlowableStep {
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
-        try {
-            getStepLogger().debug(Messages.DELETING_SERVICE_BROKERS);
+        getStepLogger().debug(Messages.DELETING_SERVICE_BROKERS);
 
-            List<CloudApplication> appsToUndeploy = StepsUtil.getAppsToUndeploy(execution.getContext());
-            CloudControllerClient client = execution.getControllerClient();
-            List<String> createdOrUpdatedServiceBrokers = getCreatedOrUpdatedServiceBrokerNames(execution.getContext());
+        List<CloudApplication> appsToUndeploy = StepsUtil.getAppsToUndeploy(execution.getContext());
+        CloudControllerClient client = execution.getControllerClient();
+        List<String> createdOrUpdatedServiceBrokers = getCreatedOrUpdatedServiceBrokerNames(execution.getContext());
 
-            for (CloudApplication app : appsToUndeploy) {
-                deleteServiceBrokerIfNecessary(execution.getContext(), app, createdOrUpdatedServiceBrokers, client);
-            }
-
-            getStepLogger().debug(Messages.SERVICE_BROKERS_DELETED);
-            return StepPhase.DONE;
-        } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_DELETING_SERVICE_BROKERS);
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_DELETING_SERVICE_BROKERS);
-            throw e;
+        for (CloudApplication app : appsToUndeploy) {
+            deleteServiceBrokerIfNecessary(execution.getContext(), app, createdOrUpdatedServiceBrokers, client);
         }
+
+        getStepLogger().debug(Messages.SERVICE_BROKERS_DELETED);
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_DELETING_SERVICE_BROKERS);
+        throw e;
     }
 
     protected List<String> getCreatedOrUpdatedServiceBrokerNames(DelegateExecution context) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
@@ -22,6 +22,7 @@ import org.cloudfoundry.client.lib.domain.CloudService;
 import org.cloudfoundry.client.lib.domain.CloudServiceBinding;
 import org.cloudfoundry.client.lib.domain.CloudServiceInstance;
 import org.cloudfoundry.client.lib.domain.CloudServiceKey;
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
@@ -47,39 +48,40 @@ public class DeleteServicesStep extends AsyncFlowableStep {
 
     @Override
     protected StepPhase executeAsyncStep(ExecutionWrapper execution) throws Exception {
-        try {
-            getStepLogger().debug(Messages.DELETING_SERVICES);
+        getStepLogger().debug(Messages.DELETING_SERVICES);
 
-            CloudControllerClient client = execution.getControllerClient();
+        CloudControllerClient client = execution.getControllerClient();
 
-            List<String> servicesToDelete = new ArrayList<>(StepsUtil.getServicesToDelete(execution.getContext()));
+        List<String> servicesToDelete = new ArrayList<>(StepsUtil.getServicesToDelete(execution.getContext()));
 
-            if (servicesToDelete.isEmpty()) {
-                getStepLogger().debug(Messages.MISSING_SERVICES_TO_DELETE);
-                return StepPhase.DONE;
-            }
-
-            Map<String, CloudServiceExtended> servicesData = getServicesData(servicesToDelete, execution);
-            List<String> servicesWithoutData = getServicesWithoutData(servicesToDelete, servicesData);
-            if (!servicesWithoutData.isEmpty()) {
-                execution.getStepLogger()
-                    .info(Messages.SERVICES_ARE_ALREADY_DELETED, servicesWithoutData);
-                servicesToDelete.removeAll(servicesWithoutData);
-            }
-            StepsUtil.setServicesData(execution.getContext(), servicesData);
-
-            Map<String, ServiceOperationType> triggeredServiceOperations = deleteServices(client, servicesToDelete);
-
-            execution.getStepLogger()
-                .debug(Messages.TRIGGERED_SERVICE_OPERATIONS, JsonUtil.toJson(triggeredServiceOperations, true));
-            StepsUtil.setTriggeredServiceOperations(execution.getContext(), triggeredServiceOperations);
-
-            getStepLogger().debug(Messages.SERVICES_DELETED);
-            return StepPhase.POLL;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_DELETING_SERVICES);
-            throw e;
+        if (servicesToDelete.isEmpty()) {
+            getStepLogger().debug(Messages.MISSING_SERVICES_TO_DELETE);
+            return StepPhase.DONE;
         }
+
+        Map<String, CloudServiceExtended> servicesData = getServicesData(servicesToDelete, execution);
+        List<String> servicesWithoutData = getServicesWithoutData(servicesToDelete, servicesData);
+        if (!servicesWithoutData.isEmpty()) {
+            execution.getStepLogger()
+                .info(Messages.SERVICES_ARE_ALREADY_DELETED, servicesWithoutData);
+            servicesToDelete.removeAll(servicesWithoutData);
+        }
+        StepsUtil.setServicesData(execution.getContext(), servicesData);
+
+        Map<String, ServiceOperationType> triggeredServiceOperations = deleteServices(client, servicesToDelete);
+
+        execution.getStepLogger()
+            .debug(Messages.TRIGGERED_SERVICE_OPERATIONS, JsonUtil.toJson(triggeredServiceOperations, true));
+        StepsUtil.setTriggeredServiceOperations(execution.getContext(), triggeredServiceOperations);
+
+        getStepLogger().debug(Messages.SERVICES_DELETED);
+        return StepPhase.POLL;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_DELETING_SERVICES);
+        throw e;
     }
 
     private Map<String, CloudServiceExtended> getServicesData(List<String> serviceNames, ExecutionWrapper execution) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteSubscriptionsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteSubscriptionsStep.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -41,6 +42,12 @@ public class DeleteSubscriptionsStep extends SyncFlowableStep {
 
         getStepLogger().debug(Messages.DELETED_SUBSCRIPTIONS);
         return StepPhase.DONE;
+    }
+    
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_DELETING_SUBSCRIPTIONS);
+        throw e;
     }
 
     private void infoSubscriptionDeletion(ConfigurationSubscription subscription) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
@@ -78,6 +78,11 @@ public class DetermineServiceCreateUpdateServiceActionsStep extends SyncFlowable
         StepsUtil.setServiceToProcessName(serviceToProcess.getName(), execution.getContext());
         return StepPhase.DONE;
     }
+    
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        throw e;
+    }
 
     private void setServiceParameters(CloudServiceExtended service, List<ServiceAction> actions, DelegateExecution delegateExecution)
         throws FileStorageException {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineTasksFromHookStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineTasksFromHookStep.java
@@ -3,6 +3,7 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 import java.util.Arrays;
 
 import org.cloudfoundry.client.lib.domain.CloudTask;
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -27,6 +28,11 @@ public class DetermineTasksFromHookStep extends SyncFlowableStep {
         StepsUtil.setTasksToExecute(execution.getContext(), Arrays.asList(task));
 
         return StepPhase.DONE;
+    }
+    
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        throw e;
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/IncrementIndexStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/IncrementIndexStep.java
@@ -1,5 +1,6 @@
 package com.sap.cloud.lm.sl.cf.process.steps;
 
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,11 @@ public class IncrementIndexStep extends SyncFlowableStep {
         StepsUtil.incrementVariable(execution.getContext(), indexVariableName);
 
         return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        throw e;
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/MergeDescriptorsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/MergeDescriptorsStep.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -12,7 +13,6 @@ import com.sap.cloud.lm.sl.cf.core.cf.HandlerFactory;
 import com.sap.cloud.lm.sl.cf.core.helpers.MtaDescriptorMerger;
 import com.sap.cloud.lm.sl.cf.core.util.ApplicationConfiguration;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
 import com.sap.cloud.lm.sl.mta.model.ExtensionDescriptor;
 import com.sap.cloud.lm.sl.mta.model.Platform;
@@ -31,23 +31,23 @@ public class MergeDescriptorsStep extends SyncFlowableStep {
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
         getStepLogger().debug(Messages.MERGING_DESCRIPTORS);
-        try {
-            DeploymentDescriptor deploymentDescriptor = StepsUtil.getDeploymentDescriptor(execution.getContext());
-            List<ExtensionDescriptor> extensionDescriptors = StepsUtil.getExtensionDescriptorChain(execution.getContext());
+        DeploymentDescriptor deploymentDescriptor = StepsUtil.getDeploymentDescriptor(execution.getContext());
+        List<ExtensionDescriptor> extensionDescriptors = StepsUtil.getExtensionDescriptorChain(execution.getContext());
 
-            HandlerFactory handlerFactory = StepsUtil.getHandlerFactory(execution.getContext());
-            Platform platform = configuration.getPlatform();
-            DeploymentDescriptor descriptor = getMtaDescriptorMerger(handlerFactory, platform).merge(deploymentDescriptor,
-                extensionDescriptors);
+        HandlerFactory handlerFactory = StepsUtil.getHandlerFactory(execution.getContext());
+        Platform platform = configuration.getPlatform();
+        DeploymentDescriptor descriptor = getMtaDescriptorMerger(handlerFactory, platform).merge(deploymentDescriptor,
+            extensionDescriptors);
 
-            StepsUtil.setDeploymentDescriptor(execution.getContext(), descriptor);
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_MERGING_DESCRIPTORS);
-            throw e;
-        }
+        StepsUtil.setDeploymentDescriptor(execution.getContext(), descriptor);
         getStepLogger().debug(Messages.DESCRIPTORS_MERGED);
 
         return StepPhase.DONE;
     }
 
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_MERGING_DESCRIPTORS);
+        throw e;
+    }
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollExecuteAppStatusExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollExecuteAppStatusExecution.java
@@ -52,23 +52,22 @@ public class PollExecuteAppStatusExecution implements AsyncExecution {
         if (!actions.contains(ApplicationStateAction.EXECUTE)) {
             return AsyncExecutionState.FINISHED;
         }
-        try {
-            CloudControllerClient client = execution.getControllerClient();
-            ApplicationAttributes appAttributes = ApplicationAttributes.fromApplication(app);
-            Pair<AppExecutionStatus, String> status = getAppExecutionStatus(execution.getContext(), client, appAttributes, app);
-            ProcessLoggerProvider processLoggerProvider = execution.getStepLogger().getProcessLoggerProvider();
-            StepsUtil.saveAppLogs(execution.getContext(), client, recentLogsRetriever, app, LOGGER, processLoggerProvider);
-            return checkAppExecutionStatus(execution, client, app, appAttributes, status);
-        } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            execution.getStepLogger()
-                .error(e, Messages.ERROR_EXECUTING_APP_1, app.getName());
-            throw e;
-        } catch (SLException e) {
-            execution.getStepLogger()
-                .error(e, Messages.ERROR_EXECUTING_APP_1, app.getName());
-            throw e;
-        }
+        CloudControllerClient client = execution.getControllerClient();
+        ApplicationAttributes appAttributes = ApplicationAttributes.fromApplication(app);
+        Pair<AppExecutionStatus, String> status = getAppExecutionStatus(execution.getContext(), client, appAttributes, app);
+        ProcessLoggerProvider processLoggerProvider = execution.getStepLogger()
+            .getProcessLoggerProvider();
+        StepsUtil.saveAppLogs(execution.getContext(), client, recentLogsRetriever, app, LOGGER, processLoggerProvider);
+        return checkAppExecutionStatus(execution, client, app, appAttributes, status);
+
+    }
+
+    @Override
+    public void onPollingError(ExecutionWrapper execution, Exception e) throws Exception {
+        CloudApplication app = getNextApp(execution.getContext());
+        execution.getStepLogger()
+            .error(e, Messages.ERROR_EXECUTING_APP_1, app.getName());
+        throw e;
     }
 
     protected CloudApplication getNextApp(DelegateExecution context) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceCreateOrUpdateOperationsExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceCreateOrUpdateOperationsExecution.java
@@ -84,4 +84,6 @@ public class PollServiceCreateOrUpdateOperationsExecution extends PollServiceOpe
         }
         return new ServiceOperation(type, description, state);
     }
+
+
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceDeleteOperationsExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceDeleteOperationsExecution.java
@@ -55,4 +55,5 @@ public class PollServiceDeleteOperationsExecution extends PollServiceOperationsE
             .filter(Objects::nonNull)
             .anyMatch(e -> eventsGetter.isDeleteEvent(e.getType()));
     }
+
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceOperationsExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollServiceOperationsExecution.java
@@ -14,8 +14,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.cloudfoundry.client.lib.CloudControllerClient;
-import org.cloudfoundry.client.lib.CloudControllerException;
-import org.cloudfoundry.client.lib.CloudOperationException;
 
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudServiceExtended;
 import com.sap.cloud.lm.sl.cf.core.cf.services.ServiceOperation;
@@ -30,48 +28,44 @@ public abstract class PollServiceOperationsExecution implements AsyncExecution {
 
     @Override
     public AsyncExecutionState execute(ExecutionWrapper execution) {
-        try {
-            execution.getStepLogger()
-                .debug(Messages.POLLING_SERVICE_OPERATIONS);
+        execution.getStepLogger()
+            .debug(Messages.POLLING_SERVICE_OPERATIONS);
 
-            CloudControllerClient client = execution.getControllerClient();
+        CloudControllerClient client = execution.getControllerClient();
 
-            Map<String, ServiceOperationType> triggeredServiceOperations = StepsUtil.getTriggeredServiceOperations(execution.getContext());
-            List<CloudServiceExtended> servicesToPoll = getServiceOperationsToPoll(execution, triggeredServiceOperations);
-            if (CollectionUtils.isEmpty(servicesToPoll)) {
-                return AsyncExecutionState.FINISHED;
-            }
-
-            Map<CloudServiceExtended, ServiceOperation> servicesWithLastOperation = new HashMap<>();
-            for (CloudServiceExtended service : servicesToPoll) {
-                ServiceOperation lastServiceOperation = getLastServiceOperation(execution, client, service);
-                if (lastServiceOperation != null) {
-                    servicesWithLastOperation.put(service, lastServiceOperation);
-                }
-                execution.getStepLogger()
-                    .debug(Messages.LAST_OPERATION_FOR_SERVICE, service.getName(), JsonUtil.toJson(lastServiceOperation, true));
-            }
-            reportIndividualServiceState(execution, servicesWithLastOperation);
-            reportServiceOperationsState(execution, servicesWithLastOperation, triggeredServiceOperations);
-            List<CloudServiceExtended> remainingServicesToPoll = getRemainingServicesToPoll(servicesWithLastOperation);
-            execution.getStepLogger()
-                .debug(Messages.REMAINING_SERVICES_TO_POLL, JsonUtil.toJson(remainingServicesToPoll, true));
-            StepsUtil.setServicesToPoll(execution.getContext(), remainingServicesToPoll);
-
-            if (remainingServicesToPoll.isEmpty()) {
-                return AsyncExecutionState.FINISHED;
-            }
-            return AsyncExecutionState.RUNNING;
-        } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            execution.getStepLogger()
-                .error(e, Messages.ERROR_MONITORING_CREATION_OF_SERVICES);
-            throw e;
-        } catch (SLException e) {
-            execution.getStepLogger()
-                .error(e, Messages.ERROR_MONITORING_CREATION_OF_SERVICES);
-            throw e;
+        Map<String, ServiceOperationType> triggeredServiceOperations = StepsUtil.getTriggeredServiceOperations(execution.getContext());
+        List<CloudServiceExtended> servicesToPoll = getServiceOperationsToPoll(execution, triggeredServiceOperations);
+        if (CollectionUtils.isEmpty(servicesToPoll)) {
+            return AsyncExecutionState.FINISHED;
         }
+
+        Map<CloudServiceExtended, ServiceOperation> servicesWithLastOperation = new HashMap<>();
+        for (CloudServiceExtended service : servicesToPoll) {
+            ServiceOperation lastServiceOperation = getLastServiceOperation(execution, client, service);
+            if (lastServiceOperation != null) {
+                servicesWithLastOperation.put(service, lastServiceOperation);
+            }
+            execution.getStepLogger()
+                .debug(Messages.LAST_OPERATION_FOR_SERVICE, service.getName(), JsonUtil.toJson(lastServiceOperation, true));
+        }
+        reportIndividualServiceState(execution, servicesWithLastOperation);
+        reportServiceOperationsState(execution, servicesWithLastOperation, triggeredServiceOperations);
+        List<CloudServiceExtended> remainingServicesToPoll = getRemainingServicesToPoll(servicesWithLastOperation);
+        execution.getStepLogger()
+            .debug(Messages.REMAINING_SERVICES_TO_POLL, JsonUtil.toJson(remainingServicesToPoll, true));
+        StepsUtil.setServicesToPoll(execution.getContext(), remainingServicesToPoll);
+
+        if (remainingServicesToPoll.isEmpty()) {
+            return AsyncExecutionState.FINISHED;
+        }
+        return AsyncExecutionState.RUNNING;
+    }
+
+    @Override
+    public void onPollingError(ExecutionWrapper execution, Exception e) throws Exception {
+        execution.getStepLogger()
+            .error(e, Messages.ERROR_MONITORING_CREATION_OF_SERVICES);
+        throw e;
     }
 
     protected List<CloudServiceExtended> getServiceOperationsToPoll(ExecutionWrapper execution,

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollStartServiceBrokerSubscriberStatusExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollStartServiceBrokerSubscriberStatusExecution.java
@@ -1,9 +1,12 @@
 package com.sap.cloud.lm.sl.cf.process.steps;
 
+import static java.text.MessageFormat.format;
+
 import org.cloudfoundry.client.lib.domain.CloudApplication;
 import org.flowable.engine.delegate.DelegateExecution;
 
 import com.sap.cloud.lm.sl.cf.core.cf.clients.RecentLogsRetriever;
+import com.sap.cloud.lm.sl.cf.process.message.Messages;
 
 public class PollStartServiceBrokerSubscriberStatusExecution extends PollStartAppStatusExecution {
 
@@ -12,9 +15,11 @@ public class PollStartServiceBrokerSubscriberStatusExecution extends PollStartAp
     }
 
     @Override
-    protected void onError(ExecutionWrapper execution, String message, Exception e) {
+    public void onPollingError(ExecutionWrapper execution, Exception e) throws Exception {
+        String appToPoll = getAppToPoll(execution.getContext()).getName();
         execution.getStepLogger()
-            .warn(e, message);
+            .warn(e, format(Messages.ERROR_STARTING_APP_1, appToPoll));
+        throw e;
     }
 
     @Override

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollUploadAppStatusExecution.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PollUploadAppStatusExecution.java
@@ -3,14 +3,11 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 import static java.text.MessageFormat.format;
 
 import org.cloudfoundry.client.lib.CloudControllerClient;
-import org.cloudfoundry.client.lib.CloudControllerException;
-import org.cloudfoundry.client.lib.CloudOperationException;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
 import org.cloudfoundry.client.lib.domain.Upload;
 import org.cloudfoundry.client.lib.domain.UploadToken;
 
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 
 public class PollUploadAppStatusExecution implements AsyncExecution {
 
@@ -18,44 +15,41 @@ public class PollUploadAppStatusExecution implements AsyncExecution {
     public AsyncExecutionState execute(ExecutionWrapper execution) {
         CloudApplication app = StepsUtil.getApp(execution.getContext());
 
-        try {
-            execution.getStepLogger()
-                .debug(Messages.CHECKING_UPLOAD_APP_STATUS, app.getName());
+        execution.getStepLogger()
+            .debug(Messages.CHECKING_UPLOAD_APP_STATUS, app.getName());
 
-            CloudControllerClient client = execution.getControllerClient();
+        CloudControllerClient client = execution.getControllerClient();
 
-            UploadToken uploadToken = StepsUtil.getUploadToken(execution.getContext());
-            Upload upload = client.getUploadStatus(uploadToken.getToken());
-            switch (upload.getStatus()) {
-                case FAILED:
-                case EXPIRED:
-                    execution.getStepLogger()
-                        .debug(Messages.ERROR_UPLOADING_APP_WITH_DETAILS, app.getName(), upload.getStatus(), upload.getErrorDetails()
-                            .getDescription());
-                    execution.getStepLogger()
-                        .error(Messages.ERROR_UPLOADING_APP, app.getName());
-                    return AsyncExecutionState.ERROR;
-                case READY:
-                    execution.getStepLogger()
-                        .debug(Messages.APP_UPLOADED, app.getName());
-                    return AsyncExecutionState.FINISHED;
-                case PROCESSING_UPLOAD:
-                case COPYING:
-                case AWAITING_UPLOAD:
-                    return AsyncExecutionState.RUNNING;
-                default:
-                    throw new IllegalStateException(format(Messages.UNKNOWN_UPLOAD_STATUS, upload.getStatus()));
-            }
-        } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            execution.getStepLogger()
-                .error(e, Messages.ERROR_CHECKING_UPLOAD_APP_STATUS, app.getName());
-            throw e;
-        } catch (SLException e) {
-            execution.getStepLogger()
-                .error(e, Messages.ERROR_CHECKING_UPLOAD_APP_STATUS, app.getName());
-            throw e;
+        UploadToken uploadToken = StepsUtil.getUploadToken(execution.getContext());
+        Upload upload = client.getUploadStatus(uploadToken.getToken());
+        switch (upload.getStatus()) {
+            case FAILED:
+            case EXPIRED:
+                execution.getStepLogger()
+                    .debug(Messages.ERROR_UPLOADING_APP_WITH_DETAILS, app.getName(), upload.getStatus(), upload.getErrorDetails()
+                        .getDescription());
+                execution.getStepLogger()
+                    .error(Messages.ERROR_UPLOADING_APP, app.getName());
+                return AsyncExecutionState.ERROR;
+            case READY:
+                execution.getStepLogger()
+                    .debug(Messages.APP_UPLOADED, app.getName());
+                return AsyncExecutionState.FINISHED;
+            case PROCESSING_UPLOAD:
+            case COPYING:
+            case AWAITING_UPLOAD:
+                return AsyncExecutionState.RUNNING;
+            default:
+                throw new IllegalStateException(format(Messages.UNKNOWN_UPLOAD_STATUS, upload.getStatus()));
         }
+    }
+
+    @Override
+    public void onPollingError(ExecutionWrapper execution, Exception e) throws Exception {
+        execution.getStepLogger()
+            .error(e, Messages.ERROR_CHECKING_UPLOAD_APP_STATUS, StepsUtil.getApp(execution.getContext())
+                .getName());
+        throw e;
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareModulesDeploymentStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareModulesDeploymentStep.java
@@ -56,6 +56,11 @@ public class PrepareModulesDeploymentStep extends SyncFlowableStep {
         return StepPhase.DONE;
     }
 
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        throw e;
+    }
+
     protected List<Module> getModulesToDeploy(DelegateExecution context) {
         return StepsUtil.getAllModulesToDeploy(context);
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareToExecuteTasksStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareToExecuteTasksStep.java
@@ -3,17 +3,14 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 import java.util.List;
 
 import org.cloudfoundry.client.lib.CloudControllerClient;
-import org.cloudfoundry.client.lib.CloudControllerException;
-import org.cloudfoundry.client.lib.CloudOperationException;
 import org.cloudfoundry.client.lib.domain.CloudTask;
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudApplicationExtended;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("prepareToExecuteTasksStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -21,21 +18,7 @@ public class PrepareToExecuteTasksStep extends SyncFlowableStep {
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
-        CloudApplicationExtended app = StepsUtil.getApp(execution.getContext());
         List<CloudTask> tasksToExecute = StepsUtil.getTasksToExecute(execution.getContext());
-        try {
-            return attemptToPrepareExecutionOfTasks(execution, tasksToExecute);
-        } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_PREPARING_TO_EXECUTE_TASKS_ON_APP, app.getName());
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_PREPARING_TO_EXECUTE_TASKS_ON_APP, app.getName());
-            throw e;
-        }
-    }
-
-    private StepPhase attemptToPrepareExecutionOfTasks(ExecutionWrapper execution, List<CloudTask> tasksToExecute) {
         execution.getContext()
             .setVariable(Constants.VAR_PLATFORM_SUPPORTS_TASKS, platformSupportsTasks(execution));
 
@@ -47,6 +30,13 @@ public class PrepareToExecuteTasksStep extends SyncFlowableStep {
         execution.getContext()
             .setVariable(Constants.VAR_INDEX_VARIABLE_NAME, Constants.VAR_TASKS_INDEX);
         return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_PREPARING_TO_EXECUTE_TASKS_ON_APP, StepsUtil.getApp(context)
+            .getName());
+        throw e;
     }
 
     private boolean platformSupportsTasks(ExecutionWrapper execution) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareToRestartServiceBrokerSubscribersStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PrepareToRestartServiceBrokerSubscribersStep.java
@@ -24,5 +24,10 @@ public class PrepareToRestartServiceBrokerSubscribersStep extends SyncFlowableSt
         context.setVariable(Constants.VAR_INDEX_VARIABLE_NAME, Constants.VAR_UPDATED_SERVICE_BROKER_SUBSCRIBERS_INDEX);
         return StepPhase.DONE;
     }
+    
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        throw e;
+    }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessGitSourceStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessGitSourceStep.java
@@ -96,15 +96,18 @@ public class ProcessGitSourceStep extends SyncFlowableStep {
                 }
             }
             return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e.getMessage());
-            throw e;
         } catch (GitAPIException | IOException | FileStorageException e) {
             getStepLogger().error(e, Messages.ERROR_DOWNLOADING_DEPLOYABLE_FROM_GIT);
             throw new SLException(e, Messages.ERROR_PROCESSING_GIT_MTA_SOURCE);
         }
     }
-
+    
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e.getMessage());
+        throw e;
+    }
+    
     private GitRepoCloner createCloner(ExecutionWrapper execution) {
         DelegateExecution context = execution.getContext();
         GitRepoCloner cloner = new GitRepoCloner();

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessMtaArchiveStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessMtaArchiveStep.java
@@ -21,7 +21,6 @@ import com.sap.cloud.lm.sl.cf.persistence.services.FileStorageException;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
 import com.sap.cloud.lm.sl.cf.process.util.ProcessConflictPreventer;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.mta.handlers.ArchiveHandler;
 import com.sap.cloud.lm.sl.mta.handlers.DescriptorParserFacade;
 import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
@@ -39,23 +38,20 @@ public class ProcessMtaArchiveStep extends SyncFlowableStep {
         operationDao);
 
     @Override
-    protected StepPhase executeStep(ExecutionWrapper execution) {
-        try {
-            getStepLogger().debug(Messages.PROCESSING_MTA_ARCHIVE);
+    protected StepPhase executeStep(ExecutionWrapper execution) throws FileStorageException {
+        getStepLogger().debug(Messages.PROCESSING_MTA_ARCHIVE);
 
-            String appArchiveId = StepsUtil.getRequiredString(execution.getContext(), Constants.PARAM_APP_ARCHIVE_ID);
-            processApplicationArchive(execution.getContext(), appArchiveId);
-            setMtaIdForProcess(execution.getContext());
-            getStepLogger().debug(Messages.MTA_ARCHIVE_PROCESSED);
-            return StepPhase.DONE;
-        } catch (FileStorageException fse) {
-            SLException e = new SLException(fse, fse.getMessage());
-            getStepLogger().error(e, Messages.ERROR_PROCESSING_MTA_ARCHIVE);
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_PROCESSING_MTA_ARCHIVE);
-            throw e;
-        }
+        String appArchiveId = StepsUtil.getRequiredString(execution.getContext(), Constants.PARAM_APP_ARCHIVE_ID);
+        processApplicationArchive(execution.getContext(), appArchiveId);
+        setMtaIdForProcess(execution.getContext());
+        getStepLogger().debug(Messages.MTA_ARCHIVE_PROCESSED);
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_PROCESSING_MTA_ARCHIVE);
+        throw e;
     }
 
     private void processApplicationArchive(final DelegateExecution context, String appArchiveId) throws FileStorageException {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessMtaExtensionDescriptorsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessMtaExtensionDescriptorsStep.java
@@ -35,21 +35,22 @@ public class ProcessMtaExtensionDescriptorsStep extends SyncFlowableStep {
         DelegateExecution context = execution.getContext();
         getStepLogger().debug(Messages.PROCESSING_MTA_EXTENSION_DESCRIPTORS);
         List<String> extensionDescriptorFileIds = getExtensionDescriptorFileIds(context);
-        try {
-            String spaceId = StepsUtil.getSpaceId(context);
-            DeploymentDescriptor deploymentDescriptor = StepsUtil.getDeploymentDescriptor(context);
+        String spaceId = StepsUtil.getSpaceId(context);
+        DeploymentDescriptor deploymentDescriptor = StepsUtil.getDeploymentDescriptor(context);
 
-            List<ExtensionDescriptor> extensionDescriptors = parseExtensionDescriptors(spaceId, extensionDescriptorFileIds);
-            List<ExtensionDescriptor> extensionDescriptorChain = extensionDescriptorChainBuilder.build(deploymentDescriptor,
-                extensionDescriptors);
+        List<ExtensionDescriptor> extensionDescriptors = parseExtensionDescriptors(spaceId, extensionDescriptorFileIds);
+        List<ExtensionDescriptor> extensionDescriptorChain = extensionDescriptorChainBuilder.build(deploymentDescriptor,
+            extensionDescriptors);
 
-            StepsUtil.setExtensionDescriptorChain(context, extensionDescriptorChain);
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_PROCESSING_MTA_EXTENSION_DESCRIPTORS);
-            throw e;
-        }
+        StepsUtil.setExtensionDescriptorChain(context, extensionDescriptorChain);
         getStepLogger().debug(Messages.MTA_EXTENSION_DESCRIPTORS_PROCESSED);
         return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_PROCESSING_MTA_EXTENSION_DESCRIPTORS);
+        throw e;
     }
 
     private List<String> getExtensionDescriptorFileIds(DelegateExecution context) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessStepHelper.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ProcessStepHelper.java
@@ -92,7 +92,15 @@ public class ProcessStepHelper {
         try {
             ProgressMessage msg = new ProgressMessage(StepsUtil.getCorrelationId(context), getCurrentActivityId(context), ProgressMessageType.ERROR,
                 MessageFormat.format(Messages.UNEXPECTED_ERROR, t.getMessage()), new Timestamp(System.currentTimeMillis()));
-            progressMessageService.add(msg);
+//            
+//            List<ProgressMessage> progressMessages = progressMessageService.findByProcessId(StepsUtil.getCorrelationId(context));
+//            Optional<ProgressMessage> errorProgressMessage = progressMessages.stream()
+//                .filter(message -> message.getType() == ProgressMessageType.ERROR)
+//                .findAny();
+//            
+//            if(!errorProgressMessage.isPresent()) {
+                progressMessageService.add(msg);
+//            }
         } catch (SLException e) {
             getProcessLogger().error(Messages.SAVING_ERROR_MESSAGE_FAILED, e);
         }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PublishConfigurationEntriesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/PublishConfigurationEntriesStep.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -17,7 +18,6 @@ import com.sap.cloud.lm.sl.cf.core.dao.ConfigurationEntryDao;
 import com.sap.cloud.lm.sl.cf.core.model.ConfigurationEntry;
 import com.sap.cloud.lm.sl.cf.core.security.serialization.SecureSerializationFacade;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.common.util.CommonUtil;
 
 @Component("publishProvidedDependenciesStep")
@@ -33,28 +33,29 @@ public class PublishConfigurationEntriesStep extends SyncFlowableStep {
     protected StepPhase executeStep(ExecutionWrapper execution) {
         CloudApplicationExtended app = StepsUtil.getApp(execution.getContext());
 
-        try {
-            getStepLogger().debug(MessageFormat.format(Messages.PUBLISHING_PUBLIC_PROVIDED_DEPENDENCIES, app.getName()));
+        getStepLogger().debug(MessageFormat.format(Messages.PUBLISHING_PUBLIC_PROVIDED_DEPENDENCIES, app.getName()));
 
-            List<ConfigurationEntry> entriesToPublish = StepsUtil.getConfigurationEntriesToPublish(execution.getContext());
+        List<ConfigurationEntry> entriesToPublish = StepsUtil.getConfigurationEntriesToPublish(execution.getContext());
 
-            if (CollectionUtils.isEmpty(entriesToPublish)) {
-                StepsUtil.setPublishedEntries(execution.getContext(), Collections.emptyList());
-                getStepLogger().debug(Messages.NO_PUBLIC_PROVIDED_DEPENDENCIES_FOR_PUBLISHING);
-                return StepPhase.DONE;
-            }
-
-            List<ConfigurationEntry> publishedEntries = publish(entriesToPublish);
-
-            getStepLogger().debug(Messages.PUBLISHED_ENTRIES, secureSerializer.toJson(publishedEntries));
-            StepsUtil.setPublishedEntries(execution.getContext(), publishedEntries);
-
-            getStepLogger().debug(Messages.PUBLIC_PROVIDED_DEPENDENCIES_PUBLISHED);
+        if (CollectionUtils.isEmpty(entriesToPublish)) {
+            StepsUtil.setPublishedEntries(execution.getContext(), Collections.emptyList());
+            getStepLogger().debug(Messages.NO_PUBLIC_PROVIDED_DEPENDENCIES_FOR_PUBLISHING);
             return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_PUBLISHING_PUBLIC_PROVIDED_DEPENDENCIES);
-            throw e;
         }
+
+        List<ConfigurationEntry> publishedEntries = publish(entriesToPublish);
+
+        getStepLogger().debug(Messages.PUBLISHED_ENTRIES, secureSerializer.toJson(publishedEntries));
+        StepsUtil.setPublishedEntries(execution.getContext(), publishedEntries);
+
+        getStepLogger().debug(Messages.PUBLIC_PROVIDED_DEPENDENCIES_PUBLISHED);
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_PUBLISHING_PUBLIC_PROVIDED_DEPENDENCIES);
+        throw e;
     }
 
     private List<ConfigurationEntry> publish(List<ConfigurationEntry> entriesToPublish) {
@@ -77,7 +78,7 @@ public class PublishConfigurationEntriesStep extends SyncFlowableStep {
     }
 
     private void infoConfigurationPublishment(ConfigurationEntry entry) {
-        if(!CommonUtil.isNullOrEmpty(entry.getContent())) {
+        if (!CommonUtil.isNullOrEmpty(entry.getContent())) {
             getStepLogger().info(MessageFormat.format(Messages.PUBLISHING_PUBLIC_PROVIDED_DEPENDENCY, entry.getProviderId()));
         }
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/RestartServiceBrokerSubscriberStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/RestartServiceBrokerSubscriberStep.java
@@ -9,15 +9,18 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import com.sap.cloud.lm.sl.cf.process.message.Messages;
+
 @Component("restartServiceBrokerSubscriberStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
 public class RestartServiceBrokerSubscriberStep extends RestartAppStep {
 
     @Override
-    protected void onError(String message, Exception e) {
-        getStepLogger().warn(e, message);
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().warn(e, Messages.ERROR_STARTING_APP_1, getAppToRestart(context).getName());
+        throw e;
     }
-
+    
     @Override
     protected CloudApplication getAppToRestart(DelegateExecution context) {
         return StepsUtil.getServiceBrokerSubscriberToRestart(context);

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/RestartSubscribersStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/RestartSubscribersStep.java
@@ -7,6 +7,7 @@ import org.cloudfoundry.client.lib.CloudOperationException;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
 import org.cloudfoundry.client.lib.domain.CloudOrganization;
 import org.cloudfoundry.client.lib.domain.CloudSpace;
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -25,6 +26,11 @@ public class RestartSubscribersStep extends SyncFlowableStep {
             restartSubscriber(execution, subscriber);
         }
         return StepPhase.DONE;
+    }
+    
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        throw e;
     }
 
     private void restartSubscriber(ExecutionWrapper execution, CloudApplication subscriber) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ScaleAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ScaleAppStep.java
@@ -1,15 +1,13 @@
 package com.sap.cloud.lm.sl.cf.process.steps;
 
-import org.cloudfoundry.client.lib.CloudControllerException;
-import org.cloudfoundry.client.lib.CloudOperationException;
 import org.cloudfoundry.client.lib.CloudControllerClient;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.common.SLException;
 
 @Component("scaleAppStep")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -21,29 +19,27 @@ public class ScaleAppStep extends SyncFlowableStep {
 
         CloudApplication existingApp = StepsUtil.getExistingApp(execution.getContext());
 
-        try {
-            getStepLogger().debug(Messages.SCALING_APP, app.getName());
+        getStepLogger().debug(Messages.SCALING_APP, app.getName());
 
-            CloudControllerClient client = execution.getControllerClient();
+        CloudControllerClient client = execution.getControllerClient();
 
-            String appName = app.getName();
-            Integer instances = (app.getInstances() != 0) ? app.getInstances() : null;
+        String appName = app.getName();
+        Integer instances = (app.getInstances() != 0) ? app.getInstances() : null;
 
-            if (instances != null && (existingApp == null || !instances.equals(existingApp.getInstances()))) {
-                getStepLogger().info(Messages.SCALING_APP_0_TO_X_INSTANCES, appName, instances);
-                client.updateApplicationInstances(appName, instances);
-            }
-
-            getStepLogger().debug(Messages.APP_SCALED, app.getName());
-            return StepPhase.DONE;
-        } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_SCALING_APP, app.getName());
-            throw e;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_SCALING_APP, app.getName());
-            throw e;
+        if (instances != null && (existingApp == null || !instances.equals(existingApp.getInstances()))) {
+            getStepLogger().info(Messages.SCALING_APP_0_TO_X_INSTANCES, appName, instances);
+            client.updateApplicationInstances(appName, instances);
         }
+
+        getStepLogger().debug(Messages.APP_SCALED, app.getName());
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_SCALING_APP, StepsUtil.getApp(context)
+            .getName());
+        throw e;
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ServiceStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ServiceStep.java
@@ -48,9 +48,14 @@ public abstract class ServiceStep extends AsyncFlowableStep {
         StepsUtil.isServiceUpdated(true, execution.getContext());
         return StepPhase.POLL;
     }
+    
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        throw e;
+    }
 
     protected abstract MethodExecution<String> executeOperation(DelegateExecution context, CloudControllerClient controllerClient,
-        CloudServiceExtended service);
+        CloudServiceExtended service) throws Exception;
     
     protected abstract ServiceOperationType getOperationType();
     

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StageAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StageAppStep.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.cloudfoundry.client.lib.CloudControllerException;
-import org.cloudfoundry.client.lib.CloudOperationException;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -28,14 +26,15 @@ public class StageAppStep extends TimeoutAsyncFlowableStep {
     @Override
     protected StepPhase executeAsyncStep(ExecutionWrapper execution) {
         CloudApplication app = StepsUtil.getApp(execution.getContext());
-        try {
-            ApplicationStager applicationStager = new ApplicationStager();
-            return applicationStager.stageApp(execution.getContext(), execution.getControllerClient(), app, getStepLogger());
-        } catch (CloudOperationException coe) {
-            CloudControllerException e = new CloudControllerException(coe);
-            getStepLogger().error(e, Messages.ERROR_STAGING_APP_1, app.getName());
-            throw e;
-        }
+        ApplicationStager applicationStager = new ApplicationStager();
+        return applicationStager.stageApp(execution.getContext(), execution.getControllerClient(), app, getStepLogger());
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_STAGING_APP_1, StepsUtil.getApp(context)
+            .getName());
+        throw e;
     }
 
     @Override

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/SyncFlowableStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/SyncFlowableStep.java
@@ -3,6 +3,9 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.cloudfoundry.client.lib.CloudControllerException;
+import org.cloudfoundry.client.lib.CloudOperationException;
+import org.cloudfoundry.client.lib.CloudServiceBrokerException;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.delegate.JavaDelegate;
@@ -13,6 +16,7 @@ import org.slf4j.MDC;
 import com.sap.cloud.lm.sl.cf.core.Constants;
 import com.sap.cloud.lm.sl.cf.core.cf.CloudControllerClientProvider;
 import com.sap.cloud.lm.sl.cf.persistence.services.FileService;
+import com.sap.cloud.lm.sl.cf.persistence.services.FileStorageException;
 import com.sap.cloud.lm.sl.cf.persistence.services.ProcessLoggerProvider;
 import com.sap.cloud.lm.sl.cf.persistence.services.ProcessLogsPersister;
 import com.sap.cloud.lm.sl.cf.persistence.services.ProgressMessageService;
@@ -55,9 +59,9 @@ public abstract class SyncFlowableStep implements JavaDelegate {
                 throw new SLException("A step of the process has failed. Retrying it may solve the issue.");
             }
             getStepHelper().failStepIfProcessIsAborted(context);
-        } catch (Throwable t) {
+        } catch (Exception e) {
             stepPhase = StepPhase.RETRY;
-            handleException(context, t);
+            handleException(executionWrapper, e);
         } finally {
             StepsUtil.setStepPhase(context, stepPhase);
             postExecuteStep(context, stepPhase);
@@ -72,10 +76,15 @@ public abstract class SyncFlowableStep implements JavaDelegate {
         return new ExecutionWrapper(context, stepLogger, clientProvider);
     }
 
-    private void handleException(DelegateExecution context, Throwable t) {
-        t = getWithProperMessage(t);
-        getStepHelper().logException(context, t);
-        throw t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t);
+    protected void handleException(ExecutionWrapper execution, Exception e) {
+        try {
+            e = preprocessException(e);
+            onError(execution, e);
+        } catch (Exception ex) {
+            ex = getWithProperMessage(ex);
+            getStepHelper().logException(execution.getContext(), ex);
+            throw ex instanceof RuntimeException ? (RuntimeException) ex : new RuntimeException(ex);
+        }
     }
 
     protected void postExecuteStep(DelegateExecution context, StepPhase stepState) {
@@ -86,8 +95,42 @@ public abstract class SyncFlowableStep implements JavaDelegate {
             throw e;
         }
     }
+    
+
+    protected void onError(ExecutionWrapper execution, Exception e) throws Exception {
+        onStepError(execution.getContext(), e);
+    }
+
+    private Exception preprocessException(Exception e) {
+        if (e instanceof CloudOperationException && !(e instanceof CloudServiceBrokerException)) {
+            e = new CloudControllerException((CloudOperationException) e);
+        } else if (e instanceof FileStorageException) {
+            e = new SLException(e, e.getMessage());
+        }
+        return e;
+    }
 
     protected abstract StepPhase executeStep(ExecutionWrapper execution) throws Exception;
+
+    /**
+     * <p>
+     * Add step specific progress message. Eventually, re-throw the exception. Example:
+     * 
+     * <pre>
+     * <code>
+     * protected void onError(DelegateExecution context, Exception e) throws Exception {
+     *     getStepLogger().error(e, "You passed invalid MTA archive format");
+     *     throw e;
+     *  }
+     * </code>
+     * </pre>
+     * </p>
+     * 
+     * @param context flowable context of the step
+     * @param e thrown exception from {@link #executeStep(ExecutionWrapper) executeStep} and pre-processed by
+     *        {@link #handleException(DelegateExecution, Exception) handleException}
+     */
+    protected abstract void onStepError(DelegateExecution context, Exception e) throws Exception;
 
     protected StepLogger getStepLogger() {
         if (stepLogger == null) {
@@ -100,12 +143,12 @@ public abstract class SyncFlowableStep implements JavaDelegate {
         stepLogger = stepLoggerFactory.create(context, progressMessageService, processLoggerProvider, logger);
     }
 
-    protected Throwable getWithProperMessage(Throwable t) {
-        if (t.getMessage() == null || t.getMessage()
+    protected Exception getWithProperMessage(Exception e) {
+        if (e.getMessage() == null || e.getMessage()
             .isEmpty()) {
-            return new Exception("An unknown error occurred", t);
+            return new Exception("An unknown error occurred", e);
         }
-        return t;
+        return e;
     }
 
     protected ProcessStepHelper getStepHelper() {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/SyncFlowableStepWithHooks.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/SyncFlowableStepWithHooks.java
@@ -42,6 +42,11 @@ public abstract class SyncFlowableStepWithHooks extends SyncFlowableStep {
 
         return currentStepPhase;
     }
+    
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        throw e;
+    }
 
     private List<Hook> executeHooksForStepPhase(DelegateExecution context, Module moduleToDeploy, StepPhase currentStepPhase) {
         HookPhase currentHookPhaseForExecution = determineHookPhaseForCurrentStepPhase(context, currentStepPhase);

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UndeployAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UndeployAppStep.java
@@ -2,6 +2,7 @@ package com.sap.cloud.lm.sl.cf.process.steps;
 
 import org.cloudfoundry.client.lib.CloudControllerClient;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.flowable.engine.delegate.DelegateExecution;
 
 public abstract class UndeployAppStep extends SyncFlowableStepWithHooks {
 
@@ -13,6 +14,11 @@ public abstract class UndeployAppStep extends SyncFlowableStepWithHooks {
         return undeployApplication(client, cloudApplicationToUndeploy);
     }
 
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        throw e;
+    }
+    
     protected abstract StepPhase undeployApplication(CloudControllerClient client, CloudApplication cloudApplicationToUndeploy);
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UpdateSubscribersStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UpdateSubscribersStep.java
@@ -105,38 +105,38 @@ public class UpdateSubscribersStep extends SyncFlowableStep {
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
-        try {
-            getStepLogger().debug(Messages.UPDATING_SUBSCRIBERS);
-            List<ConfigurationEntry> publishedEntries = StepsUtil.getPublishedEntriesFromSubProcesses(execution.getContext(),
-                flowableFacade);
-            List<ConfigurationEntry> deletedEntries = StepsUtil.getDeletedEntriesFromAllProcesses(execution.getContext(), flowableFacade);
-            List<ConfigurationEntry> updatedEntries = ListUtils.union(publishedEntries, deletedEntries);
+        getStepLogger().debug(Messages.UPDATING_SUBSCRIBERS);
+        List<ConfigurationEntry> publishedEntries = StepsUtil.getPublishedEntriesFromSubProcesses(execution.getContext(), flowableFacade);
+        List<ConfigurationEntry> deletedEntries = StepsUtil.getDeletedEntriesFromAllProcesses(execution.getContext(), flowableFacade);
+        List<ConfigurationEntry> updatedEntries = ListUtils.union(publishedEntries, deletedEntries);
 
-            CloudControllerClient clientForCurrentSpace = execution.getControllerClient();
+        CloudControllerClient clientForCurrentSpace = execution.getControllerClient();
 
-            List<CloudApplication> updatedSubscribers = new ArrayList<>();
-            List<CloudApplication> updatedServiceBrokerSubscribers = new ArrayList<>();
-            for (ConfigurationSubscription subscription : subscriptionsDao.findAll(updatedEntries)) {
-                ClientHelper clientHelper = new ClientHelper(clientForCurrentSpace);
-                Pair<String, String> orgAndSpace = orgAndSpaceCalculator.apply(clientHelper, subscription.getSpaceId());
-                if (orgAndSpace == null) {
-                    getStepLogger().warn(Messages.COULD_NOT_COMPUTE_ORG_AND_SPACE, subscription.getSpaceId());
-                    continue;
-                }
-                CloudApplication updatedApplication = updateSubscriber(execution, orgAndSpace, subscription);
-                if (updatedApplication != null) {
-                    updatedApplication = addOrgAndSpaceIfNecessary(updatedApplication, orgAndSpace);
-                    addApplicationToProperList(updatedSubscribers, updatedServiceBrokerSubscribers, updatedApplication);
-                }
+        List<CloudApplication> updatedSubscribers = new ArrayList<>();
+        List<CloudApplication> updatedServiceBrokerSubscribers = new ArrayList<>();
+        for (ConfigurationSubscription subscription : subscriptionsDao.findAll(updatedEntries)) {
+            ClientHelper clientHelper = new ClientHelper(clientForCurrentSpace);
+            Pair<String, String> orgAndSpace = orgAndSpaceCalculator.apply(clientHelper, subscription.getSpaceId());
+            if (orgAndSpace == null) {
+                getStepLogger().warn(Messages.COULD_NOT_COMPUTE_ORG_AND_SPACE, subscription.getSpaceId());
+                continue;
             }
-            StepsUtil.setUpdatedSubscribers(execution.getContext(), removeDuplicates(updatedSubscribers));
-            StepsUtil.setUpdatedServiceBrokerSubscribers(execution.getContext(), updatedServiceBrokerSubscribers);
-            getStepLogger().debug(Messages.SUBSCRIBERS_UPDATED);
-            return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_UPDATING_SUBSCRIBERS);
-            throw e;
+            CloudApplication updatedApplication = updateSubscriber(execution, orgAndSpace, subscription);
+            if (updatedApplication != null) {
+                updatedApplication = addOrgAndSpaceIfNecessary(updatedApplication, orgAndSpace);
+                addApplicationToProperList(updatedSubscribers, updatedServiceBrokerSubscribers, updatedApplication);
+            }
         }
+        StepsUtil.setUpdatedSubscribers(execution.getContext(), removeDuplicates(updatedSubscribers));
+        StepsUtil.setUpdatedServiceBrokerSubscribers(execution.getContext(), updatedServiceBrokerSubscribers);
+        getStepLogger().debug(Messages.SUBSCRIBERS_UPDATED);
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_UPDATING_SUBSCRIBERS);
+        throw e;
     }
 
     private void addApplicationToProperList(List<CloudApplication> updatedSubscribers,

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ValidateDeployParametersStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/ValidateDeployParametersStep.java
@@ -39,20 +39,21 @@ public class ValidateDeployParametersStep extends SyncFlowableStep {
 
     @Override
     protected StepPhase executeStep(ExecutionWrapper execution) {
-        try {
-            getStepLogger().debug(Messages.VALIDATING_PARAMETERS);
+        getStepLogger().debug(Messages.VALIDATING_PARAMETERS);
 
-            validateParameters(execution.getContext());
-            String space = StepsUtil.getSpace(execution.getContext());
-            String org = StepsUtil.getOrg(execution.getContext());
-            getStepLogger().info(Messages.DEPLOYING_IN_ORG_0_AND_SPACE_1, org, space);
+        validateParameters(execution.getContext());
+        String space = StepsUtil.getSpace(execution.getContext());
+        String org = StepsUtil.getOrg(execution.getContext());
+        getStepLogger().info(Messages.DEPLOYING_IN_ORG_0_AND_SPACE_1, org, space);
 
-            getStepLogger().debug(Messages.PARAMETERS_VALIDATED);
-            return StepPhase.DONE;
-        } catch (SLException e) {
-            getStepLogger().error(e, Messages.ERROR_VALIDATING_PARAMS);
-            throw e;
-        }
+        getStepLogger().debug(Messages.PARAMETERS_VALIDATED);
+        return StepPhase.DONE;
+    }
+
+    @Override
+    protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+        getStepLogger().error(e, Messages.ERROR_VALIDATING_PARAMS);
+        throw e;
     }
 
     private void validateParameters(DelegateExecution context) {
@@ -67,8 +68,8 @@ public class ValidateDeployParametersStep extends SyncFlowableStep {
         try {
             VersionRule.value(versionRuleString);
         } catch (IllegalArgumentException e) {
-            throw new SLException(e, Messages.ERROR_PARAMETER_1_IS_NOT_VALID_VALID_VALUES_ARE_2, versionRuleString, Constants.PARAM_VERSION_RULE,
-                Arrays.asList(VersionRule.values()));
+            throw new SLException(e, Messages.ERROR_PARAMETER_1_IS_NOT_VALID_VALID_VALUES_ARE_2, versionRuleString,
+                Constants.PARAM_VERSION_RULE, Arrays.asList(VersionRule.values()));
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/AbstractProcessStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/AbstractProcessStepTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 import java.util.Arrays;
 import java.util.function.Supplier;
 
+import org.flowable.engine.delegate.DelegateExecution;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,6 +67,11 @@ public class AbstractProcessStepTest extends SyncFlowableStepTest<AbstractProces
         @Override
         protected StepPhase executeStep(ExecutionWrapper execution) throws Exception {
             throw exceptionSupplier.get();
+        }
+
+        @Override
+        protected void onStepError(DelegateExecution context, Exception e) throws Exception {
+            throw e;
         }
 
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateServiceBrokerStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateServiceBrokerStepTest.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 
 import org.cloudfoundry.client.lib.CloudControllerException;
 import org.cloudfoundry.client.lib.CloudOperationException;
+import org.cloudfoundry.client.lib.CloudServiceBrokerException;
 import org.cloudfoundry.client.lib.domain.CloudServiceBroker;
 import org.junit.Before;
 import org.junit.Rule;
@@ -104,7 +105,7 @@ public class CreateOrUpdateServiceBrokerStepTest extends SyncFlowableStepTest<Cr
             },
             // (12) Create/update calls for should fail, because both create and update throw an exception and failsafe option is not set: 
             {
-                "create-service-brokers-step-input-09.json", "create-service-brokers-step-output-09.json", null, "Controller operation failed: 403 Forbidden", CloudControllerException.class, new CloudOperationException(HttpStatus.FORBIDDEN), new CloudOperationException(HttpStatus.FORBIDDEN),
+                "create-service-brokers-step-input-09.json", "create-service-brokers-step-output-09.json", null, "Service broker operation failed: 403 Forbidden", CloudServiceBrokerException.class, new CloudOperationException(HttpStatus.FORBIDDEN), new CloudOperationException(HttpStatus.FORBIDDEN),
             },
             // (13) Update call for broker should be made, although both create and update throw an exception but failsafe option is set: 
             {

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/SyncFlowableStepWithHooksTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/SyncFlowableStepWithHooksTest.java
@@ -249,6 +249,7 @@ public class SyncFlowableStepWithHooksTest {
         protected String getModuleName(CloudApplicationExtended cloudApplication) {
             return moduleName;
         }
+
     }
 
     public static class ModuleHooksAgregatorTest {


### PR DESCRIPTION
#### Description: 
When one process fails, multiapps-controller generates more than one error messages.
All the error messages are essentially the same, so the change is to minimise the error messages to one for each process.

#### Issue: 
Jira: LMCROSSITXSADEPLOY-1536
