### PR TITLE
Fix abort deadlocks

### DIFF
--- a/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/Constants.java
+++ b/com.sap.cloud.lm.sl.cf.persistence/src/main/java/com/sap/cloud/lm/sl/cf/persistence/Constants.java
@@ -22,6 +22,7 @@ public class Constants {
     public static final String FILE_ENTRY_ID = "FILE_ID";
 
     protected Constants() {
+
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/Messages.java
@@ -5,11 +5,29 @@ public class Messages {
     private Messages() {
     }
 
+    // Info messages
+
+    public static final String NEW_ACTIVE_EXECUTIONS_WITHOUT_CHILDREN_0_FOR_PROCESS_1 = "New active executions without children \"{0}\" for process: \"{1}\"";
+    public static final String TIMEOUT_OF_0_FOR_PROCESS_1_HAS_BEEN_REACHED = "Timeout of \"{0}\" for process: \"{1}\" has been reached";
+    public static final String CURRENT_EXECUTION_WITHOUT_CHILDREN_0 = "Current execution without children: \"{0}\"";
+    public static final String PARENT_EXECUTION_WILL_NOT_BE_WAITED_TO_FINISH = "Parent execution: \"{0}\" will not be waited to finish";
+    public static final String TIMER_EXECUTION_WILL_NOT_BE_WAITED_TO_FINISH = "Timer execution: \"{0}\" will not be waited to finish";
+    public static final String EXECUTION_0_DOES_NOT_HAVE_DEAD_LETTER_JOBS = "Execution: \"{0}\" does not have dead letter jobs";
+    public static final String PROCESS_0_HAS_BEEN_SUSPENDED_SUCCESSFULLY = "Process \"{0}\" has been suspended successfully";
+    public static final String PROCESS_0_HAS_BEEN_DELETED_SUCCESSFULLY = "Process \"{0}\" has been deleted successfully";
+    public static final String PROCESS_0_HAS_ALREADY_BEEN_SUSPENDED = "Process: \"{0}\" has already been suspended";
+    public static final String PROCESS_INSTANCE_0_IS_AT_RECEIVE_TASK = "Process instance: \"{0}\" is at receive task";
+    public static final String NO_DEAD_LETTER_JOBS_FOUND_FOR_PROCESS_WITH_ID_0 = "No dead letter jobs found for process with id \"{0}\"";
+    public static final String DEAD_LETTER_JOBS_FOR_PROCESS_0_1 = "Dead letter jobs for process: \"{0}\": \"{1}\"";
+
+
     // Exception messages
 
-    public static final String ABORT_OPERATION_TIMED_OUT = "Abort operation timed out";
+    public static final String ABORT_OPERATION_FOR_PROCESS_0_FAILED = "Abort operation for process: \"{0}\" failed";
+    public static final String ABORT_OPERATION_FAILED = "Abort operation failed: {0}";
     public static final String FLOWABLE_JOB_RETRY_FAILED = "Flowable job retry failed";
     public static final String PROCESS_STEP_NOT_REACHED_BEFORE_TIMEOUT = "Step \"{0}\" of process \"{1}\" not reached before timeout";
+    public static final String PROCESS_WITH_ID_0_NOT_FOUND_WHILE_WAITING_FOR_EXECUTION_1_TO_FINISH = "Process with id: \"{0}\" not found while waiting for execution: \"{1}\" to finish";
 
     // Warn messages
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/RetryProcessAdditionalAction.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/RetryProcessAdditionalAction.java
@@ -36,8 +36,7 @@ public class RetryProcessAdditionalAction implements AdditionalProcessAction {
     }
 
     private List<String> findFailedActivityIds(String superProcessInstanceId) {
-        List<Execution> executionsForProcess = flowableFacade.getActiveProcessExecutions(superProcessInstanceId);
-
+        List<Execution> executionsForProcess = flowableFacade.getProcessExecutionsWhichExecuteCallActivity(superProcessInstanceId);
         return executionsForProcess.stream()
                                    .map(Execution::getActivityId)
                                    .collect(Collectors.toList());

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/SetRetryPhaseAdditionalProcessAction.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/SetRetryPhaseAdditionalProcessAction.java
@@ -4,7 +4,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.flowable.engine.impl.persistence.entity.ExecutionEntityImpl;
-import org.flowable.engine.runtime.Execution;
 
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.steps.StepPhase;
@@ -21,9 +20,9 @@ public class SetRetryPhaseAdditionalProcessAction implements AdditionalProcessAc
 
     @Override
     public void executeAdditionalProcessAction(String processInstanceId) {
-        flowableFacade.getActiveProcessExecutions(processInstanceId)
+        flowableFacade.getProcessExecutionsWhichExecuteCallActivity(processInstanceId)
                       .stream()
-                      .map(this::toExecutionEntityImpl)
+                      .map(FlowableFacade::toExecutionEntityImpl)
                       .filter(executionEntityImpl -> executionEntityImpl.getDeadLetterJobCount() > 0)
                       .map(ExecutionEntityImpl::getProcessInstanceId)
                       .forEach(executionProcessId -> flowableFacade.getProcessEngine()
@@ -31,11 +30,6 @@ public class SetRetryPhaseAdditionalProcessAction implements AdditionalProcessAc
                                                                    .setVariable(executionProcessId, Constants.VAR_STEP_PHASE,
                                                                                 StepPhase.RETRY.toString()));
     }
-    
-    private ExecutionEntityImpl toExecutionEntityImpl(Execution e) {
-        return (ExecutionEntityImpl)e;
-    }
-
 
     @Override
     public String getApplicableActionId() {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/execute-tasks.bpmn
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/execute-tasks.bpmn
@@ -12,7 +12,7 @@
     <serviceTask id="incrementTaskIndexTask" name="Increment Task Index" flowable:async="true" flowable:delegateExpression="${incrementIndexStep}"></serviceTask>
     <exclusiveGateway id="sid-D1BA59BB-19D2-40A7-8C50-8DBD35AC6963" default="sid-3F51D90A-8256-4D3E-8BFB-66EEA61C0AB0"></exclusiveGateway>
     <exclusiveGateway id="sid-A72A16B0-7CD4-4C94-8A2D-75856CB783EE" default="taskNotExecutedFlow"></exclusiveGateway>
-    <intermediateCatchEvent id="sid-A55F319D-B571-4F5E-89C7-E2DCB340E71E">
+    <intermediateCatchEvent id="sid-A55F319D-B571-4F5E-89C7-E2DCB340E71E" name="TimerCatchEvent">
       <timerEventDefinition>
         <timeDuration>PT${applicationConfiguration.getStepPollingIntervalInSeconds()}S</timeDuration>
       </timerEventDefinition>

--- a/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-undeploy.bpmn
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/resources/com/sap/cloud/lm/sl/cf/process/xs2-undeploy.bpmn
@@ -50,7 +50,7 @@
     <sequenceFlow id="notAllServiceBrokerSubscribersAreRestartedFlow" sourceRef="areAllServiceBrokerSubscribersRestartedGateway" targetRef="restartServiceBrokerSubscriberTask"></sequenceFlow>
     <serviceTask id="updateServiceBrokerSubscriberTask" name="Update Service Broker Subscriber" flowable:async="true" flowable:delegateExpression="${updateServiceBrokerSubscriberStep}"></serviceTask>
     <exclusiveGateway id="isServiceBrokerSubscriberStartedGateway" name="Is Service Broker Subscriber Started" default="waitForServiceBrokerSubscriberToStartFlow"></exclusiveGateway>
-    <intermediateCatchEvent id="waitForServiceBrokerSubscribersToBeRestarted">
+    <intermediateCatchEvent id="waitForServiceBrokerSubscribersToBeRestarted" name="TimerCatchEvent">
       <timerEventDefinition>
         <timeDuration>PT${applicationConfiguration.getStepPollingIntervalInSeconds()}S</timeDuration>
       </timerEventDefinition>
@@ -72,7 +72,7 @@
     <sequenceFlow id="flow40" sourceRef="deleteServicesCallActivity" targetRef="updateSubscribersTask"></sequenceFlow>
     <exclusiveGateway id="sid-1B34E2BF-18FD-49A5-9083-4892F4E2BA5C" default="deleteDiscontinuedServicesFlow"></exclusiveGateway>
     <sequenceFlow id="sid-5C5B02D1-A40E-41A4-8C0B-C93A7E500B93" sourceRef="undeployAppsCallActivity" targetRef="shouldDeleteDiscontinuedServicesGateway"></sequenceFlow>
-    <intermediateCatchEvent id="waitForServicesToBeDeleted">
+    <intermediateCatchEvent id="waitForServicesToBeDeleted" name="TimerCatchEvent">
       <timerEventDefinition>
         <timeDuration>PT${applicationConfiguration.getStepPollingIntervalInSeconds()}S</timeDuration>
       </timerEventDefinition>

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/flowable/FlowableFacadeTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/flowable/FlowableFacadeTest.java
@@ -1,8 +1,32 @@
 package com.sap.cloud.lm.sl.cf.process.flowable;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.flowable.common.engine.impl.db.SuspensionState;
+import org.flowable.engine.HistoryService;
+import org.flowable.engine.ManagementService;
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
+import org.flowable.engine.RuntimeService;
+import org.flowable.engine.history.HistoricActivityInstance;
+import org.flowable.engine.history.HistoricActivityInstanceQuery;
+import org.flowable.engine.impl.persistence.entity.ExecutionEntityImpl;
+import org.flowable.engine.runtime.Execution;
+import org.flowable.engine.runtime.ExecutionQuery;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.runtime.ProcessInstanceQuery;
+import org.flowable.job.api.DeadLetterJobQuery;
+import org.flowable.job.api.Job;
+import org.flowable.job.api.TimerJobQuery;
 import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -11,16 +35,46 @@ import org.mockito.MockitoAnnotations;
 
 class FlowableFacadeTest {
 
+    private static final String ROOT_PROCESS_INSTANCE_ID = "35640629-619d-4e8e-9840-6bca38f51f35";
+    private static final String PROCESS_INSTANCE_ID = "65640629-619d-4e8e-9840-6bca38f51f35";
+    private static final String PARENT_EXECUTION_ID = "05640649-619d-4e8e-9840-6bca38f51f35";
+    private static final String EXECUTION_ID = "89640629-619d-4e8e-9840-6bca38f51f35";
+    private static final String DELETE_REASON = "Process was aborted";
+    private static final String DEPLOY_MODULES_PARALLEL = "deployModulesParallel";
     private FlowableFacade flowableFacade;
 
     @Mock
-    DefaultAsyncJobExecutor mockedAsyncExecutor;
+    private DefaultAsyncJobExecutor mockedAsyncExecutor;
 
     @Mock
-    ProcessEngine mockedProcessEngine;
+    private ProcessEngine mockedProcessEngine;
 
     @Mock
-    ProcessEngineConfiguration mockedProcessEngineConfiguration;
+    private RuntimeService mockedRuntimeService;
+
+    @Mock
+    private ExecutionQuery mockedExecutionQuery;
+
+    @Mock
+    private HistoryService mockedHistoryService;
+
+    @Mock
+    private HistoricActivityInstanceQuery mockedHistoricActivityInstanceQuery;
+
+    @Mock
+    private ProcessInstanceQuery mockedProcessInstanceQuery;
+
+    @Mock
+    private ProcessEngineConfiguration mockedProcessEngineConfiguration;
+
+    @Mock
+    private ManagementService mockedManagementService;
+
+    @Mock
+    private TimerJobQuery mockedTimerJobQuery;
+
+    @Mock
+    private DeadLetterJobQuery mockedDeadLetterJobQuery;
 
     @BeforeEach
     void setUp() {
@@ -30,15 +84,215 @@ class FlowableFacadeTest {
                .thenReturn(mockedAsyncExecutor);
         Mockito.when(mockedProcessEngine.getProcessEngineConfiguration())
                .thenReturn(mockedProcessEngineConfiguration);
+        Mockito.when(mockedProcessEngine.getRuntimeService())
+               .thenReturn(mockedRuntimeService);
+        Mockito.when(mockedRuntimeService.createExecutionQuery())
+               .thenReturn(mockedExecutionQuery);
+        Mockito.when(mockedProcessEngine.getHistoryService())
+               .thenReturn(mockedHistoryService);
+        Mockito.when(mockedHistoryService.createHistoricActivityInstanceQuery())
+               .thenReturn(mockedHistoricActivityInstanceQuery);
+        Mockito.when(mockedRuntimeService.createExecutionQuery())
+               .thenReturn(mockedExecutionQuery);
+        Mockito.when(mockedRuntimeService.createProcessInstanceQuery())
+               .thenReturn(mockedProcessInstanceQuery);
+        Mockito.when(mockedProcessEngine.getManagementService())
+               .thenReturn(mockedManagementService);
+        Mockito.when(mockedManagementService.createTimerJobQuery())
+               .thenReturn(mockedTimerJobQuery);
+        Mockito.when(mockedManagementService.createDeadLetterJobQuery())
+               .thenReturn(mockedDeadLetterJobQuery);
 
         flowableFacade = new FlowableFacade(mockedProcessEngine);
     }
 
     @Test
-    void testAsyncExecutorMethodsAreCalled() {
+    public void testAsyncExecutorMethodsAreCalled() {
         flowableFacade.shutdownJobExecutor();
-        Mockito.verify(mockedAsyncExecutor, Mockito.times(1))
+        Mockito.verify(mockedAsyncExecutor, times(1))
                .shutdown();
     }
 
+    @Test
+    public void testDeleteProcessWhenAtReceiveTask() {
+        mockExecutionQueryListExecutions(getExecutionsWithValidActivityIds());
+        mockHistoricActivityInstanceQuery(getMockedHistoryActivityInstances());
+        flowableFacade.deleteProcessInstance(ROOT_PROCESS_INSTANCE_ID, DELETE_REASON);
+        verifyProcessIsDeleted();
+        verifyProcessIsNotSuspended();
+    }
+
+    @Test
+    public void testDeleteProcessWhenProcessHasBeenAlreadyDeleted() {
+        mockExecutionQueryListExecutions(getExecutionsWithValidActivityIds());
+        mockExecutionQuery();
+        mockHistoricActivityInstanceQuery(Collections.emptyList());
+        Mockito.when(mockedTimerJobQuery.executionId(EXECUTION_ID))
+               .thenReturn(mockedTimerJobQuery);
+        Mockito.when(mockedDeadLetterJobQuery.processInstanceId(EXECUTION_ID))
+               .thenReturn(mockedDeadLetterJobQuery);
+        Mockito.when(mockedProcessInstanceQuery.processInstanceId(ROOT_PROCESS_INSTANCE_ID))
+               .thenReturn(mockedProcessInstanceQuery);
+        flowableFacade.deleteProcessInstance(ROOT_PROCESS_INSTANCE_ID, DELETE_REASON);
+        verifyProcessIsNotDeleted();
+        verifyProcessIsNotSuspended();
+    }
+
+    @Test
+    public void testDeleteProcessInstanceWhenThereAreNoActiveExecutions() {
+        mockExecutionQueryListExecutions(Collections.emptyList());
+        mockExecutionQuery();
+        mockHistoricActivityInstanceQuery(Collections.emptyList());
+        flowableFacade.deleteProcessInstance(ROOT_PROCESS_INSTANCE_ID, DELETE_REASON);
+        verifyProcessIsDeleted();
+        verifyProcessIsSuspended();
+    }
+
+    @Test
+    public void testDeleteProcessInstanceWhenAllActiveExecutionsHaveDeadLetterJobs() {
+        mockExecutionQueryListExecutions(getExecutionsWithValidActivityIds());
+        mockExecutionQuery();
+        mockHistoricActivityInstanceQuery(Collections.emptyList());
+        mockProcessFound();
+        Mockito.when(mockedTimerJobQuery.executionId(EXECUTION_ID))
+               .thenReturn(mockedTimerJobQuery);
+        Mockito.when(mockedDeadLetterJobQuery.processInstanceId(EXECUTION_ID))
+               .thenReturn(mockedDeadLetterJobQuery);
+        Mockito.when(mockedDeadLetterJobQuery.list())
+               .thenReturn(getMockedDeadLetterJobs());
+        Mockito.when(mockedProcessInstanceQuery.processInstanceId(ROOT_PROCESS_INSTANCE_ID))
+               .thenReturn(mockedProcessInstanceQuery);
+        flowableFacade.deleteProcessInstance(ROOT_PROCESS_INSTANCE_ID, DELETE_REASON);
+        verifyProcessIsDeleted();
+        verifyProcessIsSuspended();
+    }
+
+    @Test
+    public void testDeleteProcessInstanceWhichHasBeenSuspended() {
+        mockExecutionQueryListExecutions(getExecutionsWithValidActivityIds());
+        mockExecutionQuery();
+        mockProcessFound();
+        mockHistoricActivityInstanceQuery(Collections.emptyList());
+        Mockito.when(mockedTimerJobQuery.executionId(EXECUTION_ID))
+               .thenReturn(mockedTimerJobQuery);
+        Mockito.when(mockedDeadLetterJobQuery.processInstanceId(EXECUTION_ID))
+               .thenReturn(mockedDeadLetterJobQuery);
+        Mockito.when(mockedDeadLetterJobQuery.list())
+               .thenReturn(getMockedDeadLetterJobs());
+        Mockito.when(mockedProcessInstanceQuery.processInstanceId(ROOT_PROCESS_INSTANCE_ID))
+               .thenReturn(mockedProcessInstanceQuery);
+        Mockito.when(mockedExecutionQuery.singleResult())
+               .thenReturn(getSuspendedExecution());
+        flowableFacade.deleteProcessInstance(ROOT_PROCESS_INSTANCE_ID, DELETE_REASON);
+        verifyProcessIsDeleted();
+        verifyProcessIsNotSuspended();
+    }
+
+    @Test
+    public void testGetInactiveExecutionIdsWithoutChildren() {
+        mockExecutionQueryListExecutions(getParentAndChildrenExecution());
+        List<Execution> inactiveExecutionIdsWithoutChildren = flowableFacade.getLeafExecutionsByFilter(ROOT_PROCESS_INSTANCE_ID,
+                                                                                                         executionEntity -> !executionEntity.isActive());
+        Assertions.assertEquals(1, inactiveExecutionIdsWithoutChildren.size());
+        Assertions.assertEquals(PROCESS_INSTANCE_ID, inactiveExecutionIdsWithoutChildren.get(0)
+                                                                                        .getProcessInstanceId());
+    }
+
+    private List<Execution> getExecutionsWithValidActivityIds() {
+        ExecutionEntityImpl executionWithValidActivityId = Mockito.mock(ExecutionEntityImpl.class);
+        Mockito.when(executionWithValidActivityId.getActivityId())
+               .thenReturn(DEPLOY_MODULES_PARALLEL);
+        Mockito.when(executionWithValidActivityId.getId())
+               .thenReturn(EXECUTION_ID);
+        Mockito.when(executionWithValidActivityId.isActive())
+               .thenReturn(true);
+        Mockito.when(executionWithValidActivityId.getProcessInstanceId())
+               .thenReturn(EXECUTION_ID);
+        Execution executionWithInvalidActivityId = Mockito.mock(ExecutionEntityImpl.class);
+        return Arrays.asList(executionWithValidActivityId, executionWithInvalidActivityId);
+    }
+
+    private void mockExecutionQueryListExecutions(List<Execution> executions) {
+        Mockito.when(mockedExecutionQuery.rootProcessInstanceId(ROOT_PROCESS_INSTANCE_ID))
+               .thenReturn(mockedExecutionQuery);
+        Mockito.when(mockedExecutionQuery.list())
+               .thenReturn(executions);
+    }
+
+    private void mockHistoricActivityInstanceQuery(List<HistoricActivityInstance> historicActivityInstances) {
+        Mockito.when(mockedHistoricActivityInstanceQuery.activityId(DEPLOY_MODULES_PARALLEL))
+               .thenReturn(mockedHistoricActivityInstanceQuery);
+        Mockito.when(mockedHistoricActivityInstanceQuery.executionId(EXECUTION_ID))
+               .thenReturn(mockedHistoricActivityInstanceQuery);
+        Mockito.when(mockedHistoricActivityInstanceQuery.activityType("receiveTask"))
+               .thenReturn(mockedHistoricActivityInstanceQuery);
+        Mockito.when(mockedHistoricActivityInstanceQuery.list())
+               .thenReturn(historicActivityInstances);
+    }
+
+    private List<HistoricActivityInstance> getMockedHistoryActivityInstances() {
+        HistoricActivityInstance historicActivityInstance = Mockito.mock(HistoricActivityInstance.class);
+        return Collections.singletonList(historicActivityInstance);
+    }
+
+    private void mockExecutionQuery() {
+        Mockito.when(mockedExecutionQuery.processInstanceId(ROOT_PROCESS_INSTANCE_ID))
+               .thenReturn(mockedExecutionQuery);
+        Mockito.when(mockedExecutionQuery.executionId(ROOT_PROCESS_INSTANCE_ID))
+               .thenReturn(mockedExecutionQuery);
+    }
+
+    private void mockProcessFound() {
+        Mockito.when(mockedProcessInstanceQuery.processInstanceId(ROOT_PROCESS_INSTANCE_ID))
+               .thenReturn(mockedProcessInstanceQuery);
+        Mockito.when(mockedProcessInstanceQuery.singleResult())
+               .thenReturn(Mockito.mock(ProcessInstance.class));
+    }
+
+    private List<Job> getMockedDeadLetterJobs() {
+        Job deadLetterJob = Mockito.mock(Job.class);
+        return Collections.singletonList(deadLetterJob);
+    }
+
+    private void verifyProcessIsNotDeleted() {
+        Mockito.verify(mockedProcessEngine.getRuntimeService(), never())
+               .deleteProcessInstance(any(), anyString());
+    }
+
+    private void verifyProcessIsNotSuspended() {
+        Mockito.verify(mockedProcessEngine.getRuntimeService(), never())
+               .suspendProcessInstanceById(any());
+    }
+
+    private void verifyProcessIsDeleted() {
+        Mockito.verify(mockedProcessEngine.getRuntimeService(), times(1))
+               .deleteProcessInstance(ROOT_PROCESS_INSTANCE_ID, DELETE_REASON);
+    }
+
+    private void verifyProcessIsSuspended() {
+        Mockito.verify(mockedProcessEngine.getRuntimeService(), times(1))
+               .suspendProcessInstanceById(ROOT_PROCESS_INSTANCE_ID);
+    }
+
+    private Execution getSuspendedExecution() {
+        ExecutionEntityImpl execution = new ExecutionEntityImpl();
+        execution.setSuspensionState(SuspensionState.SUSPENDED.getStateCode());
+        return execution;
+    }
+
+    private List<Execution> getParentAndChildrenExecution() {
+        ExecutionEntityImpl childExecution = Mockito.mock(ExecutionEntityImpl.class);
+        Mockito.when(childExecution.getParentId())
+               .thenReturn(PARENT_EXECUTION_ID);
+        Mockito.when(childExecution.getId())
+               .thenReturn(EXECUTION_ID);
+        Mockito.when(childExecution.getProcessInstanceId())
+               .thenReturn(PROCESS_INSTANCE_ID);
+        ExecutionEntityImpl parentExecution = Mockito.mock(ExecutionEntityImpl.class);
+        Mockito.when(parentExecution.getId())
+               .thenReturn(PARENT_EXECUTION_ID);
+        Mockito.when(parentExecution.getProcessInstanceId())
+               .thenReturn(PARENT_EXECUTION_ID);
+        return Arrays.asList(parentExecution, childExecution);
+    }
 }


### PR DESCRIPTION
Sometimes when an operation gets aborted, deadlocks occur because flowable hasn't managed to update all dead letter jobs for all executions. When a process is deleted all of its subprocesses are also deleted as so as their dead letter jobs. This change provides a way to wait for flowable to create dead letter jobs for all aborted processes and afterward remove the processes and this way the deadlocks should not occur anymore.

LMCROSSITXSADEPLOY-1792