### PR TITLE
Configurable CC api for debugging: CF_API env variable

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfiguration.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/ApplicationConfiguration.java
@@ -553,8 +553,11 @@ public class ApplicationConfiguration {
     }
 
     private URL getControllerUrlFromEnvironment() {
-        Map<String, Object> vcapApplicationMap = getVcapApplication();
-        String controllerUrlString = getControllerUrl(vcapApplicationMap);
+        String controllerUrlString = environment.getString("CF_API");
+        if(controllerUrlString == null || controllerUrlString.isEmpty()){
+            Map<String, Object> vcapApplicationMap = getVcapApplication();
+            controllerUrlString = getControllerUrl(vcapApplicationMap);
+        }
         try {
             URL parsedControllerUrl = MiscUtil.getURL(controllerUrlString);
             LOGGER.info(format(Messages.CONTROLLER_URL, parsedControllerUrl));


### PR DESCRIPTION
#### Description: 
make the deploy-service call a proxy instead of the original CF api url
Does not work as the cf client is smart enough to call the original CC url upon first responses from it via the proxy

