### PR TITLE
Filter mtas by space id as well as mta id

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/RemoveNewApplicationsSuffixStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/RemoveNewApplicationsSuffixStep.java
@@ -39,14 +39,16 @@ public class RemoveNewApplicationsSuffixStep extends SyncFlowableStep {
 
         String mtaId = (String) execution.getContext()
                                          .getVariable(Constants.PARAM_MTA_ID);
-        updateConfigurationSubscribers(appsToProcess, mtaId);
+        String spaceId = StepsUtil.getSpaceId(execution.getContext());
+        updateConfigurationSubscribers(appsToProcess, mtaId, spaceId);
 
         return StepPhase.DONE;
     }
 
-    private void updateConfigurationSubscribers(List<String> appsToProcess, String mtaId) {
+    private void updateConfigurationSubscribers(List<String> appsToProcess, String mtaId, String spaceId) {
         List<ConfigurationSubscription> subscriptions = subscriptionService.createQuery()
                                                                            .mtaId(mtaId)
+                                                                           .spaceId(spaceId)
                                                                            .list();
         for (ConfigurationSubscription subscription : subscriptions) {
             if (appsToProcess.contains(subscription.getAppName())) {

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/RemoveNewApplicationsSuffixStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/RemoveNewApplicationsSuffixStepTest.java
@@ -6,6 +6,7 @@ import com.sap.cloud.lm.sl.cf.core.persistence.service.ConfigurationSubscription
 import com.sap.cloud.lm.sl.cf.process.Constants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
@@ -18,13 +19,12 @@ public class RemoveNewApplicationsSuffixStepTest extends SyncFlowableStepTest<Re
     @Mock
     private ConfigurationSubscriptionService subscriptionService;
 
+    @Mock(answer = Answers.RETURNS_SELF)
+    private ConfigurationSubscriptionQuery query;
+
     @BeforeEach
     public void setUp() {
         context.setVariable(Constants.PARAM_KEEP_ORIGINAL_APP_NAMES_AFTER_DEPLOY, true);
-        context.setVariable(Constants.PARAM_MTA_ID, "");
-        ConfigurationSubscriptionQuery query = Mockito.mock(ConfigurationSubscriptionQuery.class);
-        Mockito.when(query.mtaId(""))
-               .thenReturn(query);
         Mockito.when(query.list())
                .thenReturn(Collections.emptyList());
         Mockito.when(subscriptionService.createQuery())
@@ -58,9 +58,6 @@ public class RemoveNewApplicationsSuffixStepTest extends SyncFlowableStepTest<Re
 
     @Test
     public void testUpdatingOfConfigurationSubscriptions() {
-        ConfigurationSubscriptionQuery query = Mockito.mock(ConfigurationSubscriptionQuery.class);
-        Mockito.when(query.mtaId(""))
-               .thenReturn(query);
         Mockito.when(query.list())
                .thenReturn(Collections.singletonList(new ConfigurationSubscription(0, "", "", "a-idle", null, null, null)));
         Mockito.when(subscriptionService.createQuery())


### PR DESCRIPTION
When updating configuration subscriptions, mtas must be filtered by
space id as well, otherwise it would break mtas with same mta id in
different spaces.

LMCROSSITXSADEPLOY-1159
