### PR TITLE
Fix cleanup of processes in Flowable tables

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/Messages.java
@@ -137,6 +137,7 @@ public class Messages {
     public static final String ERROR_POLLING_OF_SERVICE = "Error polling last operation of service \"{0}\": {1}";
     public static final String ERROR_MERGING_ARCHIVE = "Error merging archive. Retrying...";
     public static final String ERROR_DELETING_OPERATION_WITH_ID = "Error deleting operation with ID \"{0}\"";
+    public static final String ERROR_DELETING_FLOWABLE_PROCESS_WITH_ID = "Error deleting Flowable process with ID \"{0}\"";
     public static final String ERROR_MISSING_DEFAULT_DOMAIN = "Missing default domain in current org";
 
     // WARN log messages
@@ -202,6 +203,8 @@ public class Messages {
     public static final String CREATE_SUPPORT_TICKET_TO_SERVICE_BROKER_COMPONENT = "If you think the problem is in the service broker, please create a support ticket to {0} component \"{1}\".";
     public static final String CREATE_SUPPORT_TICKET_TO_CC_COMPONENT = "If you think the problem is in the controller, please create a support ticket to {0} component \"{1}\".";
     public static final String DELETING_OPERATION_WITH_ID = "Deleting operation with ID \"{0}\"";
+    public static final String DELETING_FLOWABLE_PROCESS_WITH_ID = "Deleting Flowable process with ID \"{0}\"";
+    public static final String FLOWABLE_PROCESSES_TO_DELETE = "Flowable processes to delete: {0}";
 
     // Progress messages
 

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/FlowableFacade.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/flowable/FlowableFacade.java
@@ -3,6 +3,7 @@ package com.sap.cloud.lm.sl.cf.process.flowable;
 import static java.text.MessageFormat.format;
 
 import java.text.MessageFormat;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -314,6 +315,14 @@ public class FlowableFacade {
                             .processDefinitionKey(processDefinitionKey)
                             .singleResult()
                             .getId();
+    }
+
+    public List<ProcessInstance> findAllRunningProcessInstanceStartedBefore(Date startedBefore) {
+        return processEngine.getRuntimeService()
+                            .createProcessInstanceQuery()
+                            .excludeSubprocesses(true)
+                            .startedBefore(startedBefore)
+                            .list();
     }
 
 }

--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/jobs/FlowableDataCleaner.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/jobs/FlowableDataCleaner.java
@@ -1,0 +1,51 @@
+package com.sap.cloud.lm.sl.cf.process.jobs;
+
+import java.text.MessageFormat;
+import java.util.Date;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.flowable.engine.runtime.ProcessInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+
+import com.sap.cloud.lm.sl.cf.process.Messages;
+import com.sap.cloud.lm.sl.cf.process.flowable.FlowableFacade;
+import com.sap.cloud.lm.sl.cf.web.api.model.Operation;
+
+@Named
+@Order(30)
+public class FlowableDataCleaner implements Cleaner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowableDataCleaner.class);
+
+    private FlowableFacade flowableFacade;
+
+    @Inject
+    public FlowableDataCleaner(FlowableFacade flowableFacade) {
+        this.flowableFacade = flowableFacade;
+    }
+
+    @Override
+    public void execute(Date expirationTime) {
+        List<ProcessInstance> processInstances = flowableFacade.findAllRunningProcessInstanceStartedBefore(expirationTime);
+        LOGGER.info(CleanUpJob.LOG_MARKER, MessageFormat.format(Messages.FLOWABLE_PROCESSES_TO_DELETE, processInstances.size()));
+        processInstances.stream()
+                        .map(ProcessInstance::getProcessInstanceId)
+                        .forEach(this::deleteProcessInstance);
+    }
+
+    private void deleteProcessInstance(String processInstanceId) {
+        try {
+            LOGGER.info(CleanUpJob.LOG_MARKER, MessageFormat.format(Messages.DELETING_FLOWABLE_PROCESS_WITH_ID, processInstanceId));
+            flowableFacade.deleteProcessInstance(processInstanceId, Operation.State.ABORTED.name());
+        } catch (Exception e) {
+            LOGGER.error(CleanUpJob.LOG_MARKER,
+                         MessageFormat.format(Messages.ERROR_DELETING_FLOWABLE_PROCESS_WITH_ID, processInstanceId), e);
+        }
+    }
+
+}

--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/jobs/FlowableDataCleanerTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/jobs/FlowableDataCleanerTest.java
@@ -1,0 +1,78 @@
+package com.sap.cloud.lm.sl.cf.process.jobs;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.flowable.engine.impl.persistence.entity.ExecutionEntityImpl;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sap.cloud.lm.sl.cf.process.flowable.FlowableFacade;
+import com.sap.cloud.lm.sl.cf.web.api.model.Operation;
+
+public class FlowableDataCleanerTest {
+
+    @Mock
+    private FlowableFacade flowableFacade;
+    @InjectMocks
+    private FlowableDataCleaner flowableDataCleaner;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    static Stream<Arguments> testDeleteInvocation() {
+        // @formatter:off
+             return Stream.of(
+                              Arguments.of(Arrays.asList("process-id-1")),
+                              Arguments.of(Arrays.asList("process-id-1", "process-id-2")),
+                              Arguments.of(Collections.emptyList())
+             );
+        // @formatter:on
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testDeleteInvocation(List<String> processIds) {
+        Date date = new Date();
+        prepareFlowableFacade(processIds, date);
+
+        flowableDataCleaner.execute(date);
+
+        verifyDeletionOfProcessIds(processIds);
+        verify(flowableFacade).findAllRunningProcessInstanceStartedBefore(date);
+    }
+
+    private void prepareFlowableFacade(List<String> processIds, Date date) {
+        List<ProcessInstance> processInstances = processIds.stream()
+                                                           .map(this::buildProcessInstance)
+                                                           .collect(Collectors.toList());
+        when(flowableFacade.findAllRunningProcessInstanceStartedBefore(date)).thenReturn(processInstances);
+    }
+
+    private ProcessInstance buildProcessInstance(String processId) {
+        ExecutionEntityImpl executionEntity = new ExecutionEntityImpl();
+        executionEntity.setProcessInstanceId(processId);
+        return executionEntity;
+    }
+
+    private void verifyDeletionOfProcessIds(List<String> processIds) {
+        for (String processId : processIds) {
+            verify(flowableFacade).deleteProcessInstance(processId, Operation.State.ABORTED.name());
+        }
+    }
+}


### PR DESCRIPTION
Change logic for searching active operations in AbortProcessListener and
add new cleaner which will delete all left processes in act_ru_execution
table by TTL

JIRA:LMCROSSITXSADEPLOY-2120

