### PR TITLE
Remove dynamic operation state calculation

### DIFF
--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/model/Operation.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/model/Operation.java
@@ -97,9 +97,6 @@ public abstract class Operation implements AuditableConfiguration {
     @Nullable
     public abstract State getState();
 
-    @Nullable // TODO on next takt, this nullable must be removed + add nonnull constrain in liquibase
-    public abstract State getCachedState();
-
     @Nullable
     public abstract ErrorType getErrorType();
 
@@ -131,7 +128,6 @@ public abstract class Operation implements AuditableConfiguration {
         identifiersList.add(new ConfigurationIdentifier("mta id", getMtaId()));
         identifiersList.add(new ConfigurationIdentifier("user", getUser()));
         identifiersList.add(new ConfigurationIdentifier("state", Objects.toString(getState())));
-        identifiersList.add(new ConfigurationIdentifier("cached state", Objects.toString(getCachedState())));
         identifiersList.add(new ConfigurationIdentifier("error type", Objects.toString(getErrorType())));
         return identifiersList;
     }

--- a/multiapps-controller-api/src/main/resources/mtarest.yaml
+++ b/multiapps-controller-api/src/main/resources/mtarest.yaml
@@ -522,15 +522,6 @@ definitions:
         - "ERROR"
         - "ABORTED"
         - "ACTION_REQUIRED"
-      cachedState:
-        type: "string"
-        readOnly: true
-        enum:
-        - "RUNNING"
-        - "FINISHED"
-        - "ERROR"
-        - "ABORTED"
-        - "ACTION_REQUIRED"
       errorType:
         type: "string"
         readOnly: true

--- a/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/query/OperationQuery.java
+++ b/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/query/OperationQuery.java
@@ -23,9 +23,7 @@ public interface OperationQuery extends Query<Operation, OperationQuery> {
 
     OperationQuery acquiredLock(Boolean acquiredLock);
 
-    OperationQuery state(Operation.State finalState);
-
-    OperationQuery cachedState(Operation.State cachedState);
+    OperationQuery state(Operation.State state);
 
     OperationQuery startedBefore(Date startedBefore);
 

--- a/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/query/impl/OperationQueryImpl.java
+++ b/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/query/impl/OperationQueryImpl.java
@@ -98,21 +98,11 @@ public class OperationQueryImpl extends AbstractQueryImpl<Operation, OperationQu
     }
 
     @Override
-    public OperationQuery state(Operation.State finalState) {
-        queryCriteria.addRestriction(ImmutableQueryAttributeRestriction.builder()
-                                                                       .attribute(AttributeNames.FINAL_STATE)
-                                                                       .condition(getCriteriaBuilder()::equal)
-                                                                       .value(finalState)
-                                                                       .build());
-        return this;
-    }
-
-    @Override
-    public OperationQuery cachedState(Operation.State currentState) {
+    public OperationQuery state(Operation.State state) {
         queryCriteria.addRestriction(ImmutableQueryAttributeRestriction.builder()
                                                                        .attribute(AttributeNames.CURRENT_STATE)
                                                                        .condition(getCriteriaBuilder()::equal)
-                                                                       .value(currentState)
+                                                                       .value(state)
                                                                        .build());
         return this;
     }
@@ -139,28 +129,18 @@ public class OperationQueryImpl extends AbstractQueryImpl<Operation, OperationQu
 
     @Override
     public OperationQuery inNonFinalState() {
-        queryCriteria.addRestriction(ImmutableQueryAttributeRestriction.builder()
-                                                                       .attribute(AttributeNames.FINAL_STATE)
-                                                                       .condition(getCriteriaBuilder()::equal)
-                                                                       .value(null)
-                                                                       .build());
-        return this;
+        return withStateAnyOf(Operation.State.getNonFinalStates());
     }
 
     @Override
     public OperationQuery inFinalState() {
-        queryCriteria.addRestriction(ImmutableQueryAttributeRestriction.builder()
-                                                                       .attribute(AttributeNames.FINAL_STATE)
-                                                                       .condition(getCriteriaBuilder()::notEqual)
-                                                                       .value(null)
-                                                                       .build());
-        return this;
+        return withStateAnyOf(Operation.State.getFinalStates());
     }
 
     @Override
     public OperationQuery withStateAnyOf(List<Operation.State> states) {
         queryCriteria.addRestriction(ImmutableQueryAttributeRestriction.<List<Operation.State>> builder()
-                                                                       .attribute(AttributeNames.FINAL_STATE)
+                                                                       .attribute(AttributeNames.CURRENT_STATE)
                                                                        .condition(Expression::in)
                                                                        .value(states)
                                                                        .build());

--- a/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/services/OperationService.java
+++ b/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/services/OperationService.java
@@ -64,8 +64,7 @@ public class OperationService extends PersistenceService<Operation, OperationDto
                                      .namespace(dto.getNamespace())
                                      .user(dto.getUser())
                                      .hasAcquiredLock(dto.hasAcquiredLock())
-                                     .state(toState(dto.getFinalState()))
-                                     .cachedState(toState(dto.getCurrentState()))
+                                     .state(toState(dto.getCurrentState()))
                                      .build();
         }
 
@@ -74,7 +73,7 @@ public class OperationService extends PersistenceService<Operation, OperationDto
         }
 
         private Operation.State toState(String operationState) {
-            return operationState == null ? null : Operation.State.fromValue(operationState);
+            return Operation.State.fromValue(operationState);
         }
 
         private ZonedDateTime toZonedDateTime(Date date) {
@@ -91,8 +90,7 @@ public class OperationService extends PersistenceService<Operation, OperationDto
             String mtaId = operation.getMtaId();
             String namespace = operation.getNamespace();
             String user = operation.getUser();
-            String finalState = toString(operation.getState());
-            String currentState = toString(operation.getCachedState());
+            String currentState = toString(operation.getState());
             boolean acquiredLock = operation.hasAcquiredLock();
             return OperationDto.builder()
                                .processId(processId)
@@ -104,7 +102,6 @@ public class OperationService extends PersistenceService<Operation, OperationDto
                                .namespace(namespace)
                                .user(user)
                                .acquiredLock(acquiredLock)
-                               .finalState(finalState)
                                .currentState(currentState)
                                .build();
         }

--- a/multiapps-controller-persistence/src/test/java/org/cloudfoundry/multiapps/controller/persistence/services/OperationServiceTest.java
+++ b/multiapps-controller-persistence/src/test/java/org/cloudfoundry/multiapps/controller/persistence/services/OperationServiceTest.java
@@ -26,10 +26,12 @@ class OperationServiceTest {
 
     private static final Operation OPERATION_1 = createOperation("1", ProcessType.DEPLOY, "spaceId", "mtaId", "user", false,
                                                                  ZonedDateTime.parse("2010-10-08T10:00:00.000Z[UTC]"),
-                                                                 ZonedDateTime.parse("2010-10-14T10:00:00.000Z[UTC]"));
+                                                                 ZonedDateTime.parse("2010-10-14T10:00:00.000Z[UTC]"),
+                                                                 Operation.State.RUNNING);
     private static final Operation OPERATION_2 = createOperation("2", ProcessType.UNDEPLOY, "spaceId1", "mtaId1", "user1", true,
                                                                  ZonedDateTime.parse("2010-10-10T10:00:00.000Z[UTC]"),
-                                                                 ZonedDateTime.parse("2010-10-12T10:00:00.000Z[UTC]"));
+                                                                 ZonedDateTime.parse("2010-10-12T10:00:00.000Z[UTC]"),
+                                                                 Operation.State.RUNNING);
     private final OperationService operationService = createOperationService();
 
     @AfterEach
