### PR TITLE
POC: Masking env variable values

### DIFF
--- a/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/ResilientCloudControllerClient.java
+++ b/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/ResilientCloudControllerClient.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -321,8 +322,8 @@ public class ResilientCloudControllerClient implements CloudControllerClient {
     }
 
     @Override
-    public void updateApplicationEnv(String applicationName, Map<String, String> env) {
-        executeWithRetry(() -> delegate.updateApplicationEnv(applicationName, env));
+    public void updateApplicationEnv(String applicationName, Map<String, String> env, Collection<String> sensitiveVariables) {
+        executeWithRetry(() -> delegate.updateApplicationEnv(applicationName, env, sensitiveVariables));
     }
 
     @Override

--- a/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/lib/domain/CloudApplicationExtended.java
+++ b/com.sap.cloud.lm.sl.cf.client/src/main/java/com/sap/cloud/lm/sl/cf/client/lib/domain/CloudApplicationExtended.java
@@ -65,4 +65,5 @@ public interface CloudApplicationExtended extends CloudApplication {
 
     }
 
+    List<String> getSensitiveEnvVariableNames();
 }

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/detect/DeployedMtaDetector.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/detect/DeployedMtaDetector.java
@@ -66,7 +66,7 @@ public class DeployedMtaDetector {
             return deployedMtasByMetadata.stream()
                                          .findFirst();
         }
-        if (envDetectionEnabled) {
+        if(envDetectionEnabled){
             return deployedMtaEnvDetector.detectDeployedMta(mtaId, client);
         }
         return Optional.empty();

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/detect/DeployedMtaDetector.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/detect/DeployedMtaDetector.java
@@ -66,7 +66,7 @@ public class DeployedMtaDetector {
             return deployedMtasByMetadata.stream()
                                          .findFirst();
         }
-        if(envDetectionEnabled){
+        if (envDetectionEnabled) {
             return deployedMtaEnvDetector.detectDeployedMta(mtaId, client);
         }
         return Optional.empty();

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/v2/ApplicationCloudModelBuilder.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/v2/ApplicationCloudModelBuilder.java
@@ -102,6 +102,7 @@ public class ApplicationCloudModelBuilder {
                                                 .services(getAllApplicationServices(module))
                                                 .serviceKeysToInject(getServicesKeysToInject(module))
                                                 .env(applicationEnvCloudModelBuilder.build(module, getApplicationServices(module)))
+                                                .sensitiveEnvVariableNames(getSensitivePropertyNames(module))
                                                 .bindingParameters(getBindingParameters(module))
                                                 .tasks(getTasks(parametersList))
                                                 .domains(getApplicationDomains(parametersList, module))
@@ -112,6 +113,7 @@ public class ApplicationCloudModelBuilder {
                                                                                              getApplicationServices(module)))
                                                 .build();
     }
+
 
     private AttributeUpdateStrategy getApplicationAttributesUpdateStrategy(List<Map<String, Object>> parametersList) {
         return parseParameters(parametersList, new ApplicationAttributeUpdateStrategyParser());
@@ -210,6 +212,15 @@ public class ApplicationCloudModelBuilder {
                                     ValidatorUtil.getPrefixedName(prefix, SupportedParameters.SERVICE_BINDING_CONFIG),
                                     Map.class.getSimpleName(), bindingParameters.getClass()
                                                                                 .getSimpleName());
+    }
+
+    private List<String> getSensitivePropertyNames(final Module module) {
+        Predicate<String> filter = (property) -> module.getPropertiesMetadata().getSensitiveMetadata(property);
+        return module.getProperties()
+                .keySet()
+                .stream()
+                .filter(filter)
+                .collect(Collectors.toList());
     }
 
     protected List<String> getApplicationServices(Module module, Predicate<ResourceAndResourceType> filterRule) {

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/security/serialization/SecureSerializationFacade.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/security/serialization/SecureSerializationFacade.java
@@ -23,6 +23,11 @@ public class SecureSerializationFacade {
         return this;
     }
 
+    public SecureSerializationFacade addSensitiveElementNames(Collection<String> extraElementNames) {
+        this.configuration.addSensitiveElementNames(extraElementNames);
+        return this;
+    }
+
     public SecureSerializationFacade setSensitiveElementPaths(Collection<String> sensitiveElementPaths) {
         this.configuration.setSensitiveElementPaths(sensitiveElementPaths);
         return this;

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/security/serialization/SecureSerializerConfiguration.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/security/serialization/SecureSerializerConfiguration.java
@@ -1,10 +1,12 @@
 package com.sap.cloud.lm.sl.cf.core.security.serialization;
 
+import com.sap.cloud.lm.sl.common.util.ListUtil;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-
-import org.apache.commons.lang3.StringUtils;
 
 public class SecureSerializerConfiguration {
 
@@ -46,4 +48,8 @@ public class SecureSerializerConfiguration {
                                          .anyMatch(name -> StringUtils.containsIgnoreCase(value, name));
     }
 
+    public void addSensitiveElementNames(Collection<String> extraElementNames) {
+        this.sensitiveElementNames = new ArrayList<>(this.sensitiveElementNames);
+        this.sensitiveElementNames.addAll(extraElementNames);
+    }
 }

--- a/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/helpers/ApplicationEnvironmentUpdaterTest.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/helpers/ApplicationEnvironmentUpdaterTest.java
@@ -60,7 +60,7 @@ public class ApplicationEnvironmentUpdaterTest {
         applicationEnvironmentUpdater.updateApplicationEnvironment(input.envPropertyKey, input.newKey, input.newValue);
         ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(client)
-               .updateApplicationEnv(Mockito.eq(input.app.name), (Map<String, String>) captor.capture());
+               .updateApplicationEnv(Mockito.eq(input.app.name), (Map<String, String>) captor.capture(), sensitiveVariables);
         tester.test(captor::getValue, expectation);
     }
 

--- a/com.sap.cloud.lm.sl.cf.core/src/test/resources/com/sap/cloud/lm/sl/cf/core/cf/v2/apps-01.json
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/resources/com/sap/cloud/lm/sl/cf/core/cf/v2/apps-01.json
@@ -54,6 +54,7 @@
       "shouldKeepExistingEnv": false,
       "shouldKeepExistingServiceBindings": false,
       "shouldKeepExistingRoutes": false
-    }
+    },
+    "sensitiveEnvVariableNames" : [ ]
   }
 ]

