### PR TITLE
SLP accepts org/space names with slash

### DIFF
--- a/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/configuration/WebMvcConfiguration.java
+++ b/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/configuration/WebMvcConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.util.UrlPathHelper;
 
 @Configuration
 @EnableWebMvc
@@ -39,6 +40,9 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
     @Override
     public void configurePathMatch(PathMatchConfigurer configurer) {
         configurer.setUseSuffixPatternMatch(false);
+        UrlPathHelper urlPathHelper = new UrlPathHelper();
+        urlPathHelper.setUrlDecode(false);
+        configurer.setUrlPathHelper(urlPathHelper);
     }
 
     @Override


### PR DESCRIPTION
This is a regression on our side for SLP.
In the past, this scenario was working. Most probably,
the regiression comes from migration to WebMVC from Jersey

Jira: LMCROSSITXSADEPLOY-2291
