### PR TITLE
Extend GetOperations api with mtaId query param

### DIFF
--- a/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/Constants.java
+++ b/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/Constants.java
@@ -13,9 +13,25 @@ public class Constants {
         public static final String OPERATION_ID = "operationId";
         public static final String ACTION_ID = "actionId";
         public static final String LOG_ID = "logId";
-        public static final String MTA_ID = "mtaId";
         public static final String SPACE_GUID = "spaceGuid";
 
+    }
+
+    public static class RequestVariables {
+
+        private RequestVariables() {
+        }
+
+        public static final String MTA_ID = "mtaId";
+    }
+
+    public static class QueryVariables {
+
+        private QueryVariables() {
+        }
+
+        public static final String LAST = "last";
+        public static final String STATE = "state";
     }
 
     public static class Resources {
@@ -39,7 +55,7 @@ public class Constants {
         private Endpoints() {
         }
 
-        public static final String MTA = "/{" + PathVariables.MTA_ID + "}";
+        public static final String MTA = "/{" + RequestVariables.MTA_ID + "}";
         public static final String OPERATION = "/{" + PathVariables.OPERATION_ID + "}";
         public static final String OPERATION_LOGS = OPERATION + "/logs";
         public static final String OPERATION_LOG_CONTENT = OPERATION_LOGS + "/{" + PathVariables.LOG_ID + "}/content";

--- a/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/MtasApi.java
+++ b/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/MtasApi.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.sap.cloud.lm.sl.cf.web.api.Constants.Endpoints;
 import com.sap.cloud.lm.sl.cf.web.api.Constants.PathVariables;
+import com.sap.cloud.lm.sl.cf.web.api.Constants.RequestVariables;
 import com.sap.cloud.lm.sl.cf.web.api.Constants.Resources;
 import com.sap.cloud.lm.sl.cf.web.api.model.Mta;
 
@@ -37,7 +38,7 @@ public class MtasApi {
         }) }, tags = {})
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Mta.class) })
     public ResponseEntity<Mta> getMta(@PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
-                                      @PathVariable(PathVariables.MTA_ID) String mtaId) {
+                                      @PathVariable(RequestVariables.MTA_ID) String mtaId) {
         return delegate.getMta(spaceGuid, mtaId);
     }
 

--- a/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/OperationsApi.java
+++ b/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/OperationsApi.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.sap.cloud.lm.sl.cf.web.api.Constants.Endpoints;
 import com.sap.cloud.lm.sl.cf.web.api.Constants.PathVariables;
+import com.sap.cloud.lm.sl.cf.web.api.Constants.RequestVariables;
+import com.sap.cloud.lm.sl.cf.web.api.Constants.QueryVariables;
 import com.sap.cloud.lm.sl.cf.web.api.Constants.Resources;
 import com.sap.cloud.lm.sl.cf.web.api.model.Log;
 import com.sap.cloud.lm.sl.cf.web.api.model.Operation;
@@ -91,9 +93,10 @@ public class OperationsApi {
         }) }, tags = {})
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Operation.class, responseContainer = "List") })
     public ResponseEntity<List<Operation>> getOperations(@PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
-                                                         @RequestParam(name = "last", required = false) Integer last,
-                                                         @RequestParam(name = "state", required = false) List<String> states) {
-        return delegate.getOperations(spaceGuid, states, last);
+                                                         @RequestParam(name = RequestVariables.MTA_ID, required = false) String mtaId,
+                                                         @RequestParam(name = QueryVariables.LAST, required = false) Integer last,
+                                                         @RequestParam(name = QueryVariables.STATE, required = false) List<String> states) {
+        return delegate.getOperations(spaceGuid, mtaId, states, last);
     }
 
     @GetMapping(path = Endpoints.OPERATION_ACTIONS, produces = { MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_JSON_UTF8_VALUE })

