### PR TITLE
Move ApplicationServicesUpdater to enable logging

### DIFF
--- a/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/ResilientCloudControllerClient.java
+++ b/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/ResilientCloudControllerClient.java
@@ -319,15 +319,6 @@ public class ResilientCloudControllerClient implements CloudControllerClient {
     }
 
     @Override
-    public List<String> updateApplicationServices(String applicationName,
-                                                  Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
-                                                  ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
-        return executeWithRetry(() -> delegate.updateApplicationServices(applicationName, serviceNamesWithBindingParameters,
-                                                                         applicationServicesUpdateCallback),
-                                HttpStatus.NOT_FOUND);
-    }
-
-    @Override
     public void updateApplicationStaging(String applicationName, Staging staging) {
         executeWithRetry(() -> delegate.updateApplicationStaging(applicationName, staging));
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Messages.java
@@ -65,6 +65,7 @@ public class Messages {
     public static final String MERGED_FILE_NOT_DELETED = "Merged file not deleted";
     public static final String FAILED_TO_RETRIEVE_FILE_WITH_ID_0 = "Failed to retrieve file with id \"{0}\"";
     public static final String PARAMETERS_HAVE_READ_ONLY_ELEMENTS = "\"{0}\" parameters have read-only elements \"{1}\"";
+    public static final String APPLICATION_UNBOUND_IN_PARALLEL = "Application {0} was bound to service {1} which was unbound in parallel";
 
     // Audit log messages
 
@@ -181,7 +182,7 @@ public class Messages {
     public static final String PROCESS_0_RELEASING_LOCK_FOR_MTA_1_IN_SPACE_2 = "Process \"{0}\" releasing lock for MTA \"{1}\" in space \"{2}\"";
     public static final String PROCESS_0_RELEASED_LOCK = "Process \"{0}\" released lock successfully!";
     public static final String BINDING_APP_TO_SERVICE_WITH_PARAMETERS = "Binding application \"{0}\" to service \"{1}\" with parameters \"{2}\"";
-    public static final String UNBINDING_APP_FROM_SERVICE = "Unbinding application \"{0}\" from service \"{1}\"...";
+    public static final String UNBINDING_SERVICE_FROM_APP = "Unbinding service \"{0}\" from application \"{1}\"...";
     public static final String POLLING_SERVICE_OPERATIONS = "Polling service operations...";
     public static final String AUTO_ABORTING_PROCESS_0 = "Auto-aborting process \"{0}\"...";
     public static final String SOME_INSTANCES_ARE_FLAPPING = "Some instances are flapping. Check the logs of your application for more information.";
@@ -300,6 +301,7 @@ public class Messages {
     public static final String SERVICES_TO_CREATE = "Services to create: {0}";
     public static final String CREATED_SERVICE_KEY = "Service key \"{0}\" created";
     public static final String SERVICE_BINDINGS_EXISTS = "Service bindings \"{0}\" exists";
+    public static final String LOOKING_FOR_SERVICE_BINDINGS = "Looking for service binding between application \"{0}\" and service instance \"{1}\". Service bindings: {2}";
     public static final String PREPARING_MODULES_DEPLOYMENT = "Preparing modules deployment...";
     public static final String COMPUTING_NEXT_MODULES_FOR_PARALLEL_ITERATION = "Computing modules for next parallel iteration...";
     public static final String COMPUTED_NEXT_MODULES_FOR_PARALLEL_ITERATION = "Computed modules for next parallel iteration: {0}";

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DeleteServicesStep.java
@@ -157,7 +157,7 @@ public class DeleteServicesStep extends AsyncFlowableStep {
                 throw new IllegalStateException(MessageFormat.format(Messages.COULD_NOT_FIND_APPLICATION_WITH_GUID_0,
                                                                      binding.getApplicationGuid()));
             }
-            getStepLogger().info(Messages.UNBINDING_APP_FROM_SERVICE, application.getName(), serviceName);
+            getStepLogger().info(Messages.UNBINDING_SERVICE_FROM_APP, serviceName, application.getName());
             client.unbindService(application.getName(), serviceName);
         }
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/ApplicationServicesUpdater.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/ApplicationServicesUpdater.java
@@ -1,0 +1,146 @@
+package com.sap.cloud.lm.sl.cf.process.util;
+
+import com.sap.cloud.lm.sl.cf.process.Messages;
+import org.cloudfoundry.client.lib.ApplicationServicesUpdateCallback;
+import org.cloudfoundry.client.lib.CloudControllerClient;
+import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.cloudfoundry.client.lib.domain.CloudEntity;
+import org.cloudfoundry.client.lib.domain.CloudServiceBinding;
+import org.cloudfoundry.client.lib.domain.CloudServiceInstance;
+import org.cloudfoundry.client.lib.util.JsonUtil;
+
+import java.text.MessageFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ApplicationServicesUpdater {
+
+    private CloudControllerClient client;
+    private StepLogger stepLogger;
+
+    public ApplicationServicesUpdater(CloudControllerClient client, StepLogger stepLogger) {
+        this.client = client;
+        this.stepLogger = stepLogger;
+    }
+
+    public List<String> updateApplicationServices(String applicationName,
+        Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
+        ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
+        CloudApplication application = client.getApplication(applicationName);
+
+        List<String> addServices = calculateServicesToAdd(serviceNamesWithBindingParameters.keySet(), application);
+        bindServices(addServices, applicationName, serviceNamesWithBindingParameters, applicationServicesUpdateCallback);
+
+        List<String> deleteServices = calculateServicesToDelete(serviceNamesWithBindingParameters.keySet(), application);
+        unbindServices(deleteServices, applicationName, applicationServicesUpdateCallback);
+
+        List<String> rebindServices = calculateServicesToRebind(serviceNamesWithBindingParameters, application);
+        rebindServices(rebindServices, applicationName, serviceNamesWithBindingParameters, applicationServicesUpdateCallback);
+
+        return getUpdatedServiceNames(addServices, deleteServices, rebindServices);
+    }
+
+    private List<String> calculateServicesToAdd(Set<String> services, CloudApplication application) {
+        return services.stream()
+            .filter(serviceName -> !application.getServices()
+                .contains(serviceName))
+            .collect(Collectors.toList());
+    }
+
+    private List<String> calculateServicesToDelete(Set<String> services, CloudApplication application) {
+        return application.getServices()
+            .stream()
+            .filter(serviceName -> !services.contains(serviceName))
+            .collect(Collectors.toList());
+    }
+
+    protected List<String> calculateServicesToRebind(Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
+        CloudApplication application) {
+        List<String> servicesToRebind = new ArrayList<>();
+        for (String serviceName : serviceNamesWithBindingParameters.keySet()) {
+            if (!application.getServices()
+                .contains(serviceName)) {
+                continue;
+            }
+
+            CloudServiceInstance serviceInstance = client.getServiceInstance(serviceName);
+            Map<String, Object> newServiceBindingParameters = getNewServiceBindingParameters(serviceNamesWithBindingParameters,
+                serviceInstance);
+            if (hasServiceBindingsChanged(application, serviceInstance, newServiceBindingParameters)) {
+                servicesToRebind.add(serviceInstance.getService()
+                    .getName());
+            }
+        }
+        return servicesToRebind;
+    }
+
+    private Map<String, Object> getNewServiceBindingParameters(Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
+        CloudServiceInstance serviceInstance) {
+        return serviceNamesWithBindingParameters.get(serviceInstance.getService()
+            .getName());
+    }
+
+    private boolean hasServiceBindingsChanged(CloudApplication application, CloudServiceInstance serviceInstance,
+        Map<String, Object> newServiceBindingParameters) {
+        CloudServiceBinding bindingForApplication = getServiceBindingForApplication(application, serviceInstance);
+        return !Objects.equals(bindingForApplication.getBindingParameters(), newServiceBindingParameters);
+    }
+
+    private CloudServiceBinding getServiceBindingForApplication(CloudApplication application, CloudServiceInstance serviceInstance) {
+        stepLogger.debug(Messages.LOOKING_FOR_SERVICE_BINDINGS, getGuid(application), getGuid(serviceInstance),
+            JsonUtil.convertToJson(serviceInstance.getBindings(), true));
+        return serviceInstance.getBindings()
+            .stream()
+            .filter(serviceBinding -> application.getMetadata()
+                .getGuid()
+                .equals(serviceBinding.getApplicationGuid()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException(MessageFormat.format(Messages.APPLICATION_UNBOUND_IN_PARALLEL,
+                application.getName(),
+                serviceInstance.getService()
+                    .getName())));
+    }
+
+    private void bindServices(List<String> addServices, String applicationName,
+        Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
+        ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
+        for (String serviceName : addServices) {
+            Map<String, Object> bindingParameters = serviceNamesWithBindingParameters.get(serviceName);
+            stepLogger.info(Messages.BINDING_APP_TO_SERVICE_WITH_PARAMETERS, applicationName, serviceName, bindingParameters);
+            client.bindService(applicationName, serviceName, bindingParameters, applicationServicesUpdateCallback);
+        }
+    }
+
+    private void unbindServices(List<String> deleteServices, String applicationName,
+        ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
+        for (String serviceName : deleteServices) {
+            stepLogger.info(Messages.UNBINDING_SERVICE_FROM_APP, applicationName, serviceName);
+            client.unbindService(applicationName, serviceName, applicationServicesUpdateCallback);
+        }
+    }
+
+    private void rebindServices(List<String> rebindServices, String applicationName,
+        Map<String, Map<String, Object>> serviceNamesWithBindingParameters,
+        ApplicationServicesUpdateCallback applicationServicesUpdateCallback) {
+        for (String serviceName : rebindServices) {
+            Map<String, Object> bindingParameters = serviceNamesWithBindingParameters.get(serviceName);
+            stepLogger.info(Messages.UNBINDING_SERVICE_FROM_APP, applicationName, serviceName);
+            client.unbindService(applicationName, serviceName, applicationServicesUpdateCallback);
+            stepLogger.info(Messages.BINDING_APP_TO_SERVICE_WITH_PARAMETERS, applicationName, serviceName, bindingParameters);
+            client.bindService(applicationName, serviceName, bindingParameters, applicationServicesUpdateCallback);
+        }
+    }
+
+    private List<String> getUpdatedServiceNames(List<String> addServices, List<String> deleteServices, List<String> rebindServices) {
+        List<String> result = new ArrayList<>();
+        result.addAll(addServices);
+        result.addAll(deleteServices);
+        result.addAll(rebindServices);
+        return result;
+    }
+
+    private UUID getGuid(CloudEntity entity) {
+        return entity.getMetadata()
+            .getGuid();
+    }
+}

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateStepWithExistingAppTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateStepWithExistingAppTest.java
@@ -12,13 +12,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.ListUtils;
 import org.cloudfoundry.client.lib.ApplicationServicesUpdateCallback;
+import org.cloudfoundry.client.lib.domain.*;
 import org.cloudfoundry.client.lib.domain.CloudApplication.State;
-import org.cloudfoundry.client.lib.domain.CloudServiceBinding;
-import org.cloudfoundry.client.lib.domain.CloudServiceInstance;
-import org.cloudfoundry.client.lib.domain.CloudServiceKey;
-import org.cloudfoundry.client.lib.domain.ImmutableCloudMetadata;
-import org.cloudfoundry.client.lib.domain.ImmutableCloudServiceBinding;
-import org.cloudfoundry.client.lib.domain.ImmutableStaging;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.junit.Before;
 import org.junit.Rule;
@@ -136,7 +131,7 @@ public class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<
     }
 
     public CreateOrUpdateStepWithExistingAppTest(String input, String expectedExceptionMessage) {
-        this.input = JsonUtil.fromJson(TestUtil.getResourceAsString(input, CreateOrUpdateStepWithExistingAppTest.class), StepInput.class);
+        this.input = JsonUtil.fromJson(TestUtil.getResourceAsString(input, this.getClass()), StepInput.class);
         this.expectedExceptionMessage = expectedExceptionMessage;
     }
 
@@ -188,12 +183,11 @@ public class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<
     private void validateBindServices() {
         Map<String, Map<String, Object>> currentBindingParameters = input.application.toCloudApp()
                                                                                      .getBindingParameters();
-        Map<String, Map<String, Object>> test = new HashMap<>();
         for (String serviceToBind : expectedServicesToBind) {
-            test.put(mapToCloudService(serviceToBind).getName(), getBindingParametersForService(currentBindingParameters, serviceToBind));
+            Mockito.verify(client).bindService(input.application.toCloudApp().getName(), serviceToBind,
+                                               getBindingParametersForService(currentBindingParameters, serviceToBind),
+                                               step.getApplicationServicesUpdateCallback(context));
         }
-        Mockito.verify(client)
-               .updateApplicationServices(input.existingApplication.name, test, step.getApplicationServicesUpdateCallback(context));
     }
 
     private Map<String, Object> getBindingParametersForService(Map<String, Map<String, Object>> bindingParameters, String serviceName) {
@@ -201,9 +195,9 @@ public class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<
     }
 
     private void validateUnbindServices() {
-        for (String notRquiredService : notRequiredServices) {
+        for (String notRequiredService : notRequiredServices) {
             Mockito.verify(client)
-                   .unbindService(input.existingApplication.name, notRquiredService);
+                   .unbindService(input.existingApplication.name, notRequiredService);
         }
     }
 
@@ -235,12 +229,21 @@ public class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<
     private void prepareExistingServiceBindings() {
         for (String serviceName : input.existingServiceBindings.keySet()) {
             CloudServiceInstance cloudServiceInstance = Mockito.mock(CloudServiceInstance.class);
+            CloudService cloudService = Mockito.mock(CloudService.class);
             List<CloudServiceBinding> serviceBindings = new ArrayList<>();
             for (SimpleBinding simpleBinding : input.existingServiceBindings.get(serviceName)) {
                 serviceBindings.add(simpleBinding.toCloudServiceBinding());
             }
             Mockito.when(cloudServiceInstance.getBindings())
                    .thenReturn(serviceBindings);
+            Mockito.when(cloudServiceInstance.getService())
+                    .thenReturn(cloudService);
+            Mockito.when(cloudService.getName())
+                    .thenReturn(serviceName);
+            Mockito.when(cloudServiceInstance.getMetadata())
+                    .thenReturn(ImmutableCloudMetadata.builder()
+                                                      .guid(NameUtil.getUUID(serviceName))
+                                                      .build());
             Mockito.when(client.getServiceInstance(serviceName))
                    .thenReturn(cloudServiceInstance);
         }
@@ -280,6 +283,8 @@ public class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<
 
     private void prepareContext() {
         Mockito.when(client.getApplication(eq(input.existingApplication.name), eq(false)))
+               .thenReturn(input.existingApplication.toCloudApp());
+        Mockito.when(client.getApplication(eq(input.existingApplication.name)))
                .thenReturn(input.existingApplication.toCloudApp());
         CloudApplicationExtended cloudApp = input.application.toCloudApp();
         // TODO
@@ -359,6 +364,9 @@ public class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<
                                                     .diskQuota(diskQuota)
                                                     .bindingParameters(bindingParameters)
                                                     .serviceKeysToInject(serviceKeysToInject)
+                                                    .metadata(ImmutableCloudMetadata.builder()
+                                                                                    .guid(NameUtil.getUUID(name))
+                                                                                    .build())
                                                     .build();
         }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/update-app-step-input-2.json
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/update-app-step-input-2.json
@@ -30,7 +30,7 @@
 	"existingServiceBindings": {
 		"test-service-1" : [
 		 	{
-				"applicationName": "brum"
+				"applicationName": "test-app-1"
 			}
 		]
 	},

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <netty-codec-http.version>4.1.45.Final</netty-codec-http.version>
         <liquibase.version>3.4.1</liquibase.version>
         <liquibase-slf4j.version>1.2.1</liquibase-slf4j.version>
-        <cloudfoundry.client.version>1.19.1</cloudfoundry.client.version>
+        <cloudfoundry.client.version>1.20.0</cloudfoundry.client.version>
         <semver4j.version>2.2.0</semver4j.version>
         <jgit.version>4.0.1.201506240215-r</jgit.version>
         <swagger.version>1.5.16</swagger.version>


### PR DESCRIPTION
Move the ApplicationServicesUpdater from cf-java-client to
multiapps-controller in order to add logging capabilities in the process
of binding/unbinding services. JIRA: LMCROSSITXSADEPLOY-1869

#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->


#### Issue: <!-- Link to a Github Issue, delete if not applicable -->

