### PR TITLE
Add ConfigurationSubscriptionCleaner

### DIFF
--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/persistence/query/impl/ConfigurationSubscriptionQueryImpl.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/persistence/query/impl/ConfigurationSubscriptionQueryImpl.java
@@ -126,7 +126,8 @@ public class ConfigurationSubscriptionQueryImpl extends AbstractQueryImpl<Config
                                                                        .condition(getCriteriaBuilder()::equal)
                                                                        .value(spaceId)
                                                                        .build());
-        return executeInTransaction(manager -> createDeleteQuery(manager, queryCriteria, ConfigurationEntryDto.class).executeUpdate());
+        return executeInTransaction(manager -> createDeleteQuery(manager, queryCriteria,
+                                                                 ConfigurationSubscriptionDto.class).executeUpdate());
     }
 
 }

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/ConfigurationSubscriptionCleaner.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/ConfigurationSubscriptionCleaner.java
@@ -1,0 +1,107 @@
+package org.cloudfoundry.multiapps.controller.process.jobs;
+
+import org.cloudfoundry.client.lib.CloudControllerClient;
+import org.cloudfoundry.client.lib.CloudControllerClientImpl;
+import org.cloudfoundry.client.lib.CloudCredentials;
+import org.cloudfoundry.client.lib.CloudOperationException;
+import org.cloudfoundry.multiapps.controller.core.auditlogging.AuditLoggingProvider;
+import org.cloudfoundry.multiapps.controller.core.model.ConfigurationSubscription;
+import org.cloudfoundry.multiapps.controller.core.persistence.service.ConfigurationSubscriptionService;
+import org.cloudfoundry.multiapps.controller.core.util.ApplicationConfiguration;
+import org.cloudfoundry.multiapps.controller.core.util.SecurityUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+@Named
+@Order(40)
+public class ConfigurationSubscriptionCleaner implements Cleaner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationSubscriptionCleaner.class);
+    private static final String AUTH_ORIGIN = "uaa";
+
+    protected ApplicationConfiguration configuration;
+    protected ConfigurationSubscriptionService configurationSubscriptionService;
+    protected CloudControllerClient cfClient;
+    private boolean executed;
+
+    @Inject
+    public ConfigurationSubscriptionCleaner(ApplicationConfiguration applicationConfiguration, ConfigurationSubscriptionService configurationSubscriptionService) {
+        this.configuration = applicationConfiguration;
+        this.configurationSubscriptionService = configurationSubscriptionService;
+        this.executed = false;
+    }
+
+    @Override
+    public void execute(Date expirationTime) {
+        if (!executed) {
+            LOGGER.debug(CleanUpJob.LOG_MARKER, "Deleting orphaned configuration subscriptions...");
+            deleteOrphanedConfigurationSubscriptions();
+            LOGGER.debug(CleanUpJob.LOG_MARKER, "Orphaned configuration subscriptions deleted");
+            executed = true;
+        }
+    }
+
+    private void deleteOrphanedConfigurationSubscriptions() {
+        List<ConfigurationSubscription> configurationSubscriptions = configurationSubscriptionService.createQuery()
+                                                                                                     .list();
+        configurationSubscriptions.stream()
+                                  .filter(this::hasNoAssociatedSpace)
+                                  .peek(this::auditLogDeletion)
+                                  .map(ConfigurationSubscription::getSpaceId)
+                                  .distinct()
+                                  .forEach(this::deleteConfigurationSubscriptionsBySpaceId);
+    }
+
+    private boolean hasNoAssociatedSpace(ConfigurationSubscription configurationSubscription) {
+        String spaceId = configurationSubscription.getSpaceId();
+        return !spaceExists(spaceId);
+    }
+
+    private boolean spaceExists(String spaceId) {
+        if (cfClient == null) {
+            initCloudControllerClient();
+        }
+        try {
+            cfClient.getSpace(UUID.fromString(spaceId));
+            return true;
+        } catch (CloudOperationException e) {
+            if (e.getStatusCode()
+                 .equals(HttpStatus.NOT_FOUND)) {
+                return false;
+            }
+            LOGGER.error(CleanUpJob.LOG_MARKER, "Could not get space by uuid", e);
+            // will skip deletion of data
+            return true;
+        }
+    }
+
+    private void deleteConfigurationSubscriptionsBySpaceId(String spaceId) {
+        configurationSubscriptionService.createQuery()
+                                        .deleteAll(spaceId);
+    }
+
+    private void initCloudControllerClient() {
+        CloudCredentials cloudCredentials = new CloudCredentials(configuration.getGlobalAuditorUser(),
+                                                                 configuration.getGlobalAuditorPassword(),
+                                                                 SecurityUtil.CLIENT_ID,
+                                                                 SecurityUtil.CLIENT_SECRET,
+                                                                 AUTH_ORIGIN);
+
+        cfClient = new CloudControllerClientImpl(configuration.getControllerUrl(), cloudCredentials,
+                                                 configuration.shouldSkipSslValidation());
+        cfClient.login();
+    }
+
+    private void auditLogDeletion(ConfigurationSubscription configurationSubscription) {
+        AuditLoggingProvider.getFacade()
+                            .logConfigDelete(configurationSubscription);
+    }
+}

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/jobs/ConfigurationSubscriptionCleanerTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/jobs/ConfigurationSubscriptionCleanerTest.java
@@ -1,0 +1,77 @@
+package org.cloudfoundry.multiapps.controller.process.jobs;
+
+import org.cloudfoundry.client.lib.CloudControllerClient;
+import org.cloudfoundry.client.lib.CloudOperationException;
+import org.cloudfoundry.multiapps.controller.core.auditlogging.AuditLoggingFacade;
+import org.cloudfoundry.multiapps.controller.core.auditlogging.AuditLoggingProvider;
+import org.cloudfoundry.multiapps.controller.core.model.ConfigurationSubscription;
+import org.cloudfoundry.multiapps.controller.core.persistence.query.ConfigurationSubscriptionQuery;
+import org.cloudfoundry.multiapps.controller.core.persistence.service.ConfigurationSubscriptionService;
+import org.cloudfoundry.multiapps.controller.core.util.ApplicationConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class ConfigurationSubscriptionCleanerTest {
+
+    private ConfigurationSubscriptionCleaner cleaner;
+    private ApplicationConfiguration applicationConfiguration;
+    private CloudControllerClient cfClient;
+    private ConfigurationSubscriptionService configurationSubscriptionService;
+
+    private static final UUID FIRST_EXISTING_SPACE_ID = UUID.randomUUID();
+    private static final UUID SECOND_EXISTING_SPACE_ID = UUID.randomUUID();
+    private static final UUID FIRST_NON_EXISTING_SPACE_ID = UUID.randomUUID();
+    private static final UUID SECOND_NON_EXISTING_SPACE_ID = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        applicationConfiguration = Mockito.mock(ApplicationConfiguration.class);
+        configurationSubscriptionService = Mockito.mock(ConfigurationSubscriptionService.class);
+        cfClient = Mockito.mock(CloudControllerClient.class);
+        cleaner = new ConfigurationSubscriptionCleaner(applicationConfiguration, configurationSubscriptionService);
+        cleaner.cfClient = cfClient;
+        AuditLoggingProvider.setFacade(Mockito.mock(AuditLoggingFacade.class));
+    }
+
+    @Test
+    void testExecute() {
+        ConfigurationSubscriptionQuery fakeQuery = Mockito.mock(ConfigurationSubscriptionQuery.class);
+        Mockito.when(configurationSubscriptionService.createQuery())
+               .thenReturn(fakeQuery);
+        Mockito.when(fakeQuery.list())
+               .thenReturn(getMockedConfigurationSubscriptions());
+        Mockito.when(cfClient.getSpace(FIRST_NON_EXISTING_SPACE_ID))
+               .thenThrow(new CloudOperationException(HttpStatus.NOT_FOUND));
+        Mockito.when(cfClient.getSpace(SECOND_NON_EXISTING_SPACE_ID))
+               .thenThrow(new CloudOperationException(HttpStatus.NOT_FOUND));
+
+        cleaner.execute(null);
+        Mockito.verify(fakeQuery, Mockito.times(1)).deleteAll(FIRST_NON_EXISTING_SPACE_ID.toString());
+        Mockito.verify(fakeQuery, Mockito.times(1)).deleteAll(SECOND_NON_EXISTING_SPACE_ID.toString());
+        Mockito.verify(fakeQuery, Mockito.never()).deleteAll(FIRST_EXISTING_SPACE_ID.toString());
+        Mockito.verify(fakeQuery, Mockito.never()).deleteAll(SECOND_EXISTING_SPACE_ID.toString());
+    }
+
+    private List<ConfigurationSubscription> getMockedConfigurationSubscriptions() {
+        List<ConfigurationSubscription> configurationSubscriptions = new ArrayList<>(20);
+        for (int i = 0; i < 5; i++) {
+            configurationSubscriptions.add(new ConfigurationSubscription(i, "mtaId" + i, FIRST_NON_EXISTING_SPACE_ID.toString(), "app" + i, null, null, null, null, null));
+        }
+        for (int i = 5; i < 10; i++) {
+            configurationSubscriptions.add(new ConfigurationSubscription(i, "mtaId" + i, SECOND_NON_EXISTING_SPACE_ID.toString(), "app" + i, null, null, null, null, null));
+        }
+        for (int i = 10; i < 15; i++) {
+            configurationSubscriptions.add(new ConfigurationSubscription(i, "mtaId" + i, FIRST_EXISTING_SPACE_ID.toString(), "app" + i, null, null, null, null, null));
+        }
+        for (int i = 15; i < 20; i++) {
+            configurationSubscriptions.add(new ConfigurationSubscription(i, "mtaId" + i, SECOND_EXISTING_SPACE_ID.toString(), "app" + i, null, null, null, null, null));
+        }
+        return configurationSubscriptions;
+    }
+}


### PR DESCRIPTION
Add new clean-up job, which will delete all orphaned configuration
subscription, which were not handled by the UserDataCleaner. The cleaner
will execute once per DS application run. The cleaner queries for all
configuration subscriptions and checks each one whether its space is
existing. All configuration subscriptions with non-existence space are
deleted.
NOTE: this cleaner should be removed for the next takt.
JIRA: LMCROSSITXSADEPLOY-2130
