### PR TITLE
Feature flag parameter for disabling env based detection

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/detect/DeployedMtaDetector.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/detect/DeployedMtaDetector.java
@@ -56,7 +56,7 @@ public class DeployedMtaDetector {
                                      .collect(Collectors.toList());
     }
 
-    public Optional<DeployedMta> detectDeployedMta(String mtaId, CloudControllerClient client) {
+    public Optional<DeployedMta> detectDeployedMta(String mtaId, CloudControllerClient client, boolean envDetectionEnabled) {
         MtaMetadataCriteria selectionCriteria = MtaMetadataCriteriaBuilder.builder()
                                                                           .label(MtaMetadataLabels.MTA_ID)
                                                                           .haveValue(MtaMetadataUtil.getHashedMtaId(mtaId))
@@ -66,7 +66,10 @@ public class DeployedMtaDetector {
             return deployedMtasByMetadata.stream()
                                          .findFirst();
         }
-        return deployedMtaEnvDetector.detectDeployedMta(mtaId, client);
+        if (envDetectionEnabled) {
+            return deployedMtaEnvDetector.detectDeployedMta(mtaId, client);
+        }
+        return Optional.empty();
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/metadata/BlueGreenDeployMetadata.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/metadata/BlueGreenDeployMetadata.java
@@ -125,6 +125,12 @@ public class BlueGreenDeployMetadata {
                                              .type(ParameterType.BOOLEAN)
                                              .defaultValue(Variables.VERIFY_ARCHIVE_SIGNATURE.getDefaultValue())
                                              .build());
+        PARAMS.add(ImmutableParameterMetadata.builder()
+                                             .id(Variables.ENABLE_ENV_DETECTION.getName())
+                                             .type(ParameterType.BOOLEAN)
+                                             .defaultValue(Variables.ENABLE_ENV_DETECTION.getDefaultValue())
+                                             .required(false)
+                                             .build());
 
         // Special blue green deploy parameters:
         PARAMS.add(ImmutableParameterMetadata.builder()

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/metadata/DeployMetadata.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/metadata/DeployMetadata.java
@@ -126,6 +126,12 @@ public class DeployMetadata {
                                              .type(ParameterType.BOOLEAN)
                                              .defaultValue(Variables.VERIFY_ARCHIVE_SIGNATURE.getDefaultValue())
                                              .build());
+        PARAMS.add(ImmutableParameterMetadata.builder()
+                                             .id(Variables.ENABLE_ENV_DETECTION.getName())
+                                             .type(ParameterType.BOOLEAN)
+                                             .defaultValue(Variables.ENABLE_ENV_DETECTION.getDefaultValue())
+                                             .required(false)
+                                             .build());
     }
 
     private DeployMetadata() {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/metadata/UndeployMetadata.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/metadata/UndeployMetadata.java
@@ -50,6 +50,12 @@ public class UndeployMetadata {
                                              .type(ParameterType.BOOLEAN)
                                              .defaultValue(Variables.ABORT_ON_ERROR.getDefaultValue())
                                              .build());
+        PARAMS.add(ImmutableParameterMetadata.builder()
+                                             .id(Variables.ENABLE_ENV_DETECTION.getName())
+                                             .type(ParameterType.BOOLEAN)
+                                             .defaultValue(Variables.ENABLE_ENV_DETECTION.getDefaultValue())
+                                             .required(false)
+                                             .build());
     }
 
     private UndeployMetadata() {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetectDeployedMtaStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/DetectDeployedMtaStep.java
@@ -30,7 +30,9 @@ public class DetectDeployedMtaStep extends SyncFlowableStep {
         CloudControllerClient client = context.getControllerClient();
 
         String mtaId = context.getVariable(Variables.MTA_ID);
-        Optional<DeployedMta> optionalDeployedMta = deployedMtaDetector.detectDeployedMta(mtaId, client);
+        boolean envDetectionEnabled = context.getVariable(Variables.ENABLE_ENV_DETECTION);
+
+        Optional<DeployedMta> optionalDeployedMta = deployedMtaDetector.detectDeployedMta(mtaId, client, envDetectionEnabled);
         if (optionalDeployedMta.isPresent()) {
             DeployedMta deployedMta = optionalDeployedMta.get();
             context.setVariable(Variables.DEPLOYED_MTA, deployedMta);

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/variables/Variables.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/variables/Variables.java
@@ -526,5 +526,8 @@ public interface Variables {
     Variable<List<String>> RESOURCES_FOR_DEPLOYMENT = ImmutableCommaSeparatedValuesVariable.builder()
                                                                                            .name("resourcesForDeployment")
                                                                                            .build();
-
+    Variable<Boolean> ENABLE_ENV_DETECTION = ImmutableSimpleVariable.<Boolean> builder()
+                                                                    .name("enableEnvDetection")
+                                                                    .defaultValue(true)
+                                                                    .build();
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/metadata/BlueGreenDeployMetadataTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/metadata/BlueGreenDeployMetadataTest.java
@@ -48,6 +48,7 @@ public class BlueGreenDeployMetadataTest extends MetadataBaseTest {
                 Variables.MODULES_FOR_DEPLOYMENT.getName(),
                 Variables.RESOURCES_FOR_DEPLOYMENT.getName(),
                 Variables.VERIFY_ARCHIVE_SIGNATURE.getName(),
+                Variables.ENABLE_ENV_DETECTION.getName(),
                 Variables.NO_CONFIRM.getName(),
                 Variables.KEEP_ORIGINAL_APP_NAMES_AFTER_DEPLOY.getName(),
             // @formatter:on

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/metadata/DeployMetadataTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/metadata/DeployMetadataTest.java
@@ -48,6 +48,7 @@ public class DeployMetadataTest extends MetadataBaseTest {
                 Variables.MODULES_FOR_DEPLOYMENT.getName(),
                 Variables.RESOURCES_FOR_DEPLOYMENT.getName(),
                 Variables.VERIFY_ARCHIVE_SIGNATURE.getName(),
+                Variables.ENABLE_ENV_DETECTION.getName(),
             // @formatter:on
         };
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/metadata/UndeployMetadataTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/metadata/UndeployMetadataTest.java
@@ -32,6 +32,7 @@ public class UndeployMetadataTest extends MetadataBaseTest {
                 Variables.NO_RESTART_SUBSCRIBED_APPS.getName(),
                 Variables.NO_FAIL_ON_MISSING_PERMISSIONS.getName(),
                 Variables.ABORT_ON_ERROR.getName(),
+                Variables.ENABLE_ENV_DETECTION.getName(),
             // @formatter:on
         };
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DetectDeployedMtaStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DetectDeployedMtaStepTest.java
@@ -38,7 +38,7 @@ public class DetectDeployedMtaStepTest extends SyncFlowableStepTest<DetectDeploy
 
         when(deployedMtaDetector.detectDeployedMtas(Mockito.any(CloudControllerClient.class))).thenReturn(deployedComponents);
         when(deployedMtaDetector.detectDeployedMta(Mockito.eq(MTA_ID),
-                                                   Mockito.any(CloudControllerClient.class))).thenReturn(Optional.of(deployedMta));
+                                                   Mockito.any(CloudControllerClient.class), Mockito.eq(true))).thenReturn(Optional.of(deployedMta));
 
         step.execute(execution);
 
@@ -51,7 +51,7 @@ public class DetectDeployedMtaStepTest extends SyncFlowableStepTest<DetectDeploy
     public void testExecute4() {
         when(client.getApplications()).thenReturn(Collections.emptyList());
         when(deployedMtaDetector.detectDeployedMtas(client)).thenReturn(Collections.emptyList());
-        when(deployedMtaDetector.detectDeployedMta(MTA_ID, client)).thenReturn(Optional.empty());
+        when(deployedMtaDetector.detectDeployedMta(MTA_ID, client, false)).thenReturn(Optional.empty());
         step.execute(execution);
 
         assertStepFinishedSuccessfully();

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/api/impl/MtasApiServiceImpl.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/api/impl/MtasApiServiceImpl.java
@@ -48,7 +48,7 @@ public class MtasApiServiceImpl implements MtasApiService {
 
     @Override
     public ResponseEntity<Mta> getMta(String spaceGuid, String mtaId) {
-        Optional<DeployedMta> optionalDeployedMta = deployedMtaDetector.detectDeployedMta(mtaId, getCloudFoundryClient(spaceGuid));
+        Optional<DeployedMta> optionalDeployedMta = deployedMtaDetector.detectDeployedMta(mtaId, getCloudFoundryClient(spaceGuid), true);
         DeployedMta deployedMta = optionalDeployedMta.orElseThrow(() -> new NotFoundException(Messages.MTA_NOT_FOUND, mtaId));
         return ResponseEntity.ok()
                              .body(getMta(deployedMta));

--- a/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/api/impl/MtaApiServiceImplTest.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/api/impl/MtaApiServiceImplTest.java
@@ -129,7 +129,7 @@ public class MtaApiServiceImplTest {
         Mockito.when(deployedMtaDetector.detectDeployedMta(mtas.get(1)
                                                                .getMetadata()
                                                                .getId(),
-                                                           client))
+                                                           client, true))
                .thenReturn(Optional.of(getDeployedMta(mtas.get(1))));
     }
 


### PR DESCRIPTION
#### Description: 
To enable MTA deploy orchestrators working in monstrous spaces to disable env-based detection and avoid hitting the CC rate limit. 
#### Issue: NGPBUG-112089

PS: I know that adding a boolean parameter to a method is not exactly clean code. This code is anyway meant to be deleted in a couple of months, when env-based detection is phased out. 
