### PR TITLE
Adopt jackson.version 2.10.0 and netty-codec-http.version 4.1.42.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <jackson.version>2.10.0</jackson.version>
         <jackson-databind.version>2.10.0</jackson-databind.version>
         <jackson-asl.version>1.9.13</jackson-asl.version>
-        <netty-codec-http.version>4.1.36.Final</netty-codec-http.version>
+        <netty-codec-http.version>4.1.42.Final</netty-codec-http.version>
         <liquibase.version>3.4.1</liquibase.version>
         <liquibase-slf4j.version>1.2.1</liquibase-slf4j.version>
         <cloudfoundry.client.version>1.13.18</cloudfoundry.client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
         <spring.cloud.version>1.2.3.RELEASE</spring.cloud.version>
         <hana.cloud.version>1.0.4.RELEASE</hana.cloud.version>
         <quartz.version>2.2.1</quartz.version>
-        <jackson.version>2.10.0.pr1</jackson.version>
-        <jackson-databind.version>2.9.10</jackson-databind.version>
+        <jackson.version>2.10.0</jackson.version>
+        <jackson-databind.version>2.10.0</jackson-databind.version>
         <jackson-asl.version>1.9.13</jackson-asl.version>
         <netty-codec-http.version>4.1.36.Final</netty-codec-http.version>
         <liquibase.version>3.4.1</liquibase.version>


### PR DESCRIPTION
Adopt jackson.version 2.10.0 due to CVE-2019-17531