### PR TITLE
Set version rule ALL as default for CTS+ processes

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/metadata/CtsDeployMetadata.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/metadata/CtsDeployMetadata.java
@@ -9,6 +9,7 @@ import com.sap.cloud.lm.sl.cf.web.api.model.ImmutableOperationMetadata;
 import com.sap.cloud.lm.sl.cf.web.api.model.ImmutableParameterMetadata;
 import com.sap.cloud.lm.sl.cf.web.api.model.OperationMetadata;
 import com.sap.cloud.lm.sl.cf.web.api.model.ParameterMetadata.ParameterType;
+import com.sap.cloud.lm.sl.mta.model.VersionRule;
 
 public class CtsDeployMetadata {
 
@@ -43,8 +44,7 @@ public class CtsDeployMetadata {
                                              .build());
         PARAMS.add(ImmutableParameterMetadata.builder()
                                              .id(Variables.VERSION_RULE.getName())
-                                             .defaultValue(Variables.VERSION_RULE.getDefaultValue()
-                                                                                 .toString())
+                                             .defaultValue(VersionRule.ALL.toString())
                                              .build());
         PARAMS.add(ImmutableParameterMetadata.builder()
                                              .id(Variables.DELETE_SERVICES.getName())


### PR DESCRIPTION
#### Description: 
To enable batched deployments downgrade without the need of fine-tuning of upgrade rule configurations

#### Issue: LMCROSSITXSADEPLOY-2083

