### PR TITLE
Retry jobs only once

### DIFF
--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/flowable/RetryProcessAction.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/flowable/RetryProcessAction.java
@@ -33,7 +33,6 @@ public class RetryProcessAction extends ProcessAction {
     protected void executeActualProcessAction(String user, String superProcessInstanceId) {
         List<String> subProcessIds = getActiveExecutionIds(superProcessInstanceId);
         ListIterator<String> subProcessesIdsIterator = subProcessIds.listIterator(subProcessIds.size());
-
         updateUserIfNecessary(user, superProcessInstanceId);
         while (subProcessesIdsIterator.hasPrevious()) {
             String subProcessId = subProcessesIdsIterator.previous();

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/flowable/FlowableFacadeTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/flowable/FlowableFacadeTest.java
@@ -1,7 +1,25 @@
 package org.cloudfoundry.multiapps.controller.process.flowable;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.flowable.common.engine.api.FlowableObjectNotFoundException;
+import org.flowable.engine.ManagementService;
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
+import org.flowable.engine.RuntimeService;
+import org.flowable.engine.runtime.Execution;
+import org.flowable.engine.runtime.ExecutionQuery;
+import org.flowable.job.api.DeadLetterJobQuery;
+import org.flowable.job.api.Job;
 import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,14 +29,27 @@ import org.mockito.MockitoAnnotations;
 
 class FlowableFacadeTest {
 
+    private static final Supplier<String> UUID_SUPPLIER = () -> UUID.randomUUID()
+                                                                    .toString();
+    private static final String PROCESS_INSTANCE_ID = UUID_SUPPLIER.get();
+    private static final String JOB_ID = UUID_SUPPLIER.get();
+
     private FlowableFacade flowableFacade;
 
     @Mock
-    DefaultAsyncJobExecutor mockedAsyncExecutor;
+    private DefaultAsyncJobExecutor mockedAsyncExecutor;
     @Mock
-    ProcessEngine mockedProcessEngine;
+    private ProcessEngine mockedProcessEngine;
     @Mock
-    ProcessEngineConfiguration mockedProcessEngineConfiguration;
+    private ProcessEngineConfiguration mockedProcessEngineConfiguration;
+    @Mock
+    private RuntimeService mockedRuntimeService;
+    @Mock
+    private ExecutionQuery mockedExecutionQuery;
+    @Mock
+    private ManagementService mockedManagementService;
+    @Mock
+    private DeadLetterJobQuery mockedDeadLetterJobQuery;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -29,6 +60,14 @@ class FlowableFacadeTest {
                .thenReturn(mockedAsyncExecutor);
         Mockito.when(mockedProcessEngine.getProcessEngineConfiguration())
                .thenReturn(mockedProcessEngineConfiguration);
+        Mockito.when(mockedProcessEngine.getRuntimeService())
+               .thenReturn(mockedRuntimeService);
+        Mockito.when(mockedRuntimeService.createExecutionQuery())
+               .thenReturn(mockedExecutionQuery);
+        Mockito.when(mockedProcessEngine.getManagementService())
+               .thenReturn(mockedManagementService);
+        Mockito.when(mockedManagementService.createDeadLetterJobQuery())
+               .thenReturn(mockedDeadLetterJobQuery);
 
         flowableFacade = new FlowableFacade(mockedProcessEngine);
     }
@@ -38,6 +77,74 @@ class FlowableFacadeTest {
         flowableFacade.shutdownJobExecutor();
         Mockito.verify(mockedAsyncExecutor, Mockito.times(1))
                .shutdown();
+    }
+
+    @Test
+    void testExecuteJobWithDuplicatedJobIds() {
+        mockProcessExecutions(PROCESS_INSTANCE_ID, PROCESS_INSTANCE_ID);
+        mockDeadLetterJobQuery(PROCESS_INSTANCE_ID, JOB_ID);
+        flowableFacade.executeJob(UUID_SUPPLIER.get());
+        Mockito.verify(mockedManagementService)
+               .moveDeadLetterJobToExecutableJob(JOB_ID, 0);
+    }
+
+    @Test
+    void testExecuteJobWithoutDuplicatedJobIds() {
+        String firstProcessInstanceId = UUID_SUPPLIER.get();
+        String firstJobId = UUID_SUPPLIER.get();
+        String secondJobId = UUID_SUPPLIER.get();
+        mockProcessExecutions(firstProcessInstanceId);
+        mockDeadLetterJobQuery(firstProcessInstanceId, firstJobId, secondJobId);
+        flowableFacade.executeJob(UUID_SUPPLIER.get());
+        Mockito.verify(mockedManagementService)
+               .moveDeadLetterJobToExecutableJob(firstJobId, 0);
+        Mockito.verify(mockedManagementService)
+               .moveDeadLetterJobToExecutableJob(secondJobId, 0);
+    }
+
+    @Test
+    void testExecuteJobWhenFlowableObjectIsNotFound() {
+        mockProcessExecutions(PROCESS_INSTANCE_ID);
+        mockDeadLetterJobQuery(PROCESS_INSTANCE_ID, JOB_ID);
+        Mockito.when(mockedManagementService.moveDeadLetterJobToExecutableJob(anyString(), anyInt()))
+               .thenThrow(FlowableObjectNotFoundException.class);
+        assertDoesNotThrow(() -> flowableFacade.executeJob(UUID_SUPPLIER.get()));
+    }
+
+    private void mockProcessExecutions(String... processInstanceIds) {
+        Mockito.when(mockedExecutionQuery.rootProcessInstanceId(anyString()))
+               .thenReturn(mockedExecutionQuery);
+        List<Execution> mockedExecution = toList(this::createMockedExecution, processInstanceIds);
+        Mockito.when(mockedExecutionQuery.list())
+               .thenReturn(mockedExecution);
+    }
+
+    private <T> List<T> toList(Function<? super String, ? extends T> mapper, String... ids) {
+        return Arrays.stream(ids)
+                     .map(mapper)
+                     .collect(Collectors.toList());
+    }
+
+    private Execution createMockedExecution(String processInstanceId) {
+        Execution execution = Mockito.mock(Execution.class);
+        Mockito.when(execution.getProcessInstanceId())
+               .thenReturn(processInstanceId);
+        return execution;
+    }
+
+    private void mockDeadLetterJobQuery(String processInstanceId, String... jobIds) {
+        Mockito.when(mockedDeadLetterJobQuery.processInstanceId(processInstanceId))
+               .thenReturn(mockedDeadLetterJobQuery);
+        List<Job> mockedJobs = toList(this::createMockedJob, jobIds);
+        Mockito.when(mockedDeadLetterJobQuery.list())
+               .thenReturn(mockedJobs);
+    }
+
+    private Job createMockedJob(String jobId) {
+        Job job = Mockito.mock(Job.class);
+        Mockito.when(job.getId())
+               .thenReturn(jobId);
+        return job;
     }
 
 }


### PR DESCRIPTION
LMCROSSITXSADEPLOY-1824

Fixes: "There is no error message for operation with ID" and retries all dead letter jobs.