### PR TITLE
Adds null check to prevent a potential crash

### DIFF
--- a/multiapps-controller-database-migration/src/main/java/org/cloudfoundry/multiapps/controller/database/migration/DatabaseMigration.java
+++ b/multiapps-controller-database-migration/src/main/java/org/cloudfoundry/multiapps/controller/database/migration/DatabaseMigration.java
@@ -47,14 +47,16 @@ public class DatabaseMigration {
     }
 
     private static void configureLogger() {
-        try (InputStream inputStream = DatabaseMigration.class.getClassLoader()
-                                                              .getResourceAsStream("console-logger.properties")) {
-            if (inputStream != null) {
-                PropertyConfigurator.configure(inputStream);
+        ClassLoader classLoader = DatabaseMigration.class.getClassLoader();
+        if (classLoader != null) {
+            try (InputStream inputStream = classLoader.getResourceAsStream("console-logger.properties")) {
+                if (inputStream != null) {
+                    PropertyConfigurator.configure(inputStream);
+                }
+            } catch (IOException e) {
+                LOGGER.warn("There was an error trying to configure the logger.", e);
+                LOGGER.info("Proceeding with default logger configuration.");
             }
-        } catch (IOException e) {
-            LOGGER.warn("There was an error trying to configure the logger.", e);
-            LOGGER.info("Proceeding with default logger configuration.");
         }
     }
 


### PR DESCRIPTION
In some cases `.getClassLoader()` can return a null value. Even though returning null is very unlikely in this scenario, a null check will ensure stability.
