### PR TITLE
Skip upload of unchanged application content

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/message/Messages.java
@@ -417,7 +417,8 @@ public class Messages {
     public static final String ARCHIVE_IS_VERIFIED = "Archive signature is verified";
     public static final String CHECKING_FOR_OVERWRITING_READ_ONLY_PARAMETERS = "Checking for overwriting read-only parameters for mta with id: \"{0}\"";
     public static final String NO_READ_ONLY_PARAMETERS_ARE_OVERWRITTEN = "No read-only parameters are overwritten";
-
+    public static final String CONTENT_OF_APPLICATION_0_IS_NOT_CHANGED = "Content of application \"{0}\" is not changed - upload will be skipped.";
+    
     protected Messages() {
     }
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UploadAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UploadAppStep.java
@@ -70,8 +70,13 @@ public class UploadAppStep extends TimeoutAsyncFlowableStep {
         getStepLogger().debug(Messages.UPLOADING_FILE_0_FOR_APP_1, fileName, app.getName());
 
         String newApplicationDigest = getNewApplicationDigest(execution, appArchiveId, fileName);
-        detectApplicationFileDigestChanges(execution, app.getName(), client, newApplicationDigest);
+        boolean contentChanged = detectApplicationFileDigestChanges(execution, app.getName(), client, newApplicationDigest);
+        if (!contentChanged) {
+            getStepLogger().debug(Messages.CONTENT_OF_APPLICATION_0_IS_NOT_CHANGED, app.getName());
+            return StepPhase.DONE;
+        }
         UploadToken uploadToken = asyncUploadFiles(execution, client, app, appArchiveId, fileName);
+
         getStepLogger().debug(Messages.STARTED_ASYNC_UPLOAD_OF_APP_0, app.getName());
         StepsUtil.setUploadToken(uploadToken, execution.getContext());
         return StepPhase.POLL;
@@ -138,8 +143,8 @@ public class UploadAppStep extends TimeoutAsyncFlowableStep {
                                              getMonitorUploadStatusCallback(app, filePath.toFile(), execution.getContext()));
     }
 
-    private void detectApplicationFileDigestChanges(ExecutionWrapper execution, String appName, CloudControllerClient client,
-                                                    String newApplicationDigest) {
+    private boolean detectApplicationFileDigestChanges(ExecutionWrapper execution, String appName, CloudControllerClient client,
+                                                       String newApplicationDigest) {
         CloudApplication appWithUpdatedEnvironment = client.getApplication(appName);
         ApplicationDigestDetector digestDetector = new ApplicationDigestDetector(appWithUpdatedEnvironment);
         String currentApplicationDigest = digestDetector.getExistingApplicationDigest();
@@ -148,6 +153,7 @@ public class UploadAppStep extends TimeoutAsyncFlowableStep {
             attemptToUpdateApplicationDigest(client, appWithUpdatedEnvironment, newApplicationDigest);
         }
         setAppContentChanged(execution, contentChanged);
+        return contentChanged;
     }
 
     private void attemptToUpdateApplicationDigest(CloudControllerClient client, CloudApplication app, String newApplicationDigest) {


### PR DESCRIPTION
#### Description: 
Skip upload of application in cases when the content is not changed.
This will speed up the deployment and will eliminate one call to the CC in case the content is not changed



