### PR TITLE
Handle nullable default domain

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/helpers/SystemParameters.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/helpers/SystemParameters.java
@@ -9,6 +9,7 @@ import java.util.function.Supplier;
 import com.sap.cloud.lm.sl.cf.core.model.SupportedParameters;
 import com.sap.cloud.lm.sl.cf.core.util.NameUtil;
 import com.sap.cloud.lm.sl.cf.core.validators.parameters.HostValidator;
+import com.sap.cloud.lm.sl.common.util.CommonUtil;
 import com.sap.cloud.lm.sl.common.util.MapUtil;
 import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
 import com.sap.cloud.lm.sl.mta.model.Module;
@@ -72,9 +73,9 @@ public class SystemParameters {
         systemParameters.put(SupportedParameters.ORG, organization);
         systemParameters.put(SupportedParameters.USER, user);
         systemParameters.put(SupportedParameters.SPACE, space);
-        systemParameters.put(SupportedParameters.DEFAULT_DOMAIN, defaultDomain);
+        systemParameters.put(SupportedParameters.DEFAULT_DOMAIN, getDefaultDomain());
         if (reserveTemporaryRoutes) {
-            systemParameters.put(SupportedParameters.DEFAULT_IDLE_DOMAIN, defaultDomain);
+            systemParameters.put(SupportedParameters.DEFAULT_IDLE_DOMAIN, getDefaultDomain());
         }
         systemParameters.put(SupportedParameters.XS_TARGET_API_URL, getControllerUrl());
         systemParameters.put(SupportedParameters.CONTROLLER_URL, getControllerUrl());
@@ -90,9 +91,9 @@ public class SystemParameters {
         Map<String, Object> moduleSystemParameters = new HashMap<>();
 
         Map<String, Object> moduleParameters = Collections.unmodifiableMap(module.getParameters());
-        moduleSystemParameters.put(SupportedParameters.DOMAIN, defaultDomain);
+        moduleSystemParameters.put(SupportedParameters.DOMAIN, getDefaultDomain());
         if (reserveTemporaryRoutes) {
-            moduleSystemParameters.put(SupportedParameters.IDLE_DOMAIN, defaultDomain);
+            moduleSystemParameters.put(SupportedParameters.IDLE_DOMAIN, getDefaultDomain());
         }
         moduleSystemParameters.put(SupportedParameters.APP_NAME, module.getName());
         moduleSystemParameters.put(SupportedParameters.INSTANCES, 1);
@@ -104,6 +105,10 @@ public class SystemParameters {
         moduleSystemParameters.put(SupportedParameters.GENERATED_PASSWORD, credentialsGenerator.next(GENERATED_CREDENTIALS_LENGTH));
 
         return moduleSystemParameters;
+    }
+
+    private String getDefaultDomain() {
+        return defaultDomain == null ? "" : defaultDomain;
     }
 
     private String getDefaultTimestamp() {
@@ -167,6 +172,10 @@ public class SystemParameters {
     private String getDefaultHost(String moduleName) {
         String host = (targetName + " " + moduleName).replaceAll("\\s", "-")
                                                      .toLowerCase();
+        if (CommonUtil.isEmpty(getDefaultDomain())) {
+            return "";
+        }
+
         if (!HOST_VALIDATOR.isValid(host)) {
             return HOST_VALIDATOR.attemptToCorrect(host);
         }

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/validators/parameters/DomainValidator.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/validators/parameters/DomainValidator.java
@@ -22,6 +22,9 @@ public class DomainValidator implements ParameterValidator {
         result = result.replaceAll(DOMAIN_ILLEGAL_CHARACTERS, "-");
         result = result.replaceAll("^(\\-*)", "");
         result = result.replaceAll("(\\-*)$", "");
+        if (result.isEmpty()) {
+            return result;
+        }
         if (!isValid(result)) {
             throw new ContentException(Messages.COULD_NOT_CREATE_VALID_DOMAIN, domain);
         }

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/validators/parameters/HostValidator.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/validators/parameters/HostValidator.java
@@ -25,6 +25,9 @@ public class HostValidator implements ParameterValidator {
         result = result.replaceAll(HOST_ILLEGAL_CHARACTERS, "-");
         result = result.replaceAll("^(\\-*)", "");
         result = result.replaceAll("(\\-*)$", "");
+        if (result.isEmpty()) {
+            return result;
+        }
         if (!isValid(result)) {
             throw new SLException(Messages.COULD_NOT_CREATE_VALID_HOST, host);
         }

--- a/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/validators/parameters/DomainValidatorTest.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/validators/parameters/DomainValidatorTest.java
@@ -42,11 +42,11 @@ public class DomainValidatorTest {
             // (2)
             { "test.test.test", true , new Expectation("test.test.test"), },
             // (3)
-            { "---", false, new Expectation(Expectation.Type.EXCEPTION, "Could not create a valid domain from \"---\"") },
+            { "---", false, new Expectation("") },
             // (4)
             { "@12", false, new Expectation("12"), },
             // (5)
-            { "@@@", false, new Expectation(Expectation.Type.EXCEPTION, "Could not create a valid domain from \"@@@\"") },
+            { "@@@", false, new Expectation("") },
 // @formatter:on
         });
     }

--- a/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/validators/parameters/HostValidatorTest.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/validators/parameters/HostValidatorTest.java
@@ -40,11 +40,11 @@ public class HostValidatorTest {
             // (1)
             { "test-test-test", true , new Expectation("test-test-test"), },
             // (2)
-            { "---", false, new Expectation(Expectation.Type.EXCEPTION, "Could not create a valid host from \"---\"") },
+            { "---", false, new Expectation("") },
             // (3)
             { "@12", false, new Expectation("12"), },
             // (4)
-            { "@@@", false, new Expectation(Expectation.Type.EXCEPTION, "Could not create a valid host from \"@@@\"") },
+            { "@@@", false, new Expectation("") },
 // @formatter:on
         });
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CollectSystemParametersStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CollectSystemParametersStep.java
@@ -46,6 +46,9 @@ public class CollectSystemParametersStep extends SyncFlowableStep {
         CloudControllerClient client = execution.getControllerClient();
         String defaultDomainName = getDefaultDomain(client);
         getStepLogger().debug(Messages.DEFAULT_DOMAIN, defaultDomainName);
+        if (defaultDomainName == null) {
+            getStepLogger().warn("No shared domains found. Default URLs will not be created.");
+        }
 
         DeploymentDescriptor descriptor = StepsUtil.getDeploymentDescriptor(execution.getContext());
         SystemParameters systemParameters = createSystemParameters(execution.getContext(), client, defaultDomainName,


### PR DESCRIPTION
#### Description: 
When the default domain is null the deployment would fail
with the error that the application uris could not be created.
This commit handles this case and ensures that:
   1. When any host is being specified - the deployment will fail with error
      saying that the domain should be specified, as well.
   2. If nothing is specified, the deployment will finish with no errors
      and will create applications which have no routes bound.
This commit would be reverted with the implementation of LMCROSSITXSADEPLOY-1684

#### Issue: LMCROSSITXSADEPLOY-1681