--- a/com.sap.cloud.lm.sl.cf.core/src/test/resources/mta/devxwebide/apps.json
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/resources/mta/devxwebide/apps.json
@@ -52,6 +52,7 @@
       "shouldKeepExistingEnv": false,
       "shouldKeepExistingServiceBindings": false,
       "shouldKeepExistingRoutes": false
-    }
+    },
+    "sensitiveEnvVariableNames" : [ ]
   }
 ]

--- a/com.sap.cloud.lm.sl.cf.core/src/test/resources/mta/devxwebide/xs2-apps.json
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/resources/mta/devxwebide/xs2-apps.json
@@ -52,6 +52,7 @@
       "shouldKeepExistingEnv": false,
       "shouldKeepExistingServiceBindings": false,
       "shouldKeepExistingRoutes": false
-    }
+    },
+    "sensitiveEnvVariableNames" : [ ]
   }
 ]

--- a/com.sap.cloud.lm.sl.cf.core/src/test/resources/mta/javahelloworld/apps-patch-ns.json
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/resources/mta/javahelloworld/apps-patch-ns.json
@@ -52,6 +52,7 @@
       "shouldKeepExistingEnv": false,
       "shouldKeepExistingServiceBindings": false,
       "shouldKeepExistingRoutes": false
-    }
+    },
+    "sensitiveEnvVariableNames" : [ ]
   }
 ]

--- a/com.sap.cloud.lm.sl.cf.core/src/test/resources/mta/javahelloworld/apps-patch.json
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/resources/mta/javahelloworld/apps-patch.json
@@ -52,6 +52,7 @@
       "shouldKeepExistingEnv": false,
       "shouldKeepExistingServiceBindings": false,
       "shouldKeepExistingRoutes": false
