### PR TITLE
Ignore null objects returned from the object store

### DIFF
--- a/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/ObjectStoreFileStorage.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/services/ObjectStoreFileStorage.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -159,6 +160,7 @@ public class ObjectStoreFileStorage implements FileStorage {
     private Set<String> getEntryNames(Predicate<? super StorageMetadata> filter) {
         return blobStore.list(container, new ListContainerOptions().withDetails())
             .stream()
+            .filter(Objects::nonNull)
             .filter(filter)
             .map(StorageMetadata::getName)
             .collect(Collectors.toSet());


### PR DESCRIPTION
#### Description: 
This is needed because when some file is being deleted, it is being scheduled for deletion
and it is not deleted right away. When this happens, the file id will be returned from the blob store
but its metadata will be null and thus a NPE will be thrown.

For more information check this: https://issues.apache.org/jira/browse/JCLOUDS-1504

#### Issue: LMCROSSITXSADEPLOY-1581

This need to be reverted when the https://github.com/jclouds/jclouds/pull/1276 is being merged!



