### PR TITLE
Fix NPE when deleting multiple services

### DIFF
--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Messages.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Messages.java
@@ -156,6 +156,7 @@ public final class Messages {
     public static final String MICROMETER_STEP_IN_SECONDS = "Micrometer step in seconds: {0}";
     public static final String DB_TRANSACTION_TIMEOUT = "Database transaction timeout: {0} seconds";
     public static final String SNAKEYAML_MAX_ALIASES_FOR_COLLECTIONS = "SnakeYaml max aliases for collections: {0}";
+    public static final String SERVICE_HANDLING_MAX_PARALLEL_THREADS = "Service handling max parallel threads: {0}";
 
     // Debug messages
     public static final String DEPLOYMENT_DESCRIPTOR = "Deployment descriptor: {0}";

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/util/ApplicationConfiguration.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/util/ApplicationConfiguration.java
@@ -90,6 +90,7 @@ public class ApplicationConfiguration {
     static final String CFG_MICROMETER_STEP_IN_SECONDS = "MICROMETER_STEP_IN_SECONDS";
     static final String CFG_DB_TRANSACTION_TIMEOUT_IN_SECONDS = "DB_TRANSACTION_TIMEOUT_IN_SECONDS";
     static final String CFG_SNAKEYAML_MAX_ALIASES_FOR_COLLECTIONS = "SNAKEYAML_MAX_ALIASES_FOR_COLLECTIONS";
+    static final String CFG_SERVICE_HANDLING_MAX_PARALLEL_THREADS = "SERVICE_HANDLING_MAX_PARALLEL_THREADS";
 
     private static final List<String> VCAP_APPLICATION_URIS_KEYS = Arrays.asList("full_application_uris", "application_uris", "uris");
 
@@ -133,6 +134,7 @@ public class ApplicationConfiguration {
     // Transaction timeout must be greater than Flowable process step timeout because lower value limit execution of the whole process step.
     public static final int DEFAULT_DB_TRANSACTION_TIMEOUT_IN_SECONDS = (int) TimeUnit.MINUTES.toSeconds(60);
     public static final int DEFAULT_SNAKEYAML_MAX_ALIASES_FOR_COLLECTIONS = 50;
+    public static final int DEFAULT_SERVICE_HANDLING_MAX_PARALLEL_THREADS = 20;
     protected final Environment environment;
 
     // Cached configuration settings:
@@ -181,6 +183,7 @@ public class ApplicationConfiguration {
     private Integer micrometerStepInSeconds;
     private Integer dbTransactionTimeoutInSeconds;
     private Integer snakeyamlMaxAliasesForCollections;
+    private Integer serviceHandlingMaxParallelThreads;
 
     public ApplicationConfiguration() {
         this(new Environment());
@@ -221,6 +224,7 @@ public class ApplicationConfiguration {
         getAuditLogClientKeepAlive();
         getFssCacheUpdateTimeoutMinutes();
         getSnakeyamlMaxAliasesForCollections();
+        getServiceHandlingMaxParallelThreads();
     }
 
     protected AuditLoggingFacade getAuditLoggingFacade() {
@@ -247,7 +251,7 @@ public class ApplicationConfiguration {
                                            CFG_FLOWABLE_JOB_EXECUTOR_MAX_THREADS, CFG_FLOWABLE_JOB_EXECUTOR_QUEUE_CAPACITY,
                                            CFG_AUDIT_LOG_CLIENT_KEEP_ALIVE, CFG_CONTROLLER_CLIENT_CONNECTION_POOL_SIZE,
                                            CFG_CONTROLLER_CLIENT_THREAD_POOL_SIZE, CFG_DB_TRANSACTION_TIMEOUT_IN_SECONDS,
-                                           CFG_SNAKEYAML_MAX_ALIASES_FOR_COLLECTIONS));
+                                           CFG_SNAKEYAML_MAX_ALIASES_FOR_COLLECTIONS, CFG_SERVICE_HANDLING_MAX_PARALLEL_THREADS));
     }
 
     public Configuration getFileConfiguration() {
@@ -560,6 +564,13 @@ public class ApplicationConfiguration {
             snakeyamlMaxAliasesForCollections = getSnakeyamlMaxAliasesForCollectionsFromEnvironment();
         }
         return snakeyamlMaxAliasesForCollections;
+    }
+
+    public Integer getServiceHandlingMaxParallelThreads() {
+        if (serviceHandlingMaxParallelThreads == null) {
+            serviceHandlingMaxParallelThreads = getServiceHandlingMaxParallelThreadsFromEnvironment();
+        }
+        return serviceHandlingMaxParallelThreads;
     }
 
     private URL getControllerUrlFromEnvironment() {
@@ -917,6 +928,13 @@ public class ApplicationConfiguration {
                                                                                    DEFAULT_SNAKEYAML_MAX_ALIASES_FOR_COLLECTIONS);
         LOGGER.info(format(Messages.SNAKEYAML_MAX_ALIASES_FOR_COLLECTIONS, snakeyamlMaxAliasesForCollections));
         return snakeyamlMaxAliasesForCollections;
+    }
+
+    private Integer getServiceHandlingMaxParallelThreadsFromEnvironment() {
+        Integer serviceHandlingMaxParallelThreads = environment.getPositiveInteger(CFG_SERVICE_HANDLING_MAX_PARALLEL_THREADS,
+                                                                                   DEFAULT_SERVICE_HANDLING_MAX_PARALLEL_THREADS);
+        LOGGER.info(format(Messages.SERVICE_HANDLING_MAX_PARALLEL_THREADS, serviceHandlingMaxParallelThreads));
+        return serviceHandlingMaxParallelThreads;
     }
 
     public Boolean isInternalEnvironment() {

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CheckServiceOperationStateStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CheckServiceOperationStateStep.java
@@ -1,0 +1,37 @@
+package org.cloudfoundry.multiapps.controller.process.steps;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudServiceInstanceExtended;
+import org.cloudfoundry.multiapps.controller.process.util.ServiceOperationGetter;
+import org.cloudfoundry.multiapps.controller.process.util.ServiceProgressReporter;
+import org.cloudfoundry.multiapps.controller.process.variables.Variables;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Scope;
+
+import com.sap.cloudfoundry.client.facade.CloudControllerClient;
+
+@Named("checkServiceOperationStateStep")
+@Scope(BeanDefinition.SCOPE_PROTOTYPE)
+public class CheckServiceOperationStateStep extends CollectServicesInProgressStateStep {
+
+    @Inject
+    CheckServiceOperationStateStep(ServiceOperationGetter serviceOperationGetter, ServiceProgressReporter serviceProgressReporter) {
+        super(serviceOperationGetter, serviceProgressReporter);
+    }
+
+    @Override
+    protected List<CloudServiceInstanceExtended> getExistingServicesInProgress(ProcessContext context) {
+        CloudControllerClient client = context.getControllerClient();
+        CloudServiceInstanceExtended serviceToProcess = context.getVariable(Variables.SERVICE_TO_PROCESS);
+        CloudServiceInstanceExtended existingServiceInstance = getExistingService(client, serviceToProcess);
+        if (existingServiceInstance == null || !isServiceOperationInProgress(existingServiceInstance)) {
+            return Collections.emptyList();
+        }
+        return List.of(existingServiceInstance);
+    }
+}

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CheckServicesToDeleteStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CheckServicesToDeleteStep.java
@@ -1,12 +1,23 @@
 package org.cloudfoundry.multiapps.controller.process.steps;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.sap.cloudfoundry.client.facade.CloudControllerClient;
+import com.sap.cloudfoundry.client.facade.domain.ServiceOperation;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudServiceInstanceExtended;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.ImmutableCloudServiceInstanceExtended;
+import org.cloudfoundry.multiapps.controller.core.util.ApplicationConfiguration;
+import org.cloudfoundry.multiapps.controller.core.util.ForkJoinPoolUtil;
 import org.cloudfoundry.multiapps.controller.process.variables.Variables;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
@@ -15,12 +26,43 @@ import org.springframework.context.annotation.Scope;
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
 public class CheckServicesToDeleteStep extends CheckForOperationsInProgressStep {
 
+    @Inject
+    private ApplicationConfiguration applicationConfiguration;
+
     @Override
-    protected List<CloudServiceInstanceExtended> getServicesToProcess(ProcessContext context) {
+    protected Set<CloudServiceInstanceExtended> getExistingServicesToProcess(ProcessContext context) {
         List<String> servicesToDelete = context.getVariable(Variables.SERVICES_TO_DELETE);
-        return servicesToDelete.stream()
-                               .map(this::buildCloudServiceExtended)
-                               .collect(Collectors.toList());
+        CloudControllerClient client = context.getControllerClient();
+        int maxParallelThreads = getMaxParallelThreads(servicesToDelete);
+        return ForkJoinPoolUtil.execute(maxParallelThreads, () ->  getExistingServices(client, servicesToDelete));
+    }
+
+    private Set<CloudServiceInstanceExtended> getExistingServices(CloudControllerClient client, List<String> servicesToDelete) {
+        return servicesToDelete.parallelStream()
+                               .map(service -> getExistingService(client, buildCloudServiceExtended(service)))
+                               .filter(Objects::nonNull)
+                               .collect(Collectors.toSet());
+    }
+
+    @Override
+    protected Map<CloudServiceInstanceExtended, ServiceOperation>
+            getServicesInProgressState(ProcessContext context, Set<CloudServiceInstanceExtended> existingServices) {
+        CloudControllerClient client = context.getControllerClient();
+        int maxParallelThreads = getMaxParallelThreads(existingServices);
+        return ForkJoinPoolUtil.execute(maxParallelThreads, () -> getServicesInProgressStateInternal(client, existingServices));
+    }
+
+    private Map<CloudServiceInstanceExtended, ServiceOperation>
+            getServicesInProgressStateInternal(CloudControllerClient client, Set<CloudServiceInstanceExtended> existingServices) {
+        return existingServices.parallelStream()
+                               .map(existingService -> Pair.of(existingService,
+                                                               serviceOperationGetter.getLastServiceOperation(client, existingService)))
+                               .filter(pair -> isServiceOperationInProgress(pair.getRight()))
+                               .collect(Collectors.toConcurrentMap(Pair::getLeft, Pair::getRight));
+    }
+
+    private <E> int getMaxParallelThreads(Collection<E> collectionToProcess) {
+        return Math.min(collectionToProcess.size(), applicationConfiguration.getServiceHandlingMaxParallelThreads());
     }
 
     private CloudServiceInstanceExtended buildCloudServiceExtended(String serviceName) {

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
@@ -48,8 +48,7 @@ public class DetermineServiceCreateUpdateServiceActionsStep extends SyncFlowable
         CloudControllerClient client = context.getControllerClient();
         CloudServiceInstanceExtended serviceToProcess = context.getVariable(Variables.SERVICE_TO_PROCESS);
 
-        context.getStepLogger()
-               .info(Messages.PROCESSING_SERVICE, serviceToProcess.getName());
+        getStepLogger().info(Messages.PROCESSING_SERVICE, serviceToProcess.getName());
         CloudServiceInstance existingService = client.getServiceInstance(serviceToProcess.getName(), false);
 
         setServiceParameters(context, serviceToProcess);

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/PollServiceOperationsExecution.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/PollServiceOperationsExecution.java
@@ -105,7 +105,7 @@ public abstract class PollServiceOperationsExecution implements AsyncExecution {
     }
 
     private ServiceOperation getLastServiceOperation(ProcessContext context, CloudServiceInstanceExtended service) {
-        return serviceOperationGetter.getLastServiceOperation(context, service);
+        return serviceOperationGetter.getLastServiceOperation(context.getControllerClient(), service);
     }
 
     protected ServiceOperation mapOperationState(StepLogger stepLogger, ServiceOperation lastServiceOperation,

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/ServiceOperationGetter.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/ServiceOperationGetter.java
@@ -19,8 +19,7 @@ public class ServiceOperationGetter {
     private static final String USER_PROVIDED_SERVICE_EVENT_TYPE_DELETE = "audit.user_provided_service_instance.delete";
     private static final String SERVICE_EVENT_TYPE_DELETE = "audit.service_instance.delete";
 
-    public ServiceOperation getLastServiceOperation(ProcessContext context, CloudServiceInstanceExtended service) {
-        CloudControllerClient client = context.getControllerClient();
+    public ServiceOperation getLastServiceOperation(CloudControllerClient client, CloudServiceInstanceExtended service) {
         CloudServiceInstance serviceInstance = client.getServiceInstance(service.getName(), false);
         if (serviceInstance == null) {
             return getLastDeleteServiceOperation(client, service);

--- a/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/create-or-update-services.bpmn
+++ b/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/create-or-update-services.bpmn
@@ -70,7 +70,7 @@
     <sequenceFlow id="SkipCoUFlow" name="Skip" sourceRef="exclusivegateway2" targetRef="exclusivegateway15"></sequenceFlow>
     <exclusiveGateway id="exclusivegateway14" name="Exclusive Gateway" default="flow88"></exclusiveGateway>
     <exclusiveGateway id="exclusivegateway15" name="Exclusive Gateway" default="flow84"></exclusiveGateway>
-    <serviceTask id="CheckForOperationsInProgressTask" name="Check for operations in Progress" flowable:async="true" flowable:delegateExpression="${checkForOperationsInProgressStep}"></serviceTask>
+    <serviceTask id="CheckServiceOperationStateTask" name="Check for service operations in Progress" flowable:async="true" flowable:delegateExpression="${checkServiceOperationStateStep}"></serviceTask>
     <exclusiveGateway id="exclusivegateway16" name="Exclusive Gateway" default="DetermineActionsFlow"></exclusiveGateway>
     <intermediateCatchEvent id="timerintermediatecatchevent5" name="TimerCatchEvent">
       <timerEventDefinition>
@@ -78,13 +78,13 @@
       </timerEventDefinition>
     </intermediateCatchEvent>
     <sequenceFlow id="flow20" sourceRef="DetermineServiceCreateUpdateActionsTask" targetRef="exclusivegateway2"></sequenceFlow>
-    <sequenceFlow id="flow19" sourceRef="startevent3" targetRef="CheckForOperationsInProgressTask"></sequenceFlow>
+    <sequenceFlow id="flow19" sourceRef="startevent3" targetRef="CheckServiceOperationStateTask"></sequenceFlow>
     <sequenceFlow id="DetermineActionsFlow" sourceRef="exclusivegateway16" targetRef="DetermineServiceCreateUpdateActionsTask"></sequenceFlow>
     <sequenceFlow id="waitToFinish" name="Wait To Finish" sourceRef="exclusivegateway16" targetRef="timerintermediatecatchevent5">
       <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(StepExecution == "POLL")}]]></conditionExpression>
     </sequenceFlow>
-    <sequenceFlow id="flow85" sourceRef="CheckForOperationsInProgressTask" targetRef="exclusivegateway16"></sequenceFlow>
-    <sequenceFlow id="flow86" sourceRef="timerintermediatecatchevent5" targetRef="CheckForOperationsInProgressTask"></sequenceFlow>
+    <sequenceFlow id="flow85" sourceRef="CheckServiceOperationStateTask" targetRef="exclusivegateway16"></sequenceFlow>
+    <sequenceFlow id="flow86" sourceRef="timerintermediatecatchevent5" targetRef="CheckServiceOperationStateTask"></sequenceFlow>
     <sequenceFlow id="RecreateFlow" name="Recreate" sourceRef="exclusivegateway2" targetRef="DeleteServiceCallActivity">
       <conditionExpression xsi:type="tFormalExpression"><![CDATA[${serviceActionsToExecute.contains("RECREATE")}]]></conditionExpression>
     </sequenceFlow>
@@ -205,7 +205,7 @@
       <bpmndi:BPMNShape bpmnElement="exclusivegateway15" id="BPMNShape_exclusivegateway15">
         <omgdc:Bounds height="40.0" width="40.0" x="755.0" y="316.25"></omgdc:Bounds>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="CheckForOperationsInProgressTask" id="BPMNShape_CheckForOperationsInProgressTask">
+      <bpmndi:BPMNShape bpmnElement="CheckServiceOperationStateTask" id="BPMNShape_CheckServiceOperationStateTask">
         <omgdc:Bounds height="80.0" width="100.0" x="90.0" y="95.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="exclusivegateway16" id="BPMNShape_exclusivegateway16">

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CheckServiceOperationStateStepTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CheckServiceOperationStateStepTest.java
@@ -12,18 +12,15 @@ import java.util.stream.Stream;
 import org.apache.commons.collections4.MapUtils;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudServiceInstanceExtended;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.ImmutableCloudServiceInstanceExtended;
-import org.cloudfoundry.multiapps.controller.process.util.ServiceOperationGetter;
-import org.cloudfoundry.multiapps.controller.process.util.ServiceProgressReporter;
 import org.cloudfoundry.multiapps.controller.process.variables.Variables;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 
 import com.sap.cloudfoundry.client.facade.domain.ImmutableCloudMetadata;
 import com.sap.cloudfoundry.client.facade.domain.ServiceOperation;
 
-class CheckForOperationsInProgressStepTest extends SyncFlowableStepTest<CheckForOperationsInProgressStep> {
+class CheckServiceOperationStateStepTest extends SyncFlowableStepTest<CheckServiceOperationStateStep> {
 
     private static final String TEST_SPACE_ID = "test";
 
@@ -85,8 +82,8 @@ class CheckForOperationsInProgressStepTest extends SyncFlowableStepTest<CheckFor
     }
 
     @Override
-    protected CheckForOperationsInProgressStep createStep() {
-        return new CheckForOperationsInProgressStep();
+    protected CheckServiceOperationStateStep createStep() {
+        return new CheckServiceOperationStateStep(null, null);
     }
 
 }

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CheckServicesToDeleteStepTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CheckServicesToDeleteStepTest.java
@@ -118,6 +118,6 @@ class CheckServicesToDeleteStepTest extends SyncFlowableStepTest<CheckServicesTo
 
     @Override
     protected CheckServicesToDeleteStep createStep() {
-        return new CheckServicesToDeleteStep();
+        return new CheckServicesToDeleteStep(null, null, applicationConfiguration);
     }
 }

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CheckServicesToDeleteStepTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CheckServicesToDeleteStepTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudServiceInstanceExtended;
+import org.cloudfoundry.multiapps.controller.core.util.ApplicationConfiguration;
 import org.cloudfoundry.multiapps.controller.process.util.ServiceOperationGetter;
 import org.cloudfoundry.multiapps.controller.process.variables.Variables;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,6 +36,9 @@ class CheckServicesToDeleteStepTest extends SyncFlowableStepTest<CheckServicesTo
 
     @Mock
     private ServiceOperationGetter serviceOperationGetter;
+
+    @Mock
+    private ApplicationConfiguration applicationConfiguration;
 
     static Stream<Arguments> testExecute() {
         return Stream.of(
@@ -65,6 +69,7 @@ class CheckServicesToDeleteStepTest extends SyncFlowableStepTest<CheckServicesTo
         List<CloudServiceInstance> services = getServices(existingServiceNames);
         prepareClient(services);
         prepareServiceOperationGetter(servicesOperationState);
+        prepareApplicationConfiguration();
 
         step.execute(execution);
 
@@ -102,6 +107,10 @@ class CheckServicesToDeleteStepTest extends SyncFlowableStepTest<CheckServicesTo
             when(serviceOperationGetter.getLastServiceOperation(any(),
                                                                 argThat(new CloudServiceExtendedMatcher(serviceName)))).thenReturn(serviceOperation);
         }
+    }
+
+    private void prepareApplicationConfiguration() {
+        when(applicationConfiguration.getServiceHandlingMaxParallelThreads()).thenReturn(ApplicationConfiguration.DEFAULT_SERVICE_HANDLING_MAX_PARALLEL_THREADS);
     }
 
     private void validateExecution(List<String> expectedServicesOperations, String expectedStatus) {

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/PollServiceInProgressOperationsExecutionTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/PollServiceInProgressOperationsExecutionTest.java
@@ -31,7 +31,7 @@ import com.sap.cloudfoundry.client.facade.CloudControllerClient;
 import com.sap.cloudfoundry.client.facade.domain.ImmutableCloudMetadata;
 import com.sap.cloudfoundry.client.facade.domain.ServiceOperation;
 
-class PollServiceInProgressOperationsExecutionTest extends AsyncStepOperationTest<CheckForOperationsInProgressStep> {
+class PollServiceInProgressOperationsExecutionTest extends AsyncStepOperationTest<CheckServiceOperationStateStep> {
 
     private static final String TEST_SPACE_ID = "test";
     private static final String TEST_PROVIDER = "testProvider";
@@ -169,8 +169,8 @@ class PollServiceInProgressOperationsExecutionTest extends AsyncStepOperationTes
     }
 
     @Override
-    protected CheckForOperationsInProgressStep createStep() {
-        return new CheckForOperationsInProgressStep();
+    protected CheckServiceOperationStateStep createStep() {
+        return new CheckServiceOperationStateStep(serviceOperationGetter, serviceProgressReporter);
     }
 
     @Override

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/ServiceOperationGetterTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/ServiceOperationGetterTest.java
@@ -67,7 +67,7 @@ class ServiceOperationGetterTest {
         when(client.getServiceInstance(SERVICE_NAME, false)).thenReturn(service);
         when(context.getControllerClient()).thenReturn(client);
 
-        ServiceOperation serviceOperation = serviceOperationGetter.getLastServiceOperation(context, service);
+        ServiceOperation serviceOperation = serviceOperationGetter.getLastServiceOperation(context.getControllerClient(), service);
 
         assertServiceOperation(expectedServiceOperation, serviceOperation);
     }
@@ -100,7 +100,7 @@ class ServiceOperationGetterTest {
         prepareEvents(containsDeleteEvent);
         when(context.getControllerClient()).thenReturn(client);
 
-        ServiceOperation serviceOperation = serviceOperationGetter.getLastServiceOperation(context, service);
+        ServiceOperation serviceOperation = serviceOperationGetter.getLastServiceOperation(context.getControllerClient(), service);
 
         assertEquals(expectedOperation, serviceOperation);
     }


### PR DESCRIPTION
Add new app configuration for max number of threads for service
processing. Refactor CheckForOperationsInProgressStep to decouple it a
little more from CheckServicesToDeleteStep. Implement parallel calls to
CC for getting service instances as these calls might take up to 1
minute when there are a lot of services in the space. Utilize
ForkJoinPoolUtil so that thread number can be specified.
JIRA: LMCROSSITXSADEPLOY-2217