### PR TITLE
Fix status code Bad Gateway instead of Not Found for requests to non-…

### DIFF
--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/resources/CFExceptionMapper.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/resources/CFExceptionMapper.java
@@ -28,7 +28,7 @@ public class CFExceptionMapper {
         String message = e.getMessage();
 
         if (e instanceof CloudOperationException) {
-            status = HttpStatus.BAD_GATEWAY;
+            status = ((CloudOperationException) e).getStatusCode();
         }
         if (e instanceof ContentException || e instanceof IllegalArgumentException) {
             status = HttpStatus.BAD_REQUEST;

--- a/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/resources/CFExceptionMapperTest.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/test/java/com/sap/cloud/lm/sl/cf/web/resources/CFExceptionMapperTest.java
@@ -44,11 +44,30 @@ public class CFExceptionMapperTest {
             Arguments.of(new ResponseStatusException(HttpStatus.NOT_FOUND, "Not found"), new RestResponse(404, "Not found")),
             Arguments.of(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Bad request"), new RestResponse(400, "Bad request")),
             Arguments.of(new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Something went wrong"), new RestResponse(500, "Something went wrong")),
-            Arguments.of(new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS, HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(), "Rate limit exceeded"), new RestResponse(502, "429 Too Many Requests: Rate limit exceeded")),
+            Arguments.of(new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS, HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(), "Rate limit exceeded"), new RestResponse(429, "429 Too Many Requests: Rate limit exceeded")),
             Arguments.of(new SQLException(), new RestResponse(500, Messages.TEMPORARY_PROBLEM_WITH_PERSISTENCE_LAYER)),
             Arguments.of(new PersistenceException(), new RestResponse(500, Messages.TEMPORARY_PROBLEM_WITH_PERSISTENCE_LAYER))
         // @formatter:on
         );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void testHandleExceptionForCloudOperationExceptionWithAllHttpStatuses(HttpStatus httpStatus) {
+        ResponseEntity<String> response = exceptionMapper.handleException(new CloudOperationException(httpStatus,
+                                                                                                      httpStatus.getReasonPhrase()));
+        StringBuilder expectedMessage = new StringBuilder();
+        expectedMessage.append(httpStatus.value());
+        expectedMessage.append(" ");
+        expectedMessage.append(httpStatus.getReasonPhrase());
+        RestResponse expectedResponse = new RestResponse(httpStatus.value(), expectedMessage.toString());
+
+        assertEquals(expectedResponse.getStatus(), response.getStatusCodeValue());
+        assertEquals(expectedResponse.getEntity(), response.getBody());
+    }
+
+    public static Stream<HttpStatus> testHandleExceptionForCloudOperationExceptionWithAllHttpStatuses() {
+        return Stream.of(HttpStatus.values());
     }
 
 }


### PR DESCRIPTION
…existent spaces

-- CFExceptionMapper now returns the true status code of CloudOperationException instead of always Bad Gateway
-- Adds tests for the changes

Issue: LMCROSSITXSADEPLOY-2114
