### PR TITLE
Ignore schema from routes parameter

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/v2/ApplicationUrisCloudModelBuilder.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/v2/ApplicationUrisCloudModelBuilder.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections4.MapUtils;
-
 import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudApplicationExtended;
 import com.sap.cloud.lm.sl.cf.core.model.DeployedMtaModule;
 import com.sap.cloud.lm.sl.cf.core.model.SupportedParameters;

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/parser/UriParametersParser.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/parser/UriParametersParser.java
@@ -16,6 +16,7 @@ import org.apache.commons.collections4.CollectionUtils;
 
 import com.sap.cloud.lm.sl.cf.core.model.SupportedParameters;
 import com.sap.cloud.lm.sl.cf.core.util.ApplicationURI;
+import com.sap.cloud.lm.sl.cf.core.util.UriUtil;
 import com.sap.cloud.lm.sl.cf.core.validators.parameters.RoutesValidator;
 import com.sap.cloud.lm.sl.mta.util.PropertiesUtil;
 
@@ -141,7 +142,9 @@ public class UriParametersParser implements ParametersParser<List<String>> {
                 .collect(Collectors.toList());
         }
 
-        return allNonNullRoutes;
+        return allNonNullRoutes.stream()
+            .map(UriUtil::stripScheme)
+            .collect(Collectors.toList());
     }
 
     public String modifyUri(String inputURI, List<Map<String, Object>> customURIParts) {

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationURI.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationURI.java
@@ -10,20 +10,9 @@ import com.sap.cloud.lm.sl.cf.core.model.SupportedParameters;
 
 public class ApplicationURI {
 
-    public static final String DEFAULT_SCHEME_SEPARATOR = "://";
-    public static final char DEFAULT_PATH_SEPARATOR = '/';
     public static final char DEFAULT_HOST_DOMAIN_SEPARATOR = '.';
 
-    public static final String SCHEME_PARAMETER = "scheme";
-
-    public static final int STANDARD_HTTP_PORT = 80;
-    public static final int STANDARD_HTTPS_PORT = 443;
-
-    public static final String HTTP_PROTOCOL = "http";
-    public static final String HTTPS_PROTOCOL = "https";
-
     private String uri;
-    private String scheme;
     private String host;
     private String domain;
     private String path;
@@ -34,7 +23,7 @@ public class ApplicationURI {
     }
 
     public ApplicationURI(String initial) {
-        uri = stripScheme(initial);
+        uri = UriUtil.stripScheme(initial);
 
         int domainIndex = uri.indexOf(DEFAULT_HOST_DOMAIN_SEPARATOR);
         int pathIndex = UriUtil.getPathIndexAfter(uri, domainIndex);
@@ -52,20 +41,9 @@ public class ApplicationURI {
         }
     }
 
-    private String stripScheme(String uri) {
-        int protocolIndex = uri.indexOf(DEFAULT_SCHEME_SEPARATOR);
-        if (protocolIndex == -1) {
-            return uri;
-        }
-
-        setScheme(uri.substring(0, protocolIndex));
-        return uri.substring(protocolIndex + DEFAULT_SCHEME_SEPARATOR.length());
-    }
-
     public Map<String, Object> getURIParts() {
         Map<String, Object> uriParts = new HashMap<>();
 
-        uriParts.put(SCHEME_PARAMETER, getScheme());
         uriParts.put(SupportedParameters.HOST, getHost());
         uriParts.put(SupportedParameters.DOMAIN, getDomain());
         uriParts.put(SupportedParameters.ROUTE_PATH, getPath());
@@ -75,8 +53,6 @@ public class ApplicationURI {
 
     public Object getURIPart(String partName) {
         switch (partName) {
-            case SCHEME_PARAMETER:
-                return getScheme();
             case SupportedParameters.HOST:
                 return getHost();
             case SupportedParameters.DOMAIN:
@@ -90,9 +66,6 @@ public class ApplicationURI {
 
     public void setURIPart(String partName, String part) {
         switch (partName) {
-            case SCHEME_PARAMETER:
-                setScheme(part);
-                break;
             case SupportedParameters.HOST:
                 setHost(part);
                 break;
@@ -109,11 +82,6 @@ public class ApplicationURI {
     public String toString() {
         StringBuilder url = new StringBuilder();
 
-        if (StringUtils.isNotEmpty(getScheme())) {
-            url.append(getScheme())
-                .append(ApplicationURI.DEFAULT_SCHEME_SEPARATOR);
-        }
-
         if (StringUtils.isNotEmpty(getHost())) {
             url.append(getHost())
                 .append(ApplicationURI.DEFAULT_HOST_DOMAIN_SEPARATOR);
@@ -126,14 +94,6 @@ public class ApplicationURI {
         }
 
         return url.toString();
-    }
-
-    public String getScheme() {
-        return scheme;
-    }
-
-    public void setScheme(String scheme) {
-        this.scheme = scheme;
     }
 
     public String getHost() {

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/UriUtil.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/UriUtil.java
@@ -76,6 +76,15 @@ public class UriUtil {
 
         return uri.toString();
     }
+    
+    public static String stripScheme(String uri) {
+        int protocolIndex = uri.indexOf(DEFAULT_SCHEME_SEPARATOR);
+        if (protocolIndex == -1) {
+            return uri;
+        }
+
+        return uri.substring(protocolIndex + DEFAULT_SCHEME_SEPARATOR.length());
+    }
 
     public static Pair<String, String> getHostAndDomain(String uri) {
         uri = getUriWithoutScheme(uri);

--- a/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/parser/UriParametersParserTest.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/parser/UriParametersParserTest.java
@@ -1,5 +1,6 @@
 package com.sap.cloud.lm.sl.cf.core.parser;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -25,34 +26,60 @@ public class UriParametersParserTest {
         // @formatter:off
         return Stream.of(
             // with no uri parameters
-            Arguments.of(null, null, null, null, 
+            Arguments.of(null, null, null, null, null,
                 new Expectation(Expectation.Type.STRING, Arrays.asList(DEFAULT_HOST + "." + DEFAULT_DOMAIN).toString())),
             // with only host parameter
-            Arguments.of("some-host", null, null, null, 
+            Arguments.of("some-host", null, null, null, null,
                 new Expectation(Expectation.Type.STRING, Arrays.asList("some-host." + DEFAULT_DOMAIN).toString())),
             // with host and domain parameters
-            Arguments.of("some-host", "some-domain.com", null, null,
+            Arguments.of("some-host", "some-domain.com", null, null, null,
                 new Expectation(Expectation.Type.STRING, Arrays.asList("some-host.some-domain.com").toString())),
             // with plural hosts and domains parameters
-            Arguments.of(null, null, Arrays.asList("host1", "host2"), Arrays.asList("domain1.com", "domain2.com"),
+            Arguments.of(null, null, Arrays.asList("host1", "host2"), Arrays.asList("domain1.com", "domain2.com"), null,
                 new Expectation(Expectation.Type.STRING, 
                     Arrays.asList("host1.domain1.com", "host2.domain1.com", "host1.domain2.com", "host2.domain2.com").toString())),
             // with both singular and plural parameters, testing that only the plural parameters are taken
-            Arguments.of("host1", "domain1.com", Arrays.asList("host2"), Arrays.asList("domain2.com", "domain3.com"),
-                new Expectation(Expectation.Type.STRING, Arrays.asList("host2.domain2.com", "host2.domain3.com").toString()))
+            Arguments.of("host1", "domain1.com", Arrays.asList("host2"), Arrays.asList("domain2.com", "domain3.com"), null,
+                new Expectation(Expectation.Type.STRING, Arrays.asList("host2.domain2.com", "host2.domain3.com").toString())),
+            // with only routes parameters
+            Arguments.of(null, null, null, null,  Arrays.asList("my.custom.route"),
+                new Expectation(Expectation.Type.STRING, Arrays.asList("my.custom.route").toString())),
+            // with host and routes parameters - host is ignored
+            Arguments.of("some-host", null, null, null,  Arrays.asList("my.custom.route"),
+                new Expectation(Expectation.Type.STRING, Arrays.asList("my.custom.route").toString())),
+            // with domain and routes parameters - host is ignored
+            Arguments.of(null, "some-domain.com", null, null,  Arrays.asList("my.custom.route"),
+                new Expectation(Expectation.Type.STRING, Arrays.asList("my.custom.route").toString())),
+            // with routes parameters containing starting with http schema - it is removed
+            Arguments.of(null, null, null, null,  Arrays.asList("https://my.custom.route", "http://*.my.custom.route"),
+                new Expectation(Expectation.Type.STRING, Arrays.asList("my.custom.route", "*.my.custom.route").toString()))
         // @formatter:on
         );
     }
 
     @ParameterizedTest
     @MethodSource
-    public void testUriParameterParsing(String host, String domain, List<String> hosts, List<String> domains, Expectation expectation) {
+    public void testUriParameterParsing(String host, String domain, List<String> hosts, List<String> domains, List<String> routes, Expectation expectation) {
         Map<String, Object> parameterMap = new HashMap<>();
         parameterMap.put(SupportedParameters.HOST, host);
         parameterMap.put(SupportedParameters.HOSTS, hosts);
         parameterMap.put(SupportedParameters.DOMAIN, domain);
         parameterMap.put(SupportedParameters.DOMAINS, domains);
+        parameterMap.put(SupportedParameters.ROUTES, constructRoutesParameter(routes));
 
         tester.test(() -> new UriParametersParser(DEFAULT_HOST, DEFAULT_DOMAIN, null).parse(Arrays.asList(parameterMap)), expectation);
+    }
+
+    private List<Map<String, Object>> constructRoutesParameter(List<String> routes) {
+        if (routes == null) {
+            return null;
+        }
+        List<Map<String, Object>> routesParameter = new ArrayList<>();
+        for (String route : routes) {
+            Map<String, Object> routeMap = new HashMap<>();
+            routeMap.put(SupportedParameters.ROUTE, route);
+            routesParameter.add(routeMap);
+        }
+        return routesParameter;
     }
 }

--- a/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/util/UriUtilTest.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/util/UriUtilTest.java
@@ -139,7 +139,6 @@ public class UriUtilTest {
         public void testGetUriWithoutSchemeWithApplicationURI() {
             ApplicationURI actualUri = new ApplicationURI(uri);
 
-            actualUri.setScheme(null);
             assertEquals(expectedUri, actualUri.toString());
         }
     }


### PR DESCRIPTION
#### Description: 
We should behave the same way as CF CLI when one has defined
routes containing http(s) schema. Schema is not used at all in CF,
so we should ignore it before sending it to cf java client, that
does not expect it.

#### Issue: LMCROSSITXSADEPLOY-1601

