### PR TITLE
Fix check for dependency satisfaction

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/ModuleDependencyChecker.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/ModuleDependencyChecker.java
@@ -52,7 +52,7 @@ public class ModuleDependencyChecker {
 
         return module.getDeployedAfter()
                      .isEmpty()
-            || modulesAlreadyDeployed.containsAll(module.getDeployedAfter()) || areAllDependenciesAlreadyPresent(module.getDeployedAfter());
+            || areDependenciesProcessed(module) || areAllDependenciesAlreadyPresent(module.getDeployedAfter());
     }
 
     private boolean areAllDependenciesAlreadyPresent(List<String> deployedAfter) {
@@ -81,5 +81,15 @@ public class ModuleDependencyChecker {
 
     public Set<String> getAlreadyDeployedModules() {
         return modulesAlreadyDeployed;
+    }
+
+    private boolean areDependenciesProcessed(Module module) {
+        return module.getDeployedAfter()
+                     .stream()
+                     .allMatch(this::isProcessed);
+    }
+
+    private boolean isProcessed(String moduleName) {
+        return modulesAlreadyDeployed.contains(moduleName) || modulesNotForDeployment.contains(moduleName);
     }
 }


### PR DESCRIPTION
Make ModuleDependencyChecker verify that a module is either in the
deployed modules or in the modules not for deployment. Add a check in
ComputeNextModulesStep for possible infinite loop as safe mechanism.
JIRA: LMCROSSITXSADEPLOY-2010