### PR TITLE
Improve cloud controller clients cache

### DIFF
--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/CloudControllerClientProvider.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/CloudControllerClientProvider.java
@@ -1,19 +1,17 @@
 package org.cloudfoundry.multiapps.controller.core.cf;
 
-import java.util.Collections;
 import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength;
-import org.apache.commons.collections4.map.ReferenceMap;
 import org.cloudfoundry.client.lib.CloudControllerClient;
 import org.cloudfoundry.client.lib.CloudOperationException;
 import org.cloudfoundry.multiapps.common.SLException;
 import org.cloudfoundry.multiapps.controller.core.Messages;
 import org.cloudfoundry.multiapps.controller.core.security.token.TokenService;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.util.ConcurrentReferenceHashMap;
 
 @Named
 public class CloudControllerClientProvider {
@@ -26,8 +24,7 @@ public class CloudControllerClientProvider {
 
     // Cached clients. These are stored in memory-sensitive cache, i.e. no OutOfMemory error would
     // occur before GC tries to release the not-used clients.
-    private final Map<String, CloudControllerClient> clients = Collections.synchronizedMap(new ReferenceMap<>(ReferenceStrength.HARD,
-                                                                                                              ReferenceStrength.SOFT));
+    private final Map<String, CloudControllerClient> clients = new ConcurrentReferenceHashMap<>();
 
     /**
      * Returns a client for the specified user name, organization, space and process id by either getting it from the clients cache or

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/CachedMap.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/CachedMap.java
@@ -1,20 +1,17 @@
 package org.cloudfoundry.multiapps.controller.core.model;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
-import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength;
-import org.apache.commons.collections4.map.ReferenceMap;
+import org.springframework.util.ConcurrentReferenceHashMap;
 
 public class CachedMap<K, V> {
 
     private final long expirationTimeInSeconds;
     private final LongSupplier currentTimeSupplier = System::currentTimeMillis;
 
-    private final Map<K, CachedObject<V>> referenceMap = new ConcurrentHashMap<>(new ReferenceMap<>(ReferenceStrength.HARD,
-                                                                                                    ReferenceStrength.SOFT));
+    private final Map<K, CachedObject<V>> referenceMap = new ConcurrentReferenceHashMap<>();
 
     public CachedMap(long expirationTimeInSeconds) {
         this.expirationTimeInSeconds = expirationTimeInSeconds;


### PR DESCRIPTION
Improve CloudControllerClient cache performance using synchronization
over put method only.
Fix memory leak of SpaceDevelopers guids cache by using Concurrent Soft
reference map.

