### PR TITLE
Fix authorization for space name-based APIs

### DIFF
--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/api/impl/FilesApiServiceImpl.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/api/impl/FilesApiServiceImpl.java
@@ -31,6 +31,7 @@ import com.sap.cloud.lm.sl.cf.web.api.FilesApiService;
 import com.sap.cloud.lm.sl.cf.web.api.model.FileMetadata;
 import com.sap.cloud.lm.sl.cf.web.api.model.ImmutableFileMetadata;
 import com.sap.cloud.lm.sl.cf.web.message.Messages;
+import com.sap.cloud.lm.sl.cf.web.util.ServletUtils;
 import com.sap.cloud.lm.sl.common.SLException;
 
 @Named
@@ -60,7 +61,7 @@ public class FilesApiServiceImpl implements FilesApiService {
     public ResponseEntity<FileMetadata> uploadFile(HttpServletRequest request, String spaceGuid) {
         try {
             StopWatch stopWatch = StopWatch.createStarted();
-            LOGGER.trace("Received upload request on URI: {}", request.getRequestURI());
+            LOGGER.trace("Received upload request on URI: {}", ServletUtils.getDecodedURI(request));
             FileEntry fileEntry = uploadFiles(request, spaceGuid).get(0);
             FileMetadata file = parseFileEntry(fileEntry);
             AuditLoggingProvider.getFacade()

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/message/Messages.java
@@ -16,6 +16,7 @@ public final class Messages {
     public static final String COULD_NOT_UPLOAD_FILE_0 = "Could not upload file: {0}";
     public static final String ACTION_0_CANNOT_BE_EXECUTED_OVER_OPERATION_1 = "Action \"{0}\" cannot be executed over operation \"{1}\".";
     public static final String OPERATION_0_NOT_FOUND = "Operation \"{0}\" was not found.";
+    public static final String COULD_NOT_DECODE_URI_0 = "Could not decode URI \"{0}\".";
 
     // Audit log messages
 

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/CompositeUriAuthorizationFilter.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/CompositeUriAuthorizationFilter.java
@@ -11,6 +11,8 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.sap.cloud.lm.sl.cf.web.util.ServletUtils;
+
 @Named("compositeUriAuthorizationFilter")
 public class CompositeUriAuthorizationFilter extends AuthorizationFilter {
 
@@ -26,7 +28,7 @@ public class CompositeUriAuthorizationFilter extends AuthorizationFilter {
     @Override
     protected boolean ensureUserIsAuthorized(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
-            String uri = request.getRequestURI();
+            String uri = ServletUtils.getDecodedURI(request);
             LOGGER.trace("Looking for a matching authorization filter for request to \"{}\"...", uri);
             LOGGER.trace("Registered authorization filters: {}", uriAuthorizationFilters);
             for (UriAuthorizationFilter uriAuthorizationFilter : uriAuthorizationFilters) {
@@ -45,7 +47,7 @@ public class CompositeUriAuthorizationFilter extends AuthorizationFilter {
     private boolean ensureUserIsAuthorized(UriAuthorizationFilter uriAuthorizationFilter, HttpServletRequest request,
                                            HttpServletResponse response)
         throws IOException {
-        LOGGER.debug("Using authorization filter {} for request to \"{}\".", uriAuthorizationFilter, request.getRequestURI());
+        LOGGER.debug("Using authorization filter {} for request to \"{}\".", uriAuthorizationFilter, ServletUtils.getDecodedURI(request));
         return uriAuthorizationFilter.ensureUserIsAuthorized(request, response);
     }
 

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/MtasApiAuthorizationFilter.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/MtasApiAuthorizationFilter.java
@@ -10,6 +10,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.http.HttpStatus;
 
+import com.sap.cloud.lm.sl.cf.web.util.ServletUtils;
+
 @Named
 public class MtasApiAuthorizationFilter extends SpaceGuidBasedAuthorizationFilter {
 
@@ -27,7 +29,7 @@ public class MtasApiAuthorizationFilter extends SpaceGuidBasedAuthorizationFilte
 
     @Override
     protected String extractSpaceGuid(HttpServletRequest request) {
-        String uri = request.getRequestURI();
+        String uri = ServletUtils.getDecodedURI(request);
         return extractSpaceGuid(uri);
     }
 

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/RequestSizeFilter.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/RequestSizeFilter.java
@@ -13,6 +13,8 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.filter.GenericFilterBean;
 
+import com.sap.cloud.lm.sl.cf.web.util.ServletUtils;
+
 @Named("requestSizeFilter")
 public class RequestSizeFilter extends GenericFilterBean {
 
@@ -21,7 +23,7 @@ public class RequestSizeFilter extends GenericFilterBean {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         long requestSize = request.getContentLengthLong();
-        String path = ((HttpServletRequest) request).getRequestURI();
+        String path = ServletUtils.getDecodedURI((HttpServletRequest) request);
         if (requestSize > MAX_REQUEST_SIZE_BYTES && !path.endsWith("/files")) {
             ((HttpServletResponse) response).sendError(HttpStatus.PAYLOAD_TOO_LARGE.value());
             return;

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/SpaceGuidBasedAuthorizationFilter.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/SpaceGuidBasedAuthorizationFilter.java
@@ -13,6 +13,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.sap.cloud.lm.sl.cf.web.message.Messages;
 import com.sap.cloud.lm.sl.cf.web.util.SecurityContextUtil;
+import com.sap.cloud.lm.sl.cf.web.util.ServletUtils;
 
 public abstract class SpaceGuidBasedAuthorizationFilter implements UriAuthorizationFilter {
 
@@ -40,14 +41,14 @@ public abstract class SpaceGuidBasedAuthorizationFilter implements UriAuthorizat
 
     private String extractAndLogSpaceGuid(HttpServletRequest request) {
         String spaceGuid = extractSpaceGuid(request);
-        LOGGER.trace("Extracted space GUID \"{}\" from request to \"{}\".", spaceGuid, request.getRequestURI());
+        LOGGER.trace("Extracted space GUID \"{}\" from request to \"{}\".", spaceGuid, ServletUtils.getDecodedURI(request));
         return spaceGuid;
     }
 
     private void logUnauthorizedRequest(HttpServletRequest request, ResponseStatusException e) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("User \"%s\" is not authorized for request to \"%s\".", SecurityContextUtil.getUserName(),
-                                       request.getRequestURI()),
+                                       ServletUtils.getDecodedURI(request)),
                          e);
         }
     }

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/SpaceNameBasedAuthorizationFilter.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/SpaceNameBasedAuthorizationFilter.java
@@ -14,6 +14,7 @@ import org.springframework.web.server.ResponseStatusException;
 import com.sap.cloud.lm.sl.cf.core.model.CloudTarget;
 import com.sap.cloud.lm.sl.cf.web.message.Messages;
 import com.sap.cloud.lm.sl.cf.web.util.SecurityContextUtil;
+import com.sap.cloud.lm.sl.cf.web.util.ServletUtils;
 
 public abstract class SpaceNameBasedAuthorizationFilter implements UriAuthorizationFilter {
 
@@ -42,14 +43,16 @@ public abstract class SpaceNameBasedAuthorizationFilter implements UriAuthorizat
 
     private CloudTarget extractAndLogTarget(HttpServletRequest request) {
         CloudTarget target = extractTarget(request);
-        LOGGER.trace("Extracted target from request to \"{}\": {}", request.getRequestURI(), target);
+        LOGGER.trace("Extracted target from request to \"{}\": {}", ServletUtils.getDecodedURI(request), target);
         return target;
     }
 
     private void logUnauthorizedRequest(HttpServletRequest request, ResponseStatusException e) {
         if (LOGGER.isDebugEnabled()) {
             String userName = SecurityContextUtil.getUserName();
-            LOGGER.debug(String.format("User \"%s\" is not authorized for request to \"%s\".", userName, request.getRequestURI()), e);
+            LOGGER.debug(String.format("User \"%s\" is not authorized for request to \"%s\".", userName,
+                                       ServletUtils.getDecodedURI(request)),
+                         e);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/util/ServletUtils.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/util/ServletUtils.java
@@ -1,0 +1,23 @@
+package com.sap.cloud.lm.sl.cf.web.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.sap.cloud.lm.sl.cf.web.message.Messages;
+
+public class ServletUtils {
+
+    public static String getDecodedURI(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        try {
+            return URLDecoder.decode(uri, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException(MessageFormat.format(Messages.COULD_NOT_DECODE_URI_0, uri), e);
+        }
+    }
+
+}

--- a/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/api/impl/FilesApiServiceImplTest.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/api/impl/FilesApiServiceImplTest.java
@@ -71,6 +71,8 @@ public class FilesApiServiceImplTest {
     @Before
     public void initialize() {
         MockitoAnnotations.initMocks(this);
+        Mockito.when(request.getRequestURI())
+               .thenReturn("");
         AuditLoggingProvider.setFacade(Mockito.mock(AuditLoggingFacade.class));
     }
 

--- a/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/security/SpaceGuidBasedAuthorizationFilterTest.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/security/SpaceGuidBasedAuthorizationFilterTest.java
@@ -28,6 +28,8 @@ public class SpaceGuidBasedAuthorizationFilterTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+        Mockito.when(request.getRequestURI())
+               .thenReturn("");
         dummyUriAuthorizationFilter = new DummyUriAuthorizationFilter(authorizationChecker);
     }
 

--- a/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/security/SpaceNameBasedAuthorizationFilterTest.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/security/SpaceNameBasedAuthorizationFilterTest.java
@@ -31,6 +31,8 @@ public class SpaceNameBasedAuthorizationFilterTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+        Mockito.when(request.getRequestURI())
+               .thenReturn("");
         dummyUriAuthorizationFilter = new DummyUriAuthorizationFilter(authorizationChecker);
     }
 
@@ -39,14 +41,16 @@ public class SpaceNameBasedAuthorizationFilterTest {
         dummyUriAuthorizationFilter.ensureUserIsAuthorized(request, response);
 
         Mockito.verify(authorizationChecker)
-               .ensureUserIsAuthorized(Mockito.eq(request), Mockito.any(), Mockito.eq(new CloudTarget(ORGANIZATION_NAME, SPACE_NAME)), Mockito.any());
+               .ensureUserIsAuthorized(Mockito.eq(request), Mockito.any(), Mockito.eq(new CloudTarget(ORGANIZATION_NAME, SPACE_NAME)),
+                                       Mockito.any());
     }
 
     @Test
     public void testWithException() throws IOException {
         Mockito.doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN))
                .when(authorizationChecker)
-               .ensureUserIsAuthorized(Mockito.eq(request), Mockito.any(), Mockito.eq(new CloudTarget(ORGANIZATION_NAME, SPACE_NAME)), Mockito.any());
+               .ensureUserIsAuthorized(Mockito.eq(request), Mockito.any(), Mockito.eq(new CloudTarget(ORGANIZATION_NAME, SPACE_NAME)),
+                                       Mockito.any());
 
         dummyUriAuthorizationFilter.ensureUserIsAuthorized(request, response);
 


### PR DESCRIPTION
The authorization didn't work for organizations/spaces with whitespace characters in their names (or other characters that require URL encoding).

JIRA: LMCROSSITXSADEPLOY-1768
