### PR TITLE
Fix cases when the processes are already deleted

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/jobs/AbortedOperationsCleaner.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/jobs/AbortedOperationsCleaner.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.persistence.NoResultException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,10 +56,18 @@ public class AbortedOperationsCleaner implements Cleaner {
     }
 
     private boolean isInActiveState(String operationId) {
-        return operationService.createQuery()
-                               .processId(operationId)
-                               .singleResult()
-                               .getState() == null;
+        Operation operation = getOperation(operationId);
+        return operation != null && operation.getState() == null;
+    }
+
+    private Operation getOperation(String operationId) {
+        try {
+            return operationService.createQuery()
+                                   .processId(operationId)
+                                   .singleResult();
+        } catch (NoResultException e) {
+            return null;
+        }
     }
 
     private void deleteProcessInstance(String processInstanceId) {

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/jobs/AbortedOperationsCleaner.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/jobs/AbortedOperationsCleaner.java
@@ -23,7 +23,7 @@ import com.sap.cloud.lm.sl.cf.process.flowable.FlowableFacade;
 import com.sap.cloud.lm.sl.cf.web.api.model.Operation;
 
 @Named
-@Order(20)
+@Order(5)
 public class AbortedOperationsCleaner implements Cleaner {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbortedOperationsCleaner.class);


### PR DESCRIPTION
#### Description: 
When the CleanUp job is fired more than two times, the already deleted operations are retrieved from the database as part of the request. When this happens, the logic in this cleaner is trying to delete the operation without checking whether it is presented in the database or not.

This commit fixes this problem by adding additional check whether the operation exists.

### Cause:
Could result in growing database of operations and non-deleted Flowable processes.

#### Issue:
https://jtrack.wdf.sap.corp/browse/NGPBUG-116635