-    }
+    },
+    "sensitiveEnvVariableNames" : [ ]
   }
 ]

--- a/com.sap.cloud.lm.sl.cf.core/src/test/resources/mta/javahelloworld/apps.json
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/resources/mta/javahelloworld/apps.json
@@ -166,5 +166,6 @@
       "shouldKeepExistingServiceBindings": false,
       "shouldKeepExistingRoutes": false
     }
-  }
+  },
+  "sensitiveEnvVariableNames" : [ ]
 ]

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/client/LoggingCloudControllerClient.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/client/LoggingCloudControllerClient.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -574,9 +575,14 @@ public class LoggingCloudControllerClient implements CloudControllerClient {
     }
 
     @Override
-    public void updateApplicationEnv(String applicationName, Map<String, String> env) {
-        logger.debug(Messages.UPDATING_ENVIRONMENT_OF_APPLICATION_0_TO_1, applicationName, SERIALIZATION.toJson(env));
-        delegate.updateApplicationEnv(applicationName, env);
+    public void updateApplicationEnv(String applicationName, Map<String, String> env, Collection<String> sensitiveVariables) {
+        String envForLogging = new SecureSerializationFacade().addSensitiveElementNames(sensitiveVariables)
+                                                              .setFormattedOutput(true)
+                                                              .toJson(env);
+
+        logger.debug("known sensitive variables: {0}", sensitiveVariables);
+        logger.debug(Messages.UPDATING_ENVIRONMENT_OF_APPLICATION_0_TO_1, applicationName, envForLogging);
+        delegate.updateApplicationEnv(applicationName, env, sensitiveVariables);
     }
 
     @Override

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BuildCloudDeployModelStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/BuildCloudDeployModelStep.java
@@ -15,6 +15,7 @@ import javax.inject.Named;
 
 import org.cloudfoundry.client.lib.CloudControllerClient;
 import org.cloudfoundry.client.lib.domain.CloudServiceKey;
+import org.cloudfoundry.client.lib.util.JsonUtil;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
@@ -72,6 +73,7 @@ public class BuildCloudDeployModelStep extends SyncFlowableStep {
 
         // Build a map of service keys and save them in the context:
         Map<String, List<CloudServiceKey>> serviceKeys = getServiceKeysCloudModelBuilder(context).build();
+
         getStepLogger().debug(Messages.SERVICE_KEYS_TO_CREATE, secureSerializer.toJson(serviceKeys));
 
         context.setVariable(Variables.SERVICE_KEYS_TO_CREATE, serviceKeys);
@@ -80,6 +82,7 @@ public class BuildCloudDeployModelStep extends SyncFlowableStep {
         List<Module> modulesCalculatedForDeployment = calculateModulesForDeployment(context, deploymentDescriptor, mtaArchiveModules,
                                                                                     deployedModuleNames, mtaModules);
 
+        //TODO - for some reason in the followng line the secure serializer does not mask sensitive properties
         getStepLogger().debug(Messages.MODULES_TO_DEPLOY, secureSerializer.toJson(modulesCalculatedForDeployment));
         context.setVariable(Variables.ALL_MODULES_TO_DEPLOY, modulesCalculatedForDeployment);
         context.setVariable(Variables.MODULES_TO_DEPLOY, modulesCalculatedForDeployment);

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStep.java
@@ -193,7 +193,7 @@ public class CreateOrUpdateAppStep extends SyncFlowableStep {
 
         @Override
         public void handleApplicationEnv() {
-            client.updateApplicationEnv(app.getName(), app.getEnv());
+            client.updateApplicationEnv(app.getName(), app.getEnv(), app.getSensitiveEnvVariableNames());
             context.setVariable(Variables.USER_PROPERTIES_CHANGED, true);
         }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UpdateSubscribersStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UpdateSubscribersStep.java
@@ -240,7 +240,7 @@ public class UpdateSubscribersStep extends SyncFlowableStep {
 
         getStepLogger().info(Messages.UPDATING_SUBSCRIBER, subscription.getAppName(), subscription.getMtaId(),
                              getRequiredDependency(subscription).getName());
-        client.updateApplicationEnv(existingApplication.getName(), currentEnvironment);
+        client.updateApplicationEnv(existingApplication.getName(), currentEnvironment, Collections.emptyList());
         return existingApplication;
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UploadAppStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/UploadAppStep.java
@@ -158,6 +158,7 @@ public class UploadAppStep extends TimeoutAsyncFlowableStep {
     }
 
     private void attemptToUpdateApplicationDigest(CloudControllerClient client, CloudApplication app, String newApplicationDigest) {
+        //The application here is probably not extended or is detected from env instead of built from a module, as it does not contain the metadata...
         new ApplicationEnvironmentUpdater(app,
                                           client).updateApplicationEnvironment(com.sap.cloud.lm.sl.cf.core.Constants.ENV_DEPLOY_ATTRIBUTES,
                                                                                com.sap.cloud.lm.sl.cf.core.Constants.ATTR_APP_CONTENT_DIGEST,

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/EnvironmentApplicationAttributeUpdater.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/util/EnvironmentApplicationAttributeUpdater.java
@@ -1,12 +1,14 @@
 package com.sap.cloud.lm.sl.cf.process.util;
 
-import java.util.Map;
-
-import org.cloudfoundry.client.lib.domain.CloudApplication;
-
+import com.sap.cloud.lm.sl.cf.client.lib.domain.CloudApplicationExtended;
+import com.sap.cloud.lm.sl.cf.core.security.serialization.SecureSerializationFacade;
 import com.sap.cloud.lm.sl.cf.process.Messages;
 import com.sap.cloud.lm.sl.cf.process.util.ElementUpdater.UpdateStrategy;
-import com.sap.cloud.lm.sl.common.util.JsonUtil;
+import org.cloudfoundry.client.lib.domain.CloudApplication;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 public class EnvironmentApplicationAttributeUpdater extends ApplicationAttributeUpdater {
 
@@ -23,16 +25,25 @@ public class EnvironmentApplicationAttributeUpdater extends ApplicationAttribute
 
     @Override
     protected void updateAttribute(CloudApplication existingApplication, CloudApplication application) {
-        Map<String, String> env = applyUpdateStrategy(existingApplication.getEnv(), application.getEnv());
-        getControllerClient().updateApplicationEnv(application.getName(), env);
+        Collection<String> sensitiveVariables = getSensitiveVariables(application);
+        Map<String, String> env = applyUpdateStrategy(existingApplication.getEnv(), application.getEnv(), sensitiveVariables);
+        getControllerClient().updateApplicationEnv(application.getName(), env, sensitiveVariables);
     }
 
-    private Map<String, String> applyUpdateStrategy(Map<String, String> existingEnv, Map<String, String> env) {
-        getLogger().debug(Messages.EXISTING_ENV_0, JsonUtil.toJson(existingEnv, true));
-        getLogger().debug(Messages.APPLYING_UPDATE_STRATEGY_0_TO_ENV_1, updateStrategy, JsonUtil.toJson(env, true));
+    private Map<String, String> applyUpdateStrategy(Map<String, String> existingEnv, Map<String, String> env, Collection<String> sensitiveVariables) {
+        SecureSerializationFacade secureSerializer = new SecureSerializationFacade().addSensitiveElementNames(sensitiveVariables)
+                                                                                    .setFormattedOutput(true);
+        getLogger().debug(Messages.EXISTING_ENV_0, secureSerializer.toJson(existingEnv));
+        getLogger().debug(Messages.APPLYING_UPDATE_STRATEGY_0_TO_ENV_1, updateStrategy, secureSerializer.toJson(env));
         Map<String, String> result = getElementUpdater().updateMap(existingEnv, env);
-        getLogger().debug(Messages.RESULT_0, JsonUtil.toJson(result, true));
+        getLogger().debug(Messages.RESULT_0, secureSerializer.toJson(result));
         return result;
     }
 
+    private Collection<String> getSensitiveVariables(CloudApplication application) {
+        if(application instanceof CloudApplicationExtended){
+            return ((CloudApplicationExtended) application).getSensitiveEnvVariableNames();
+        }
+        return Collections.emptyList();
+    }
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStepTest.java
@@ -202,7 +202,7 @@ public class CreateOrUpdateAppStepTest extends CreateOrUpdateAppStepBaseTest {
             }
         }
         Mockito.verify(client)
-               .updateApplicationEnv(application.getName(), application.getEnv());
+               .updateApplicationEnv(application.getName(), application.getEnv(), sensitiveVariables);
     }
 
     private Map<String, Object> getBindingParametersForService(Map<String, Map<String, Object>> bindingParameters, String serviceName) {

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStepWithDockerTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateAppStepWithDockerTest.java
@@ -103,7 +103,7 @@ public class CreateOrUpdateAppStepWithDockerTest extends CreateOrUpdateAppStepBa
                .createApplication(eq(application.getName()), argThat(GenericArgumentMatcher.forObject(application.getStaging())),
                                   eq(diskQuota), eq(memory), eq(application.getUris()), eq(DOCKER_INFO));
         Mockito.verify(client)
-               .updateApplicationEnv(eq(application.getName()), eq(application.getEnv()));
+               .updateApplicationEnv(eq(application.getName()), eq(application.getEnv()), sensitiveVariables);
     }
 
     @Override

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateStepWithExistingAppTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateOrUpdateStepWithExistingAppTest.java
@@ -152,7 +152,7 @@ public class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<
         }
         if (input.updateEnv) {
             Mockito.verify(client)
-                   .updateApplicationEnv(appName, cloudApp.getEnv());
+                   .updateApplicationEnv(appName, cloudApp.getEnv(), sensitiveVariables);
         }
     }
 

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DetectDeployedMtaStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/DetectDeployedMtaStepTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.Functions;
 import org.cloudfoundry.client.lib.CloudControllerClient;
 import org.junit.Before;
 import org.junit.Test;

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/UpdateSubscribersStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/UpdateSubscribersStepTest.java
@@ -254,7 +254,7 @@ public class UpdateSubscribersStepTest extends SyncFlowableStepTest<UpdateSubscr
         if (!userHasPermissions(subscriber.app.getSpace(), UserPermission.WRITE)) {
             doThrow(new CloudOperationException(HttpStatus.FORBIDDEN)).when(client)
                                                                       .updateApplicationEnv(eq(subscriber.subscription.getAppName()),
-                                                                                            any(Map.class));
+                                                                                            any(Map.class), sensitiveVariables);
         }
     }
 
@@ -323,7 +323,7 @@ public class UpdateSubscribersStepTest extends SyncFlowableStepTest<UpdateSubscr
     private List<CloudApplication> getCallArgumentsOfUpdateApplicationEnvMethod(CloudSpace space, CloudControllerClient client) {
         ArgumentCaptor<Map> appEnvCaptor = ArgumentCaptor.forClass(Map.class);
         ArgumentCaptor<String> appNameCaptor = ArgumentCaptor.forClass(String.class);
-        verify(client, Mockito.atLeast(0)).updateApplicationEnv(appNameCaptor.capture(), appEnvCaptor.capture());
+        verify(client, Mockito.atLeast(0)).updateApplicationEnv(appNameCaptor.capture(), appEnvCaptor.capture(), sensitiveVariables);
 
         List<Map> appEnvs = appEnvCaptor.getAllValues();
         List<String> appNames = appNameCaptor.getAllValues();


### PR DESCRIPTION
@nictas - do you think this approach makes any sense?

#### Description: 
Does Not work:
- for the env of detected (to be updated) apps; 
- printed env when app digest is updated (upload app step)
- updating subscriptions

ugly change: 
- cloud controller client api has the notion of sensitive env variables passed as a parameter to the method updating them
- even uglier change  may be required  - persisting the list of sensitive variables as metadata

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->