--- a/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/OperationsApiService.java
+++ b/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/OperationsApiService.java
@@ -15,7 +15,7 @@ public interface OperationsApiService {
 
     ResponseEntity<Void> executeOperationAction(HttpServletRequest request, String spaceGuid, String operationId, String actionId);
 
-    ResponseEntity<List<Operation>> getOperations(String spaceGuid, List<String> states, Integer last);
+    ResponseEntity<List<Operation>> getOperations(String spaceGuid, String mtaId, List<String> states, Integer last);
 
     ResponseEntity<Operation> getOperation(String spaceGuid, String operationId, String embed);
 

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/api/impl/OperationsApiServiceImpl.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/api/impl/OperationsApiServiceImpl.java
@@ -84,9 +84,9 @@ public class OperationsApiServiceImpl implements OperationsApiService {
     private static final Logger LOGGER = LoggerFactory.getLogger(OperationsApiServiceImpl.class);
 
     @Override
-    public ResponseEntity<List<Operation>> getOperations(String spaceGuid, List<String> stateStrings, Integer last) {
+    public ResponseEntity<List<Operation>> getOperations(String spaceGuid, String mtaId, List<String> stateStrings, Integer last) {
         List<Operation.State> states = getStates(stateStrings);
-        List<Operation> operations = filterByQueryParameters(last, states, spaceGuid);
+        List<Operation> operations = filterByQueryParameters(last, states, spaceGuid, mtaId);
         return ResponseEntity.ok()
                              .body(operations);
     }
@@ -183,10 +183,13 @@ public class OperationsApiServiceImpl implements OperationsApiService {
     }
 
     private List<Operation> filterByQueryParameters(Integer lastRequestedOperationsCount, List<Operation.State> statusList,
-                                                    String spaceGuid) {
+                                                    String spaceGuid, String mtaId) {
         OperationQuery operationQuery = operationService.createQuery()
                                                         .orderByStartTime(OrderDirection.ASCENDING)
                                                         .spaceId(spaceGuid);
+        if (mtaId != null) {
+            operationQuery.mtaId(mtaId);
+        }
         if (lastRequestedOperationsCount != null) {
             operationQuery.limitOnSelect(lastRequestedOperationsCount)
                           .orderByStartTime(OrderDirection.DESCENDING);

--- a/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/api/impl/OperationsApiServiceImplTest.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/api/impl/OperationsApiServiceImplTest.java
@@ -88,6 +88,7 @@ public class OperationsApiServiceImplTest {
 
     private static final String SPACE_GUID = "896e6be9-8217-4a1c-b938-09b30966157a";
     private static final String ORG_GUID = "0a42c085-b772-4b1e-bf4d-75c463aab5f6";
+    private static final String MTA_ID = "testMta";
 
     private static final String ORG_NAME = "orgName";
     private static final String SPACE_NAME = "spaceName";
@@ -121,8 +122,9 @@ public class OperationsApiServiceImplTest {
 
     @Test
     public void testGetOperations() {
-        ResponseEntity<List<Operation>> response = testedClass.getOperations(SPACE_GUID, Arrays.asList(Operation.State.FINISHED.toString(),
-                                                                                                       Operation.State.ABORTED.toString()),
+        ResponseEntity<List<Operation>> response = testedClass.getOperations(SPACE_GUID, null,
+                                                                             Arrays.asList(Operation.State.FINISHED.toString(),
+                                                                                           Operation.State.ABORTED.toString()),
                                                                              1);
 
         List<Operation> operations = response.getBody();
@@ -136,7 +138,7 @@ public class OperationsApiServiceImplTest {
 
     @Test
     public void testGetOperationsNotFound() {
-        ResponseEntity<List<Operation>> response = testedClass.getOperations(SPACE_GUID,
+        ResponseEntity<List<Operation>> response = testedClass.getOperations(SPACE_GUID, MTA_ID,
                                                                              Collections.singletonList(Operation.State.ACTION_REQUIRED.toString()),
                                                                              1);
 


### PR DESCRIPTION
Extend the GetOperations api to have a new query param for the mta id.
This will allow more native querying for operation by mta id.
JIRA: LMCROSSITXSADEPLOY-1723 and LMCROSSITXSADEPLOY-1578

