### PR TITLE
Fix deadlock during process abort

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/FlowableFacade.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/FlowableFacade.java
@@ -2,7 +2,6 @@ package com.sap.cloud.lm.sl.cf.process.flowable;
 
 import static java.text.MessageFormat.format;
 
-import java.text.MessageFormat;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -27,6 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sap.cloud.lm.sl.cf.persistence.Constants;
+import com.sap.cloud.lm.sl.cf.web.api.model.Operation;
+import com.sap.cloud.lm.sl.common.util.CommonUtil;
 
 @Named
 public class FlowableFacade {
@@ -121,6 +122,16 @@ public class FlowableFacade {
                                    .collect(Collectors.toList());
     }
 
+    private Set<String> getDeadLetterJobsIdsForProcess(String processId) {
+        return processEngine.getManagementService()
+                            .createDeadLetterJobQuery()
+                            .processInstanceId(processId)
+                            .list()
+                            .stream()
+                            .map(Job::getId)
+                            .collect(Collectors.toSet());
+    }
+
     private List<Job> getDeadLetterJobsForExecution(Execution execution) {
         return processEngine.getManagementService()
                             .createDeadLetterJobQuery()
@@ -197,7 +208,7 @@ public class FlowableFacade {
     public void executeJob(String processInstanceId) {
         List<Job> deadLetterJobs = getDeadLetterJobs(processInstanceId);
         if (deadLetterJobs.isEmpty()) {
-            LOGGER.info(MessageFormat.format("No dead letter jobs found for process with id {0}", processInstanceId));
+            LOGGER.info(format("No dead letter jobs found for process with id {0}", processInstanceId));
             return;
         }
         moveDeadLetterJobsToExecutableJobs(deadLetterJobs);
@@ -230,6 +241,14 @@ public class FlowableFacade {
                 // different if the process has parallel executions.
                 processEngine.getRuntimeService()
                              .setVariable(processInstanceId, Constants.PROCESS_ABORTED, Boolean.TRUE);
+                LOGGER.debug(format(Messages.WAITING_PROCESS_IS_READY_FOR_DELETION, processInstanceId));
+                while (true) {
+                    CommonUtil.sleep(1000);
+                    if (readyForDeletion(processInstanceId)) {
+                        break;
+                    }
+                }
+                LOGGER.debug(format(Messages.DELETING_PROCESS, processInstanceId));
                 processEngine.getRuntimeService()
                              .deleteProcessInstance(processInstanceId, deleteReason);
                 break;
@@ -240,6 +259,44 @@ public class FlowableFacade {
                 LOGGER.warn(format(Messages.RETRYING_PROCESS_ABORT, processInstanceId));
             }
         }
+    }
+
+    private boolean readyForDeletion(String processId) {
+        ProcessInstance processInstance = getProcessInstance(processId);
+        if (processInstance == null) {
+            LOGGER.debug(format(Messages.PROCESS_HAS_STATE, processId, Operation.State.getFinalStates()));
+            return false;
+        }
+        if (isProcessInstanceAtReceiveTask(processId)) {
+            LOGGER.debug(format(Messages.PROCESS_HAS_STATE, processId, Operation.State.ACTION_REQUIRED));
+            return false;
+        }
+        if (haveAllProcessesFailed(processId)) {
+            LOGGER.debug(format(Messages.PROCESS_AND_ALL_SUBPROCESSES_FAILED, processId));
+            return true;
+        }
+        LOGGER.debug(format(Messages.PROCESS_HAS_STATE, processId, Operation.State.RUNNING));
+        return false;
+    }
+
+    private boolean haveAllProcessesFailed(String processId) {
+        Set<String> processIds = getAllProcessExecutions(processId).stream()
+                                                                   .map(Execution::getProcessInstanceId)
+                                                                   .collect(Collectors.toSet());
+        Set<String> deadLetterJobIds = new HashSet<>();
+        for (String id : processIds) {
+            deadLetterJobIds.addAll(getDeadLetterJobsIdsForProcess(id));
+        }
+        // When root process is aborted, there is only one deadletter job for it
+        if (processIds.size() == 1) {
+            return deadLetterJobIds.size() == 1;
+        }
+
+        // When a subprocess (CallActivity) is aborted,
+        // there are deadletter jobs for all executions except for the execution of the root process.
+        // TODO This will not work when there are parallel executions running in the root process, not part of CallActivity (parallel
+        // gateway)
+        return (processIds.size() - 1) == deadLetterJobIds.size();
     }
 
     protected boolean isPastDeadline(long deadline) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/Messages.java
@@ -20,6 +20,10 @@ public class Messages {
     // Debug messages
 
     public static final String SETTING_VARIABLE = "Setting variable \"{0}\" to \"{1}\"...";
+    public static final String WAITING_PROCESS_IS_READY_FOR_DELETION = "Waiting process \"{0}\" is ready for deletion";
+    public static final String DELETING_PROCESS = "Deleting process \"{0}\"...";
+    public static final String PROCESS_HAS_STATE = "Process \"{0}\" has reached on of states [\"{1}\"]";
+    public static final String PROCESS_AND_ALL_SUBPROCESSES_FAILED = "Process \"{0}\" and all its subproceses (CallActivities) failed";
     public static final String SET_SUCCESSFULLY = "Variable \"{0}\" set successfully";
     public static final String SETTING_SECONDS_TO_WAIT_BEFORE_FLOWABLE_JOB_EXECUTOR_SHUTDOWN = "Setting \"{0}\" seconds to wait before shutdown of Flowable job executor...";
     public static final String SHUTTING_DOWN_FLOWABLE_JOB_EXECUTOR = "Shutting down Flowable job executor...";

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/api/impl/OperationsApiServiceImpl.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/api/impl/OperationsApiServiceImpl.java
@@ -104,7 +104,7 @@ public class OperationsApiServiceImpl implements OperationsApiService {
         ProcessAction action = processActionRegistry.getAction(actionId);
         action.execute(getAuthenticatedUser(request), operationId);
         AuditLoggingProvider.getFacade()
-                            .logAboutToStart(MessageFormat.format("{0} over operation with id {1}", action, operation.getProcessId()));
+                            .logAboutToStart(MessageFormat.format("{0} over operation with id {1}", action.getActionId(), operation.getProcessId()));
         return ResponseEntity.accepted()
                              .header("Location", getLocationHeader(operationId, spaceGuid))
                              .build();


### PR DESCRIPTION
#### Description: 
Fix deadlock when one operation is aborted. It happens because deletion of executions (in AbortProcessAction) happens simultaneously with their update (during failing the operation).
Now deletion will wait until all executions are updated and have deadletter jobs.

#### Issue:
Jira: LMCROSSITXSADEPLOY-1761