@@ -169,7 +171,7 @@ class OperationServiceTest {
     }
 
     private static Operation createOperation(String processId, ProcessType type, String spaceId, String mtaId, String user,
-                                             boolean acquiredLock, ZonedDateTime startedAt, ZonedDateTime endedAt) {
+                                             boolean acquiredLock, ZonedDateTime startedAt, ZonedDateTime endedAt, Operation.State state) {
         return ImmutableOperation.builder()
                                  .processId(processId)
                                  .processType(type)
@@ -177,6 +179,7 @@ class OperationServiceTest {
                                  .mtaId(mtaId)
                                  .user(user)
                                  .hasAcquiredLock(acquiredLock)
+                                 .state(state)
                                  .startedAt(startedAt)
                                  .endedAt(endedAt)
                                  .build();

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/flowable/ProcessAction.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/flowable/ProcessAction.java
@@ -67,13 +67,13 @@ public abstract class ProcessAction {
         }
     }
 
-    protected void updateOperationCachedState(String processId, Operation.State newState) {
+    protected void updateOperationState(String processId, Operation.State newState) {
         Operation operation = operationService.createQuery()
                                               .processId(processId)
                                               .singleResult();
         operation = ImmutableOperation.builder()
                                       .from(operation)
-                                      .cachedState(newState)
+                                      .state(newState)
                                       .build();
         operationService.update(operation, operation);
     }

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/flowable/ResumeProcessAction.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/flowable/ResumeProcessAction.java
@@ -39,7 +39,7 @@ public class ResumeProcessAction extends ProcessAction {
         for (String processAtReceiveTask : processesAtReceiveTask) {
             triggerProcessInstance(user, processAtReceiveTask);
         }
-        updateOperationCachedState(superProcessInstanceId, Operation.State.RUNNING);
+        updateOperationState(superProcessInstanceId, Operation.State.RUNNING);
     }
 
     private void triggerProcessInstance(String user, String processId) {

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/flowable/RetryProcessAction.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/flowable/RetryProcessAction.java
@@ -40,7 +40,7 @@ public class RetryProcessAction extends ProcessAction {
             String subProcessId = subProcessesIdsIterator.previous();
             retryProcess(subProcessId);
         }
-        updateOperationCachedState(superProcessInstanceId, Operation.State.RUNNING);
+        updateOperationState(superProcessInstanceId, Operation.State.RUNNING);
         historicOperationEventService.add(ImmutableHistoricOperationEvent.of(superProcessInstanceId,
                                                                              HistoricOperationEvent.EventType.RETRIED));
     }

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/OperationsCleaner.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/OperationsCleaner.java
@@ -85,7 +85,8 @@ public class OperationsCleaner implements Cleaner {
     }
 
     private boolean inFinalState(Operation operation) {
-        return operation.getState() != null;
+        return operation.getState()
+                        .isFinal();
     }
 
     private boolean abortSafely(Operation operation) {
@@ -112,7 +113,6 @@ public class OperationsCleaner implements Cleaner {
         Operation abortedOperation = ImmutableOperation.builder()
                                                        .from(operation)
                                                        .state(Operation.State.ABORTED)
-                                                       .cachedState(Operation.State.ABORTED)
                                                        .endedAt(ZonedDateTime.now())
                                                        .hasAcquiredLock(false)
                                                        .build();

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/listeners/EnterTestingPhaseListener.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/listeners/EnterTestingPhaseListener.java
@@ -32,7 +32,7 @@ public class EnterTestingPhaseListener extends AbstractProcessExecutionListener 
                                               .singleResult();
         operation = ImmutableOperation.builder()
                                       .from(operation)
-                                      .cachedState(Operation.State.ACTION_REQUIRED)
+                                      .state(Operation.State.ACTION_REQUIRED)
                                       .build();
         operationService.update(operation, operation);
     }

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/listeners/StartProcessListener.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/listeners/StartProcessListener.java
@@ -123,7 +123,7 @@ public class StartProcessListener extends AbstractProcessExecutionListener {
                                                 .user(StepsUtil.determineCurrentUser(execution))
                                                 .hasAcquiredLock(false)
                                                 .namespace(VariableHandling.get(execution, Variables.MTA_NAMESPACE))
-                                                .cachedState(Operation.State.RUNNING)
+                                                .state(Operation.State.RUNNING)
                                                 .build();
         operationService.add(operation);
     }

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/OperationInErrorStateHandler.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/OperationInErrorStateHandler.java
@@ -153,7 +153,7 @@ public class OperationInErrorStateHandler {
                                               .singleResult();
         operation = ImmutableOperation.builder()
                                       .from(operation)
-                                      .cachedState(Operation.State.ERROR)
+                                      .state(Operation.State.ERROR)
                                       .build();
         operationService.update(operation, operation);
     }

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/OperationInFinalStateHandler.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/OperationInFinalStateHandler.java
@@ -95,7 +95,6 @@ public class OperationInFinalStateHandler {
         operation = ImmutableOperation.builder()
                                       .from(operation)
                                       .state(state)
-                                      .cachedState(state)
                                       .hasAcquiredLock(false)
                                       .endedAt(ZonedDateTime.now())
                                       .build();

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/OperationsHelper.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/OperationsHelper.java
@@ -1,27 +1,20 @@
 package org.cloudfoundry.multiapps.controller.process.util;
 
-import java.text.MessageFormat;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.cloudfoundry.multiapps.controller.api.model.ErrorType;
 import org.cloudfoundry.multiapps.controller.api.model.ImmutableOperation;
 import org.cloudfoundry.multiapps.controller.api.model.Operation;
 import org.cloudfoundry.multiapps.controller.persistence.model.HistoricOperationEvent;
 import org.cloudfoundry.multiapps.controller.persistence.services.OperationService;
-import org.cloudfoundry.multiapps.controller.process.Messages;
 import org.cloudfoundry.multiapps.controller.process.metadata.ProcessTypeToOperationMetadataMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Named
 public class OperationsHelper {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(OperationsHelper.class);
 
     private final OperationService operationService;
     private final ProcessTypeToOperationMetadataMapper metadataMapper;
@@ -48,6 +41,25 @@ public class OperationsHelper {
         return operation;
     }
 
+    public Operation releaseLockIfNeeded(Operation operation) {
+        // Fixes bug XSBUG-2035: Inconsistency in 'operation', 'act_hi_procinst' and 'act_ru_execution' tables
+        if (operation.hasAcquiredLock() && operation.getState()
+                                                    .isFinal()) {
+            operation = ImmutableOperation.builder()
+                                          .from(operation)
+                                          .hasAcquiredLock(false)
+                                          .build();
+            operationService.update(operation, operation);
+        }
+        return operation;
+    }
+
+    public List<Operation> releaseLocksIfNeeded(List<Operation> operations) {
+        return operations.stream()
+                         .map(this::releaseLockIfNeeded)
+                         .collect(Collectors.toList());
+    }
+
     private ErrorType getErrorType(Operation operation) {
         List<HistoricOperationEvent> historicEvents = processHelper.getHistoricOperationEventByProcessId(operation.getProcessId());
         if (historicEvents.isEmpty()) {
@@ -67,52 +79,4 @@ public class OperationsHelper {
         }
         return null;
     }
-
-    public Operation addState(Operation operation) {
-        if (operation.getState() != null) {
-            return operation;
-        }
-        Operation.State state = computeState(operation);
-        // Fixes bug XSBUG-2035: Inconsistency in 'operation', 'act_hi_procinst' and 'act_ru_execution' tables
-        if (operation.hasAcquiredLock() && (state.equals(Operation.State.ABORTED) || state.equals(Operation.State.FINISHED))) {
-            operation = ImmutableOperation.builder()
-                                          .from(operation)
-                                          .hasAcquiredLock(false)
-                                          .state(state)
-                                          .build();
-            operationService.update(operation, operation);
-        }
-        return ImmutableOperation.copyOf(operation)
-                                 .withState(state);
-    }
-
-    public Operation.State computeState(Operation operation) {
-        LOGGER.debug(MessageFormat.format(Messages.COMPUTING_STATE_OF_OPERATION, operation.getProcessType(), operation.getProcessId()));
-        return computeProcessState(operation.getProcessId());
-    }
-
-    public Operation.State computeProcessState(String processId) {
-        return processHelper.computeProcessState(processId);
-    }
-
-    public List<Operation> findOperations(List<Operation> operations, List<Operation.State> statusList) {
-        operations = addState(operations);
-        return filterBasedOnStates(operations, statusList);
-    }
-
-    private List<Operation> addState(List<Operation> operations) {
-        return operations.stream()
-                         .map(this::addState)
-                         .collect(Collectors.toList());
-    }
-
-    private List<Operation> filterBasedOnStates(List<Operation> operations, List<Operation.State> statusList) {
-        if (CollectionUtils.isEmpty(statusList)) {
-            return operations;
-        }
-        return operations.stream()
-                         .filter(operation -> statusList.contains(operation.getState()))
-                         .collect(Collectors.toList());
-    }
-
 }

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/ProcessConflictPreventer.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/ProcessConflictPreventer.java
@@ -82,7 +82,6 @@ public class ProcessConflictPreventer {
                                       .from(operation)
                                       .hasAcquiredLock(false)
                                       .state(state)
-                                      .cachedState(state)
                                       .endedAt(ZonedDateTime.now())
                                       .build();
         operationService.update(operation, operation);

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/flowable/ProcessActionTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/flowable/ProcessActionTest.java
@@ -106,6 +106,7 @@ abstract class ProcessActionTest {
         Mockito.when(operationService.createQuery())
                .thenReturn(operationQuery);
         Operation operation = ImmutableOperation.builder()
+                                                .state(Operation.State.RUNNING)
                                                 .build();
         Mockito.when(operationQuery.singleResult())
                .thenReturn(operation);
@@ -115,7 +116,7 @@ abstract class ProcessActionTest {
 
     protected void assertStateUpdated(Operation.State state) {
         Operation operation = ImmutableOperation.builder()
-                                                .cachedState(state)
+                                                .state(state)
                                                 .build();
         Mockito.verify(operationService)
                .update(operation, operation);

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/jobs/OperationsCleanerTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/jobs/OperationsCleanerTest.java
@@ -89,10 +89,12 @@ class OperationsCleanerTest {
         Operation operation1 = ImmutableOperation.builder()
                                                  .processId(OPERATION_ID_1)
                                                  .startedAt(epochMillisToZonedDateTime(TIME_BEFORE_EXPIRATION_1))
+                                                 .state(Operation.State.RUNNING)
                                                  .build();
         Operation operation2 = ImmutableOperation.builder()
                                                  .processId(OPERATION_ID_2)
                                                  .startedAt(epochMillisToZonedDateTime(TIME_BEFORE_EXPIRATION_2))
+                                                 .state(Operation.State.RUNNING)
                                                  .build();
         List<Operation> operationsList = List.of(operation1, operation2);
         when(operationService.createQuery()).thenReturn(operationQuery);
@@ -110,12 +112,12 @@ class OperationsCleanerTest {
         Operation operation1 = ImmutableOperation.builder()
                                                  .processId(OPERATION_ID_1)
                                                  .startedAt(epochMillisToZonedDateTime(TIME_BEFORE_EXPIRATION_1))
-                                                 .state(null)
+                                                 .state(Operation.State.RUNNING)
                                                  .build();
         Operation operation2 = ImmutableOperation.builder()
                                                  .processId(OPERATION_ID_2)
                                                  .startedAt(epochMillisToZonedDateTime(TIME_BEFORE_EXPIRATION_2))
-                                                 .state(null)
+                                                 .state(Operation.State.RUNNING)
                                                  .build();
         List<Operation> operationsList = List.of(operation1, operation2);
 
@@ -136,17 +138,17 @@ class OperationsCleanerTest {
         Operation operation1 = ImmutableOperation.builder()
                                                  .processId(OPERATION_ID_1)
                                                  .startedAt(epochMillisToZonedDateTime(TIME_BEFORE_EXPIRATION_1))
-                                                 .state(null)
+                                                 .state(Operation.State.RUNNING)
                                                  .build();
         Operation operation2 = ImmutableOperation.builder()
                                                  .processId(OPERATION_ID_2)
                                                  .startedAt(epochMillisToZonedDateTime(TIME_BEFORE_EXPIRATION_2))
-                                                 .state(null)
+                                                 .state(Operation.State.RUNNING)
                                                  .build();
         Operation operation3 = ImmutableOperation.builder()
                                                  .processId(OPERATION_ID_3)
                                                  .startedAt(epochMillisToZonedDateTime(TIME_BEFORE_EXPIRATION_2))
-                                                 .state(null)
+                                                 .state(Operation.State.RUNNING)
                                                  .build();
         List<Operation> operationsPage1 = List.of(operation1, operation2);
         List<Operation> operationsPage2 = List.of(operation3);
@@ -179,7 +181,7 @@ class OperationsCleanerTest {
         Operation operation3 = ImmutableOperation.builder()
                                                  .processId(OPERATION_ID_3)
                                                  .startedAt(epochMillisToZonedDateTime(TIME_BEFORE_EXPIRATION_2))
-                                                 .state(null)
+                                                 .state(Operation.State.RUNNING)
                                                  .build();
         List<Operation> operationsPage1 = List.of(operation1, operation2);
         List<Operation> operationsPage2 = List.of(operation3);

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/listeners/EnterTestingPhaseListenerTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/listeners/EnterTestingPhaseListenerTest.java
@@ -68,7 +68,7 @@ class EnterTestingPhaseListenerTest {
     void testNotifyInternal() {
         listener.notify(execution);
         Operation updatedOperation = ImmutableOperation.builder()
-                                                       .cachedState(Operation.State.ACTION_REQUIRED)
+                                                       .state(Operation.State.ACTION_REQUIRED)
                                                        .build();
         Mockito.verify(operationQuery)
                .processId(execution.getProcessInstanceId());
@@ -83,6 +83,7 @@ class EnterTestingPhaseListenerTest {
         Mockito.when(operationService.createQuery())
                .thenReturn(operationQuery);
         Operation operation = ImmutableOperation.builder()
+                                                .state(Operation.State.RUNNING)
                                                 .build();
         Mockito.when(operationQuery.processId(Mockito.anyString()))
                .thenReturn(operationQuery);

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/listeners/StartProcessListenerTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/listeners/StartProcessListenerTest.java
@@ -160,7 +160,7 @@ class StartProcessListenerTest {
                                                 .startedAt(START_TIME)
                                                 .user(user)
                                                 .hasAcquiredLock(false)
-                                                .cachedState(Operation.State.RUNNING)
+                                                .state(Operation.State.RUNNING)
                                                 .build();
         Mockito.verify(operationService)
                .add(Mockito.argThat(GenericArgumentMatcher.forObject(operation)));

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/OperationInErrorStateHandlerTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/OperationInErrorStateHandlerTest.java
@@ -190,6 +190,7 @@ class OperationInErrorStateHandlerTest {
 
     private void prepareOperationService() {
         Operation operation = ImmutableOperation.builder()
+                                                .state(Operation.State.RUNNING)
                                                 .build();
         Mockito.when(operationService.createQuery())
                .thenReturn(operationQuery);
@@ -201,7 +202,7 @@ class OperationInErrorStateHandlerTest {
 
     private void assertErrorStateSet() {
         Operation updatedOperation = ImmutableOperation.builder()
-                                                       .cachedState(Operation.State.ERROR)
+                                                       .state(Operation.State.ERROR)
                                                        .build();
         Mockito.verify(operationService)
                .update(updatedOperation, updatedOperation);

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/OperationsHelperTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/OperationsHelperTest.java
@@ -1,16 +1,12 @@
 package org.cloudfoundry.multiapps.controller.process.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
 
 import java.util.Collections;
 import java.util.List;
 
 import org.cloudfoundry.multiapps.controller.api.model.ErrorType;
 import org.cloudfoundry.multiapps.controller.api.model.Operation;
-import org.cloudfoundry.multiapps.controller.api.model.Operation.State;
 import org.cloudfoundry.multiapps.controller.api.model.ProcessType;
 import org.cloudfoundry.multiapps.controller.persistence.model.HistoricOperationEvent;
 import org.cloudfoundry.multiapps.controller.persistence.services.OperationService;
@@ -18,7 +14,6 @@ import org.cloudfoundry.multiapps.controller.process.Constants;
 import org.cloudfoundry.multiapps.controller.process.metadata.ProcessTypeToOperationMetadataMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -26,6 +21,7 @@ import org.mockito.MockitoAnnotations;
 class OperationsHelperTest {
 
     private static final String PROCESS_ID = "84af8e1e-4d96-11ea-b77f-2e728ce88178";
+
 
     @Mock
     private OperationService operationService;
@@ -91,128 +87,46 @@ class OperationsHelperTest {
     }
 
     @Test
-    void testAddStateWhenOperationHasState() {
-        Operation mockedOperation = createMockedOperation(PROCESS_ID, ProcessType.DEPLOY, Operation.State.RUNNING);
-        Operation operation = operationsHelper.addState(mockedOperation);
-        Assertions.assertEquals(Operation.State.RUNNING, operation.getState());
-    }
-
-    @Test
-    void testAddStateWithAcquiredLockAndAbortedOperation() {
-        Operation mockedOperation = createMockedOperation(PROCESS_ID, ProcessType.DEPLOY, null);
-        Mockito.when(processHelper.computeProcessState(PROCESS_ID))
-               .thenReturn(State.ABORTED);
+    void testReleaseLockIfNeededForFinalOperation() {
+        Operation mockedOperation = createMockedOperation(PROCESS_ID, ProcessType.DEPLOY, Operation.State.ABORTED);
         Mockito.when(mockedOperation.hasAcquiredLock())
                .thenReturn(true);
-        Operation operation = operationsHelper.addState(mockedOperation);
+        Operation operation = operationsHelper.releaseLockIfNeeded(mockedOperation);
         Assertions.assertEquals(Operation.State.ABORTED, operation.getState());
         Assertions.assertFalse(operation.hasAcquiredLock());
-        ArgumentCaptor<Operation> argumentCaptor = ArgumentCaptor.forClass(Operation.class);
         Mockito.verify(operationService)
-               .update(argumentCaptor.capture(), any());
-        assertEquals(PROCESS_ID, argumentCaptor.getValue()
-                                               .getProcessId());
+               .update(operation, operation);
     }
 
     @Test
-    void testAddStateWithAcquiredLockAndFinishedOperation() {
-        Operation mockedOperation = createMockedOperation(PROCESS_ID, ProcessType.DEPLOY, null);
+    void testReleaseLockIfNeededForNonFinalOperation() {
+        Operation mockedOperation = createMockedOperation(PROCESS_ID, ProcessType.DEPLOY, Operation.State.RUNNING);
         Mockito.when(mockedOperation.hasAcquiredLock())
                .thenReturn(true);
-        Mockito.when(processHelper.computeProcessState(PROCESS_ID))
-               .thenReturn(State.FINISHED);
-        Operation operation = operationsHelper.addState(mockedOperation);
-        Assertions.assertEquals(Operation.State.FINISHED, operation.getState());
-        Assertions.assertFalse(operation.hasAcquiredLock());
-        ArgumentCaptor<Operation> argumentCaptor = ArgumentCaptor.forClass(Operation.class);
-        Mockito.verify(operationService)
-               .update(argumentCaptor.capture(), any());
-        assertEquals(PROCESS_ID, argumentCaptor.getValue()
-                                               .getProcessId());
+        Operation operation = operationsHelper.releaseLockIfNeeded(mockedOperation);
+        Assertions.assertTrue(operation.hasAcquiredLock());
+        Mockito.verify(operationService, Mockito.never())
+               .update(operation, operation);
     }
 
     @Test
-    void testAddStateWithoutAcquiredLockAndRunningOperation() {
-        Operation mockedOperation = createMockedOperation(PROCESS_ID, ProcessType.DEPLOY, null);
-        Mockito.when(processHelper.computeProcessState(PROCESS_ID))
-               .thenReturn(State.RUNNING);
-        Operation operation = operationsHelper.addState(mockedOperation);
-        Assertions.assertEquals(Operation.State.RUNNING, operation.getState());
-        Assertions.assertFalse(operation.hasAcquiredLock());
-        Mockito.verify(operationService, never())
-               .update(any(), any());
-    }
-
-    @Test
-    void testComputeOperationStateWhenProcessIsInNonFinalStateAndProcessIsAborted() {
-        Mockito.when(processHelper.computeProcessState(PROCESS_ID))
-               .thenReturn(State.ABORTED);
-        Operation.State state = operationsHelper.computeProcessState(PROCESS_ID);
-        Assertions.assertEquals(Operation.State.ABORTED, state);
-    }
-
-    @Test
-    void testComputeOperationStateWhenProcessIsInNonFinalStateAndProcessIsAtReceiveTask() {
-        Mockito.when(processHelper.computeProcessState(PROCESS_ID))
-               .thenReturn(State.ACTION_REQUIRED);
-        Operation.State state = operationsHelper.computeProcessState(PROCESS_ID);
-        Assertions.assertEquals(Operation.State.ACTION_REQUIRED, state);
-    }
-
-    @Test
-    void testComputeOperationStateWhenProcessIsInNonFinalStateAndProcessIsInErrorState() {
-        Mockito.when(processHelper.computeProcessState(PROCESS_ID))
-               .thenReturn(State.ERROR);
-        Operation.State state = operationsHelper.computeProcessState(PROCESS_ID);
-        Assertions.assertEquals(Operation.State.ERROR, state);
-    }
-
-    @Test
-    void testComputeOperationStateWhenProcessIsInNonFinalStateAndProcessIsRunning() {
-        Mockito.when(processHelper.computeProcessState(PROCESS_ID))
-               .thenReturn(State.RUNNING);
-        Operation.State state = operationsHelper.computeProcessState(PROCESS_ID);
-        Assertions.assertEquals(Operation.State.RUNNING, state);
-    }
-
-    @Test
-    void testComputeOperationStateWhenProcessIsInFinalStateAndProcessIsAborted() {
-        Mockito.when(processHelper.computeProcessState(PROCESS_ID))
-               .thenReturn(State.ABORTED);
-        Operation.State state = operationsHelper.computeProcessState(PROCESS_ID);
-        Assertions.assertEquals(Operation.State.ABORTED, state);
-    }
-
-    @Test
-    void testComputeOperationStateWhenProcessIsInFinalStateAndProcessIsNotAborted() {
-        Mockito.when(processHelper.computeProcessState(PROCESS_ID))
-               .thenReturn(State.FINISHED);
-        Operation.State state = operationsHelper.computeProcessState(PROCESS_ID);
-        Assertions.assertEquals(Operation.State.FINISHED, state);
-    }
-
-    @Test
-    void testFindOperationsWithStatusRunning() {
-        List<Operation> operations = List.of(createMockedOperation("12af8e1e-4d96-11ea-b77f-2e728ce88178", ProcessType.DEPLOY,
-                                                                   Operation.State.RUNNING),
-                                             createMockedOperation("13af8e1e-4d96-11ea-b77f-2e728ce88178", ProcessType.DEPLOY,
-                                                                   Operation.State.ABORTED));
-        List<Operation.State> statusList = List.of(Operation.State.RUNNING);
-        List<Operation> foundOperations = operationsHelper.findOperations(operations, statusList);
-        Assertions.assertEquals(1, foundOperations.size());
-        Assertions.assertEquals("12af8e1e-4d96-11ea-b77f-2e728ce88178", operations.get(0)
-                                                                                  .getProcessId());
-    }
-
-    @Test
-    void testFundOperationsWithoutStatus() {
-        List<Operation> operations = List.of(createMockedOperation("12af8e1e-4d96-11ea-b77f-2e728ce88178", ProcessType.DEPLOY,
-                                                                   Operation.State.RUNNING),
-                                             createMockedOperation("13af8e1e-4d96-11ea-b77f-2e728ce88178", ProcessType.DEPLOY,
-                                                                   Operation.State.ABORTED));
-        List<Operation> foundOperations = operationsHelper.findOperations(operations, Collections.emptyList());
-        Assertions.assertEquals(2, foundOperations.size());
-
+    void testReleaseLocksIfNeededForFinalOperations() {
+        Operation mockedFinalOperation = createMockedOperation(PROCESS_ID, ProcessType.DEPLOY, Operation.State.ABORTED);
+        Operation mockedNonFinalOperation = createMockedOperation(PROCESS_ID, ProcessType.DEPLOY, Operation.State.RUNNING);
+        Mockito.when(mockedFinalOperation.hasAcquiredLock())
+               .thenReturn(true);
+        Mockito.when(mockedNonFinalOperation.hasAcquiredLock())
+               .thenReturn(true);
+        List<Operation> resultOperations = operationsHelper.releaseLocksIfNeeded(List.of(mockedFinalOperation, mockedNonFinalOperation));
+        Operation updatedOperation = resultOperations.get(0);
+        Operation notUpdatedOperation = resultOperations.get(1);
+        Assertions.assertEquals(Operation.State.ABORTED, updatedOperation.getState());
+        Assertions.assertFalse(updatedOperation.hasAcquiredLock());
+        Mockito.verify(operationService, Mockito.times(1))
+               .update(updatedOperation, updatedOperation);
+        Assertions.assertEquals(mockedNonFinalOperation, notUpdatedOperation);
+        Mockito.verify(operationService, Mockito.never())
+               .update(notUpdatedOperation, notUpdatedOperation);
     }
 
     private Operation createMockedOperation(String processId, ProcessType processType, Operation.State state) {

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/ProcessConflictPreventerTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/ProcessConflictPreventerTest.java
@@ -49,6 +49,7 @@ class ProcessConflictPreventerTest {
                                                 .spaceId(testSpaceId)
                                                 .mtaId(testMtaId)
                                                 .hasAcquiredLock(false)
+                                                .state(Operation.State.RUNNING)
                                                 .build();
         when(operationServiceMock.createQuery()
                                  .list()).thenReturn(List.of(operation));
@@ -91,6 +92,7 @@ class ProcessConflictPreventerTest {
                                  .processType(ProcessType.DEPLOY)
                                  .mtaId(testMtaId)
                                  .hasAcquiredLock(false)
+                                 .state(Operation.State.RUNNING)
                                  .build();
     }
 
@@ -104,8 +106,6 @@ class ProcessConflictPreventerTest {
             && operation.hasAcquiredLock()
                         .equals(false)
             && operation.getState()
-                        .equals(Operation.State.ABORTED)
-            && operation.getCachedState()
                         .equals(Operation.State.ABORTED)
             && operation.getEndedAt() != null;
     }

--- a/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/Messages.java
+++ b/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/Messages.java
@@ -29,7 +29,6 @@ public final class Messages {
     public static final String FILE_SERVICE_CLEANUP_FAILED = "FileService: Failed to delete files without content. Reason: \"{0}\"";
 
     // WARN log messages
-    public static final String OPERATION_CACHED_1_AND_COMPUTED_2_STATE_DIFFER_FOR_PROCESS_0 = "Operation cached and computed state differ for process \"{0}\"! Cached state: \"{1}\"; Computed state: \"{2}\".";
 
     // INFO log messages
     public static final String OAUTH_TOKEN_STORE = "Using OAuth token store \"{0}\"";
@@ -42,7 +41,6 @@ public final class Messages {
 
     // DEBUG log messages
     public static final String ERROR_STORING_TOKEN_DUE_TO_INTEGRITY_VIOLATION = "Cannot store access token due to data integrity violation. The exception is ignored as the token and authentication are persisted by another client";
-    public static final String OPERATION_STATE_CALCULATION_TOOK_0 = "Operation state calculation took {0} milliseconds.";
 
     private Messages() {
     }


### PR DESCRIPTION
Rely on the current state, which is persisted in the database instead of
dynamically calculating it. Map current_state in the database to
Operation.state and remove Operation.cachedState.
JIRA: LMCROSSITXSADEPLOY-2128