### PR TITLE
Lower job acquisition wait time in case of full queue

### DIFF
--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/configuration/FlowableConfiguration.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/configuration/FlowableConfiguration.java
@@ -36,6 +36,7 @@ public class FlowableConfiguration {
 
     private static final String DATABASE_SCHEMA_UPDATE = "true";
 
+    private static final int ASYNC_JOB_ACQUIRE_WAIT_TIME_IN_MILLIS = (int) TimeUnit.SECONDS.toMillis(3);
     private static final int JOB_EXECUTOR_LOCK_TIME_IN_MILLIS = (int) TimeUnit.MINUTES.toMillis(30);
     private static final String JOB_EXECUTOR_ID_TEMPLATE = "ds-%s/%d/%s";
 
@@ -95,6 +96,7 @@ public class FlowableConfiguration {
         jobExecutor.setLockOwner(jobExecutorId);
         jobExecutor.setUnlockOwnedJobs(true);
         jobExecutor.setTenantId(AbstractEngineConfiguration.NO_TENANT_ID);
+        jobExecutor.setDefaultAsyncJobAcquireWaitTimeInMillis(ASYNC_JOB_ACQUIRE_WAIT_TIME_IN_MILLIS);
         return jobExecutor;
     }
 


### PR DESCRIPTION
Change-Id: I18e1aef93bf1c6e249340d99404bb3668f204541

#### Description: 
There is a problem that when the queue of the job executor is full the thread is sleeping for 10 seconds. In that time our steps are finishing but it is still waiting. Awaking the thread earlier fasters the deploys by 50% and reduces the time between Flowable steps by 50%.


#### Issue: https://sapjira.wdf.sap.corp/browse/LMCROSSITXSADEPLOY-1759
