### PR TITLE
Fix recreation of a build if not staged yet

### DIFF
--- a/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/ResilientCloudControllerClient.java
+++ b/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/ResilientCloudControllerClient.java
@@ -82,13 +82,13 @@ public class ResilientCloudControllerClient implements CloudControllerClient {
 
     @Override
     public void bindService(String applicationName, String serviceName, Map<String, Object> parameters,
-        ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
+                            ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
         executeWithRetry(() -> cc.bindService(applicationName, serviceName, parameters, applicationServicesUpdateCallback));
     }
 
     @Override
     public void createApplication(String applicationName, Staging staging, Integer disk, Integer memory, List<String> uris,
-        List<String> serviceNames, DockerInfo dockerInfo) {
+                                  List<String> serviceNames, DockerInfo dockerInfo) {
         executeWithRetry(() -> cc.createApplication(applicationName, staging, disk, memory, uris, serviceNames, dockerInfo));
     }
 
@@ -329,11 +329,11 @@ public class ResilientCloudControllerClient implements CloudControllerClient {
 
     @Override
     public List<String> updateApplicationServices(String applicationName,
-        Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
-        ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
-        return executeWithRetry(
-            () -> cc.updateApplicationServices(applicationName, serviceNamesWithBindingParameters, applicationServicesUpdateCallback),
-            HttpStatus.NOT_FOUND);
+                                                  Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
+                                                  ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
+        return executeWithRetry(() -> cc.updateApplicationServices(applicationName, serviceNamesWithBindingParameters,
+                                                                   applicationServicesUpdateCallback),
+                                HttpStatus.NOT_FOUND);
     }
 
     @Override
@@ -751,7 +751,7 @@ public class ResilientCloudControllerClient implements CloudControllerClient {
 
     @Override
     public void openFile(String applicationName, int instanceIndex, String filePath,
-        ClientHttpResponseCallback clientHttpResponseCallback) {
+                         ClientHttpResponseCallback clientHttpResponseCallback) {
         executeWithRetry(() -> cc.openFile(applicationName, instanceIndex, filePath, clientHttpResponseCallback));
     }
 
@@ -908,6 +908,11 @@ public class ResilientCloudControllerClient implements CloudControllerClient {
     }
 
     @Override
+    public List<CloudBuild> getBuildsForPackage(UUID packageGuid) {
+        return executeWithRetry(() -> cc.getBuildsForPackage(packageGuid));
+    }
+
+    @Override
     public CloudBuild getBuild(UUID buildGuid) {
         return executeWithRetry(() -> cc.getBuild(buildGuid));
     }
@@ -923,13 +928,8 @@ public class ResilientCloudControllerClient implements CloudControllerClient {
     }
 
     @Override
-    public List<CloudBuild> getBuildsForPackage(UUID packageGuid) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void unbindService(String applicationName, String serviceName,
-        ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
+                              ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
         executeWithRetry(() -> cc.unbindService(applicationName, serviceName, applicationServicesUpdateCallback));
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -63,6 +63,7 @@ public class Messages {
 
     // ERROR log messages
     public static final String COULD_NOT_COMPUTE_ORG_AND_SPACE = "Could not find org and space for space ID \"{0}\"";
+    public static final String NO_BUILDS_FOUND_FOR_PACKAGE = "No builds found for package \"{0}\"";
 
     // Process step errors
     public static final String ERROR_PREPARING_DEPLOY_PARAMETERS = "Error preparing deploy parameters";
@@ -432,5 +433,6 @@ public class Messages {
     public static final String LAST_BUILD = "Last build: {0}";
     public static final String RESOLVED_DEPLOYMENT_DESCRIPTOR = "Resolved deployment descriptor: {0}";
     public static final String SUBSCRIPTIONS = "Subscriptions: {0}";
+    public static final String BUILD_FOR_PACKAGE_0_ALREADY_EXISTS = "Build for package: \"{0}\" already exists";
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineDesiredStateAchievingActionsStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetermineDesiredStateAchievingActionsStep.java
@@ -44,9 +44,9 @@ public class DetermineDesiredStateAchievingActionsStep extends SyncFlowableStep 
         getStepLogger().debug(Messages.CURRENT_STATE, appName, currentState);
         ApplicationStartupState desiredState = computeDesiredState(execution.getContext(), app);
         getStepLogger().debug(Messages.DESIRED_STATE, appName, desiredState);
-        ApplicationStager applicationStager = new ApplicationStager();
+        ApplicationStager applicationStager = new ApplicationStager(execution.getControllerClient());
         Set<ApplicationStateAction> actionsToExecute = getActionsCalculator(execution.getContext()).determineActionsToExecute(currentState,
-            desiredState, applicationStager.isApplicationStagedCorrectly(execution, app));
+            desiredState, applicationStager.isApplicationStagedCorrectly(execution.getStepLogger(), app));
         getStepLogger().debug(Messages.ACTIONS_TO_EXECUTE, appName, actionsToExecute);
 
         StepsUtil.setAppStateActionsToExecute(execution.getContext(), actionsToExecute);

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StageAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/StageAppStep.java
@@ -27,20 +27,20 @@ public class StageAppStep extends TimeoutAsyncFlowableStep {
     @Override
     protected StepPhase executeAsyncStep(ExecutionWrapper execution) {
         CloudApplication app = StepsUtil.getApp(execution.getContext());
-        ApplicationStager applicationStager = new ApplicationStager();
-        return applicationStager.stageApp(execution.getContext(), execution.getControllerClient(), app, getStepLogger());
+        ApplicationStager applicationStager = new ApplicationStager(execution.getControllerClient());
+        return applicationStager.stageApp(execution.getContext(), app, getStepLogger());
     }
 
     @Override
     protected String getStepErrorMessage(DelegateExecution context) {
         return MessageFormat.format(Messages.ERROR_STAGING_APP_1, StepsUtil.getApp(context)
-            .getName());
+                                                                           .getName());
     }
 
     @Override
     protected List<AsyncExecution> getAsyncStepExecutions(ExecutionWrapper execution) {
         recentLogsRetriever.setFailSafe(true);
-        return Arrays.asList(new PollStageAppStatusExecution(recentLogsRetriever, new ApplicationStager()));
+        return Arrays.asList(new PollStageAppStatusExecution(recentLogsRetriever, new ApplicationStager(execution.getControllerClient())));
     }
 
     @Override

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/ApplicationStager.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/ApplicationStager.java
@@ -1,58 +1,42 @@
 package com.sap.cloud.lm.sl.cf.process.util;
 
+import static java.text.MessageFormat.format;
+
 import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.cloudfoundry.client.lib.CloudControllerClient;
+import org.cloudfoundry.client.lib.CloudOperationException;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
 import org.cloudfoundry.client.lib.domain.CloudBuild;
 import org.cloudfoundry.client.lib.domain.PackageState;
 import org.cloudfoundry.client.lib.domain.UploadToken;
 import org.cloudfoundry.client.lib.util.JsonUtil;
 import org.flowable.engine.delegate.DelegateExecution;
+import org.springframework.http.HttpStatus;
 
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.message.Messages;
-import com.sap.cloud.lm.sl.cf.process.steps.ExecutionWrapper;
 import com.sap.cloud.lm.sl.cf.process.steps.StepPhase;
 import com.sap.cloud.lm.sl.cf.process.steps.StepsUtil;
 
 public class ApplicationStager {
 
-    public StagingState getStagingState(ExecutionWrapper execution, CloudControllerClient client) {
-        UUID buildGuid = (UUID) execution.getContext()
-            .getVariable(Constants.VAR_BUILD_GUID);
+    private CloudControllerClient client;
+
+    public ApplicationStager(CloudControllerClient client) {
+        this.client = client;
+    }
+
+    public StagingState getStagingState(DelegateExecution context) {
+        UUID buildGuid = (UUID) context.getVariable(Constants.VAR_BUILD_GUID);
         if (buildGuid == null) {
             return new StagingState(PackageState.STAGED, null);
         }
         CloudBuild build = client.getBuild(buildGuid);
-
         return getStagingState(build);
-    }
-
-    public boolean isApplicationStagedCorrectly(ExecutionWrapper execution, CloudApplication cloudApplication) {
-        CloudBuild cloudBuild = execution.getControllerClient()
-            .getBuildsForApplication(cloudApplication.getMetadata()
-                .getGuid())
-            .stream()
-            .max(Comparator.comparing(build -> build.getMetadata()
-                .getCreatedAt()))
-            .orElse(null);
-        if (cloudBuild == null) {
-            execution.getStepLogger()
-                .debug(Messages.NO_BUILD_FOUND_FOR_APPLICATION, cloudApplication.getName());
-            return false;
-        }
-        if (cloudBuild.getState() == CloudBuild.State.STAGED && cloudBuild.getDropletInfo() != null && cloudBuild.getError() == null) {
-            return true;
-        }
-        execution.getStepLogger()
-            .info(Messages.APPLICATION_NOT_STAGED_CORRECTLY, cloudApplication.getName());
-        execution.getStepLogger()
-            .debug(Messages.LAST_BUILD, cloudBuild.getName());
-        execution.getStepLogger()
-            .debug(JsonUtil.convertToJson(cloudBuild));
-        return false;
     }
 
     private StagingState getStagingState(CloudBuild build) {
@@ -70,33 +54,97 @@ public class ApplicationStager {
                 packageState = PackageState.PENDING;
                 break;
         }
-
         return new StagingState(packageState, stagingError);
     }
 
-    public void bindDropletToApp(ExecutionWrapper execution, UUID appId, CloudControllerClient client) {
-        UUID buildGuid = (UUID) execution.getContext()
-            .getVariable(Constants.VAR_BUILD_GUID);
-
-        client.bindDropletToApp(client.getBuild(buildGuid)
-            .getDropletInfo()
-            .getGuid(), appId);
+    public boolean isApplicationStagedCorrectly(StepLogger stepLogger, CloudApplication cloudApplication) {
+        // TODO Remove the null filtering.
+        // We are not sure if the controller is returning null for created_at or not, so after the proper v3 client adoption,
+        // we should decide what to do with this filtering.
+        List<CloudBuild> buildsForApplication = client.getBuildsForApplication(cloudApplication.getMetadata()
+                                                                                               .getGuid());
+        if (containsNullMetadata(buildsForApplication)) {
+            return false;
+        }
+        CloudBuild cloudBuild = getLastBuild(buildsForApplication);
+        if (cloudBuild == null) {
+            stepLogger.debug(Messages.NO_BUILD_FOUND_FOR_APPLICATION, cloudApplication.getName());
+            return false;
+        }
+        if (isCloudBuildStagedCorrectly(cloudBuild)) {
+            return true;
+        }
+        logMessages(stepLogger, cloudApplication, cloudBuild);
+        return false;
     }
 
-    public StepPhase stageApp(DelegateExecution context, CloudControllerClient client, CloudApplication app, StepLogger stepLogger) {
+    private boolean containsNullMetadata(List<CloudBuild> buildsForApplication) {
+        return buildsForApplication.stream()
+                                   .anyMatch(build -> Objects.isNull(build.getMetadata()) || Objects.isNull(build.getMetadata()
+                                                                                                                 .getCreatedAt()));
+    }
+
+    private CloudBuild getLastBuild(List<CloudBuild> cloudBuilds) {
+        return cloudBuilds.stream()
+                          .max(Comparator.comparing(build -> build.getMetadata()
+                                                                  .getCreatedAt()))
+                          .orElse(null);
+    }
+
+    private boolean isCloudBuildStagedCorrectly(CloudBuild cloudBuild) {
+        return cloudBuild.getState() == CloudBuild.State.STAGED && cloudBuild.getDropletInfo() != null && cloudBuild.getError() == null;
+    }
+
+    private void logMessages(StepLogger stepLogger, CloudApplication cloudApplication, CloudBuild cloudBuild) {
+        stepLogger.info(Messages.APPLICATION_NOT_STAGED_CORRECTLY, cloudApplication.getName());
+        stepLogger.debug(Messages.LAST_BUILD, JsonUtil.convertToJson(cloudBuild));
+    }
+
+    public void bindDropletToApp(DelegateExecution context, UUID appGuid) {
+        UUID buildGuid = (UUID) context.getVariable(Constants.VAR_BUILD_GUID);
+        client.bindDropletToApp(client.getBuild(buildGuid)
+                                      .getDropletInfo()
+                                      .getGuid(),
+                                appGuid);
+    }
+
+    public StepPhase stageApp(DelegateExecution context, CloudApplication app, StepLogger stepLogger) {
         UploadToken uploadToken = StepsUtil.getUploadToken(context);
         if (uploadToken == null) {
             return StepPhase.DONE;
         }
-        UUID packageGuid = uploadToken.getPackageGuid();
-
         stepLogger.info(Messages.STAGING_APP, app.getName());
+        return createBuild(context, uploadToken.getPackageGuid(), stepLogger);
+    }
 
-        context.setVariable(Constants.VAR_BUILD_GUID, client.createBuild(packageGuid)
-            .getMetadata()
-            .getGuid());
-
+    private StepPhase createBuild(DelegateExecution context, UUID packageGuid, StepLogger stepLogger) {
+        try {
+            context.setVariable(Constants.VAR_BUILD_GUID, client.createBuild(packageGuid)
+                                                                .getMetadata()
+                                                                .getGuid());
+        } catch (CloudOperationException e) {
+            handleCloudOperationException(e, context, packageGuid, stepLogger);
+        }
         return StepPhase.POLL;
     }
 
+    private void handleCloudOperationException(CloudOperationException e, DelegateExecution context, UUID packageGuid,
+                                               StepLogger stepLogger) {
+        if (e.getStatusCode() == HttpStatus.UNPROCESSABLE_ENTITY) {
+            stepLogger.info(Messages.BUILD_FOR_PACKAGE_0_ALREADY_EXISTS, packageGuid);
+            stepLogger.warn(e, e.getMessage());
+            processLastBuild(packageGuid, context);
+            return;
+        }
+        throw e;
+    }
+
+    private void processLastBuild(UUID packageGuid, DelegateExecution context) {
+        CloudBuild lastBuild = getLastBuild(client.getBuildsForPackage(packageGuid));
+        if (lastBuild == null) {
+            throw new CloudOperationException(HttpStatus.NOT_FOUND, format(Messages.NO_BUILDS_FOUND_FOR_PACKAGE, packageGuid));
+        }
+        context.setVariable(Constants.VAR_BUILD_GUID, lastBuild.getMetadata()
+                                                               .getGuid());
+    }
 }


### PR DESCRIPTION
If ResourceAccessException occurs when creating a build the deployment fails with CloudOperationException unprocessable entity because there is already a build.