### PR TITLE
Improve 'application not modified' message

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -274,7 +274,7 @@ public class Messages {
     public static final String CREATING_SERVICE_BROKER = "Creating service broker \"{0}\"...";
     public static final String UPDATING_SERVICE_BROKER = "Updating service broker \"{0}\"...";
     public static final String DELETING_SERVICE_BROKER = "Deleting service broker \"{0}\" for application \"{1}\"...";
-    public static final String APPLICATION_UNCHANGED = "Application \"{0}\" is not modified and will not be updated";
+    public static final String APPLICATION_ATTRIBUTES_UNCHANGED = "Application \"{0}\" attributes are not modified and will not be updated";
     public static final String WILL_NOT_REBIND_APP_TO_SERVICE = "Service \"{0}\" will not be rebound to application \"{1}\" because the binding parameters are not modified";
     public static final String SERVICE_BROKER_DOES_NOT_EXIST = "Service broker with name \"{0}\" does not exist";
     public static final String EXECUTING_HOOK_0 = "Executing hook \"{0}\"";

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
@@ -281,7 +281,7 @@ public class CreateOrUpdateAppStep extends SyncFlowableStep {
 
         private void reportApplicationUpdateStatus(CloudApplicationExtended app, boolean appPropertiesChanged) {
             if (!appPropertiesChanged) {
-                getStepLogger().info(Messages.APPLICATION_UNCHANGED, app.getName());
+                getStepLogger().info(Messages.APPLICATION_ATTRIBUTES_UNCHANGED, app.getName());
                 return;
             }
             getStepLogger().debug(Messages.APP_UPDATED, app.getName());


### PR DESCRIPTION
The message in it's former state implies that the whole application is not updated, which is not the case - the app bits may very well be updated and just a moment later staged, etc. .
By specifying that the attributes are not changed and will not be updated the user gains more insight without being confused by the following messages.

#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->


#### Issue: <!-- Link to a Github Issue, delete if not applicable -->

