### PR TITLE
Move ApplicationServicesUpdater to enable logging

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Messages.java
@@ -182,7 +182,7 @@ public class Messages {
     public static final String PROCESS_0_RELEASING_LOCK_FOR_MTA_1_IN_SPACE_2 = "Process \"{0}\" releasing lock for MTA \"{1}\" in space \"{2}\"";
     public static final String PROCESS_0_RELEASED_LOCK = "Process \"{0}\" released lock successfully!";
     public static final String BINDING_APP_TO_SERVICE_WITH_PARAMETERS = "Binding application \"{0}\" to service \"{1}\" with parameters \"{2}\"";
-    public static final String UNBINDING_APP_FROM_SERVICE = "Unbinding application \"{0}\" from service \"{1}\"...";
+    public static final String UNBINDING_SERVICE_FROM_APP = "Unbinding service \"{0}\" from application \"{1}\"...";
     public static final String POLLING_SERVICE_OPERATIONS = "Polling service operations...";
     public static final String AUTO_ABORTING_PROCESS_0 = "Auto-aborting process \"{0}\"...";
     public static final String SOME_INSTANCES_ARE_FLAPPING = "Some instances are flapping. Check the logs of your application for more information.";

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Messages.java
@@ -65,6 +65,7 @@ public class Messages {
     public static final String MERGED_FILE_NOT_DELETED = "Merged file not deleted";
     public static final String FAILED_TO_RETRIEVE_FILE_WITH_ID_0 = "Failed to retrieve file with id \"{0}\"";
     public static final String PARAMETERS_HAVE_READ_ONLY_ELEMENTS = "\"{0}\" parameters have read-only elements \"{1}\"";
+    public static final String APPLICATION_UNBOUND_IN_PARALLEL = "Application {0} was bound to service {1} which was unbound in parallel";
 
     // Audit log messages
 
@@ -300,6 +301,7 @@ public class Messages {
     public static final String SERVICES_TO_CREATE = "Services to create: {0}";
     public static final String CREATED_SERVICE_KEY = "Service key \"{0}\" created";
     public static final String SERVICE_BINDINGS_EXISTS = "Service bindings \"{0}\" exists";
+    public static final String LOOKING_FOR_SERVICE_BINDINGS = "Looking for service binding between application \"{0}\" and service instance \"{1}\". Service bindings: {2}";
     public static final String PREPARING_MODULES_DEPLOYMENT = "Preparing modules deployment...";
     public static final String COMPUTING_NEXT_MODULES_FOR_PARALLEL_ITERATION = "Computing modules for next parallel iteration...";
     public static final String COMPUTED_NEXT_MODULES_FOR_PARALLEL_ITERATION = "Computed modules for next parallel iteration: {0}";

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/helpers/ApplicationServicesUpdater.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/helpers/ApplicationServicesUpdater.java
@@ -1,0 +1,149 @@
+package com.sap.cloud.lm.sl.cf.process.helpers;
+
+import com.sap.cloud.lm.sl.cf.process.util.StepLogger;
+import org.cloudfoundry.client.lib.ApplicationServicesUpdateCallback;
+import org.cloudfoundry.client.lib.CloudControllerClient;
+import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.cloudfoundry.client.lib.domain.CloudEntity;
+import org.cloudfoundry.client.lib.domain.CloudServiceBinding;
+import org.cloudfoundry.client.lib.domain.CloudServiceInstance;
+import org.cloudfoundry.client.lib.util.JsonUtil;
+
+import java.text.MessageFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import com.sap.cloud.lm.sl.cf.process.message.Messages;
+
+public class ApplicationServicesUpdater {
+
+    private CloudControllerClient client;
+    private StepLogger stepLogger;
+
+    public ApplicationServicesUpdater(CloudControllerClient client, StepLogger stepLogger) {
+        this.client = client;
+        this.stepLogger = stepLogger;
+    }
+
+    public List<String> updateApplicationServices(String applicationName,
+                                                  Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
+                                                  ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
+        CloudApplication application = client.getApplication(applicationName);
+
+        List<String> addServices = calculateServicesToAdd(serviceNamesWithBindingParameters.keySet(), application);
+        bindServices(addServices, applicationName, serviceNamesWithBindingParameters, applicationServicesUpdateCallback);
+
+        List<String> deleteServices = calculateServicesToDelete(serviceNamesWithBindingParameters.keySet(), application);
+        unbindServices(deleteServices, applicationName, applicationServicesUpdateCallback);
+
+        List<String> rebindServices = calculateServicesToRebind(serviceNamesWithBindingParameters, application);
+        rebindServices(rebindServices, applicationName, serviceNamesWithBindingParameters, applicationServicesUpdateCallback);
+
+        return getUpdatedServiceNames(addServices, deleteServices, rebindServices);
+    }
+
+    private List<String> calculateServicesToAdd(Set<String> services, CloudApplication application) {
+        return services.stream()
+                       .filter(serviceName -> !application.getServices()
+                                                          .contains(serviceName))
+                       .collect(Collectors.toList());
+    }
+
+    private List<String> calculateServicesToDelete(Set<String> services, CloudApplication application) {
+        return application.getServices()
+                          .stream()
+                          .filter(serviceName -> !services.contains(serviceName))
+                          .collect(Collectors.toList());
+    }
+
+    protected List<String> calculateServicesToRebind(Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
+                                                     CloudApplication application) {
+        List<String> servicesToRebind = new ArrayList<>();
+        for (String serviceName : serviceNamesWithBindingParameters.keySet()) {
+            if (!application.getServices()
+                            .contains(serviceName)) {
+                continue;
+            }
+
+            CloudServiceInstance serviceInstance = client.getServiceInstance(serviceName);
+            Map<String, Object> newServiceBindingParameters = getNewServiceBindingParameters(serviceNamesWithBindingParameters,
+                                                                                             serviceInstance);
+            if (hasServiceBindingsChanged(application, serviceInstance, newServiceBindingParameters)) {
+                servicesToRebind.add(serviceInstance.getService()
+                                                    .getName());
+            }
+        }
+        return servicesToRebind;
+    }
+
+    private Map<String, Object> getNewServiceBindingParameters(Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
+                                                               CloudServiceInstance serviceInstance) {
+        return serviceNamesWithBindingParameters.get(serviceInstance.getService()
+                                                                    .getName());
+    }
+
+    private boolean hasServiceBindingsChanged(CloudApplication application, CloudServiceInstance serviceInstance,
+                                              Map<String, Object> newServiceBindingParameters) {
+        CloudServiceBinding bindingForApplication = getServiceBindingForApplication(application, serviceInstance);
+        return !Objects.equals(bindingForApplication.getBindingParameters(), newServiceBindingParameters);
+    }
+
+    private CloudServiceBinding getServiceBindingForApplication(CloudApplication application, CloudServiceInstance serviceInstance) {
+        stepLogger.debug(Messages.LOOKING_FOR_SERVICE_BINDINGS, getGuid(application), getGuid(serviceInstance),
+                         JsonUtil.convertToJson(serviceInstance.getBindings(), true));
+        return serviceInstance.getBindings()
+                              .stream()
+                              .filter(serviceBinding -> application.getMetadata()
+                                                                   .getGuid()
+                                                                   .equals(serviceBinding.getApplicationGuid()))
+                              .findFirst()
+                              .orElseThrow(() -> new IllegalStateException(MessageFormat.format(Messages.APPLICATION_UNBOUND_IN_PARALLEL,
+                                                                                                application.getName(),
+                                                                                                serviceInstance.getService()
+                                                                                                               .getName())));
+    }
+
+    private void bindServices(List<String> addServices, String applicationName,
+                              Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
+                              ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
+        for (String serviceName : addServices) {
+            Map<String, Object> bindingParameters = serviceNamesWithBindingParameters.get(serviceName);
+            stepLogger.info(Messages.BINDING_APP_TO_SERVICE_WITH_PARAMETERS, applicationName, serviceName, bindingParameters);
+            client.bindService(applicationName, serviceName, bindingParameters, applicationServicesUpdateCallback);
+        }
+    }
+
+    private void unbindServices(List<String> deleteServices, String applicationName,
+                                ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
+        for (String serviceName : deleteServices) {
+            stepLogger.info(Messages.UNBINDING_APP_FROM_SERVICE, applicationName, serviceName);
+            client.unbindService(applicationName, serviceName, applicationServicesUpdateCallback);
+        }
+    }
+
+    private void rebindServices(List<String> rebindServices, String applicationName,
+        Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
+        ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
+        for (String serviceName : rebindServices) {
+            Map<String, Object> bindingParameters = serviceNamesWithBindingParameters.get(serviceName);
+            stepLogger.info(Messages.UNBINDING_APP_FROM_SERVICE, applicationName, serviceName);
+            client.unbindService(applicationName, serviceName, applicationServicesUpdateCallback);
+            stepLogger.info(Messages.BINDING_APP_TO_SERVICE_WITH_PARAMETERS, applicationName, serviceName, bindingParameters);
+            client.bindService(applicationName, serviceName, bindingParameters, applicationServicesUpdateCallback);
+        }
+    }
+
+    private List<String> getUpdatedServiceNames(List<String> addServices, List<String> deleteServices, List<String> rebindServices) {
+        List<String> result = new ArrayList<>();
+        result.addAll(addServices);
+        result.addAll(deleteServices);
+        result.addAll(rebindServices);
+        return result;
+    }
+
+    private UUID getGuid(CloudEntity entity) {
+        return entity.getMetadata()
+                     .getGuid();
+    }
+
+}

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/helpers/ApplicationServicesUpdater.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/helpers/ApplicationServicesUpdater.java
@@ -1,6 +1,5 @@
-package com.sap.cloud.lm.sl.cf.process.helpers;
+package com.sap.cloud.lm.sl.cf.process.util;
 
-import com.sap.cloud.lm.sl.cf.process.util.StepLogger;
 import org.cloudfoundry.client.lib.ApplicationServicesUpdateCallback;
 import org.cloudfoundry.client.lib.CloudControllerClient;
 import org.cloudfoundry.client.lib.domain.CloudApplication;
@@ -13,7 +12,7 @@ import java.text.MessageFormat;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import com.sap.cloud.lm.sl.cf.process.message.Messages;
+import com.sap.cloud.lm.sl.cf.process.Messages;
 
 public class ApplicationServicesUpdater {
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Named;
 
+import com.sap.cloud.lm.sl.cf.process.helpers.ApplicationServicesUpdater;
 import org.apache.commons.collections4.ListUtils;
 import org.cloudfoundry.client.lib.ApplicationServicesUpdateCallback;
 import org.cloudfoundry.client.lib.CloudControllerClient;
@@ -386,8 +387,9 @@ public class CreateOrUpdateAppStep extends SyncFlowableStep {
                                                                                                                    serviceName -> getBindingParametersForService(serviceName,
                                                                                                                                                                  bindingParameters)));
 
-            List<String> updatedServices = client.updateApplicationServices(applicationName, serviceNamesWithBindingParameters,
-                                                                            getApplicationServicesUpdateCallback(context));
+            ApplicationServicesUpdater applicationServicesUpdater = new ApplicationServicesUpdater(client, getStepLogger());
+            List<String> updatedServices = applicationServicesUpdater.updateApplicationServices(applicationName,
+                                                        serviceNamesWithBindingParameters, getApplicationServicesUpdateCallback(context));
 
             reportNonUpdatedServices(services, applicationName, updatedServices);
             return !updatedServices.isEmpty();

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
@@ -368,7 +368,7 @@ public class CreateOrUpdateAppStep extends SyncFlowableStep {
         }
 
         private void unbindService(String appName, String serviceName, CloudControllerClient client) {
-            getStepLogger().debug(Messages.UNBINDING_APP_FROM_SERVICE, appName, serviceName);
+            getStepLogger().debug(Messages.UNBINDING_SERVICE_FROM_APP, serviceName, appName);
             client.unbindService(appName, serviceName);
         }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Named;
 
-import com.sap.cloud.lm.sl.cf.process.helpers.ApplicationServicesUpdater;
+import com.sap.cloud.lm.sl.cf.process.util.*;
 import org.apache.commons.collections4.ListUtils;
 import org.cloudfoundry.client.lib.ApplicationServicesUpdateCallback;
 import org.cloudfoundry.client.lib.CloudControllerClient;
@@ -39,15 +39,8 @@ import com.sap.cloud.lm.sl.cf.persistence.services.FileContentProcessor;
 import com.sap.cloud.lm.sl.cf.persistence.services.FileStorageException;
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import com.sap.cloud.lm.sl.cf.process.Messages;
-import com.sap.cloud.lm.sl.cf.process.util.ApplicationAttributeUpdater;
 import com.sap.cloud.lm.sl.cf.process.util.ApplicationAttributeUpdater.UpdateState;
-import com.sap.cloud.lm.sl.cf.process.util.DiskQuotaApplicationAttributeUpdater;
 import com.sap.cloud.lm.sl.cf.process.util.ElementUpdater.UpdateBehavior;
-import com.sap.cloud.lm.sl.cf.process.util.EnvironmentApplicationAttributeUpdater;
-import com.sap.cloud.lm.sl.cf.process.util.MemoryApplicationAttributeUpdater;
-import com.sap.cloud.lm.sl.cf.process.util.ServiceOperationUtil;
-import com.sap.cloud.lm.sl.cf.process.util.StagingApplicationAttributeUpdater;
-import com.sap.cloud.lm.sl.cf.process.util.UrisApplicationAttributeUpdater;
 import com.sap.cloud.lm.sl.common.SLException;
 import com.sap.cloud.lm.sl.common.util.JsonUtil;
 import com.sap.cloud.lm.sl.common.util.MapUtil;

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
@@ -157,7 +157,7 @@ public class DeleteServicesStep extends AsyncFlowableStep {
                 throw new IllegalStateException(MessageFormat.format(Messages.COULD_NOT_FIND_APPLICATION_WITH_GUID_0,
                                                                      binding.getApplicationGuid()));
             }
-            getStepLogger().info(Messages.UNBINDING_APP_FROM_SERVICE, application.getName(), serviceName);
+            getStepLogger().info(Messages.UNBINDING_SERVICE_FROM_APP, serviceName, application.getName());
             client.unbindService(application.getName(), serviceName);
         }
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/ApplicationServicesUpdater.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/ApplicationServicesUpdater.java
@@ -115,7 +115,7 @@ public class ApplicationServicesUpdater {
     private void unbindServices(List<String> deleteServices, String applicationName,
                                 ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
         for (String serviceName : deleteServices) {
-            stepLogger.info(Messages.UNBINDING_APP_FROM_SERVICE, applicationName, serviceName);
+            stepLogger.info(Messages.UNBINDING_SERVICE_FROM_APP, serviceName, applicationName);
             client.unbindService(applicationName, serviceName, applicationServicesUpdateCallback);
         }
     }
@@ -125,7 +125,7 @@ public class ApplicationServicesUpdater {
         ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
         for (String serviceName : rebindServices) {
             Map<String, Object> bindingParameters = serviceNamesWithBindingParameters.get(serviceName);
-            stepLogger.info(Messages.UNBINDING_APP_FROM_SERVICE, applicationName, serviceName);
+            stepLogger.info(Messages.UNBINDING_SERVICE_FROM_APP, serviceName, applicationName);
             client.unbindService(applicationName, serviceName, applicationServicesUpdateCallback);
             stepLogger.info(Messages.BINDING_APP_TO_SERVICE_WITH_PARAMETERS, applicationName, serviceName, bindingParameters);
             client.bindService(applicationName, serviceName, bindingParameters, applicationServicesUpdateCallback);

--- a/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/update-app-step-input-2.json
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/update-app-step-input-2.json
@@ -30,7 +30,7 @@
 	"existingServiceBindings": {
 		"test-service-1" : [
 		 	{
-				"applicationName": "brum"
+				"applicationName": "test-app-1"
 			}
 		]
 	},


### PR DESCRIPTION
Move the ApplicationServicesUpdater from cf-java-client to
multiapps-controller in order to add logging capabilities in the process
of binding/unbinding services. JIRA: LMCROSSITXSADEPLOY-1869