### PR TITLE
Set csrf headers on the return of the filter chain

### DIFF
--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/CsrfHeadersFilter.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/security/CsrfHeadersFilter.java
@@ -27,13 +27,16 @@ public class CsrfHeadersFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
         throws ServletException, IOException {
+        filterChain.doFilter(request, response);
+        // Do not move filterChain.doFilter after the header copy!
+        // The order is deliberately set to copy the csrf token on the way back, after the whole filter chain has passed.
+        // This is because user authentication may force session & token recreation after this filter.
         CsrfToken token = (CsrfToken) request.getAttribute(SPRING_SECURITY_CSRF_SESSION_ATTRIBUTE);
         if (token != null) {
             response.setHeader(Constants.CSRF_HEADER_NAME, token.getHeaderName());
             response.setHeader(Constants.CSRF_PARAM_NAME, token.getParameterName());
             response.setHeader(Constants.CSRF_TOKEN, token.getToken());
         }
-        filterChain.doFilter(request, response);
     }
 
 }


### PR DESCRIPTION
According to this github issue*, the spring security library creates a
new csrf token after user authentication. Moving the copy of that token
value to the response headers to the returning part of the request
filter chain, ensures that it will be the correct one.

LMCROSSITXSADEPLOY-1920 CSRF token not properly returned when a session is established

*https://github.com/aditzel/spring-security-csrf-token-interceptor/issues/1#issuecomment-45350315



