### PR TITLE
Add serialVersionUID in LogsOffset class

### DIFF
--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/util/LogsOffset.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/util/LogsOffset.java
@@ -6,9 +6,11 @@ import java.util.Date;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface LogsOffset extends Serializable {
+public abstract class LogsOffset implements Serializable {
 
-    Date getTimestamp();
+    private static final long serialVersionUID = 1L;
 
-    String getMessage();
+    public abstract Date getTimestamp();
+
+    public abstract String getMessage();
 }


### PR DESCRIPTION
Due to missing serialVersionUID sometimes cast to this class fails with
InvalidClassException

JIRA:LMCROSSITXSADEPLOY-2199

