### PR TITLE
fix kibana correlation-id entries

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/Constants.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/Constants.java
@@ -27,7 +27,7 @@ public class Constants {
     public static final String ENV_DEPLOY_ID = "DEPLOY_ID";
 
     // Variables
-    public static final String ATTR_CORRELATION_ID = "correlation-id";
+    public static final String ATTR_CORRELATION_ID = "correlation_id";
     public static final String EXCHANGED_TOKEN = "exchangedToken";
     public static final String RESTRICTED_UAA_CLIENTS = "restricted-uaa-clients";
 


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
This changes correlation-id to correlation_id so that the field is
permitted and will be logged.

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
Bug: LMCROSSITXSADEPLOY-1608
