### PR TITLE
removing depth of travis git clone so sonar has full history

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ notifications:
 script:
    - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then mvn clean install sonar:sonar -Dsonar.organization=cf-deploy-service -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=bc2be0dbbebfb0c29627f657c655e34c02451dc1 -Dsonar.exclusions="**/com/sap/cloud/lm/sl/cf/client/events/**/*" -Dsonar.branch.name="$TRAVIS_PULL_REQUEST"; fi'
    - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn deploy --settings .travis.settings.xml   sonar:sonar -Dsonar.organization=cf-deploy-service -Dsonar.host.url=https://sonarcloud.io -Dsonar.exclusions="**/com/sap/cloud/lm/sl/cf/client/events/**/*" -Dsonar.login=bc2be0dbbebfb0c29627f657c655e34c02451dc1; fi'
+git:
+  depth: false


### PR DESCRIPTION
#### Description: 
Sonar checks show weird results if older than 50 (default travis clone depth) commits are involved in determining whether a file is new or renmaed/moved.