### PR TITLE
Remove usage of CloudInfo

### DIFF
--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/clients/AuthorizationEndpointGetter.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/clients/AuthorizationEndpointGetter.java
@@ -1,0 +1,31 @@
+package org.cloudfoundry.multiapps.controller.core.cf.clients;
+
+import java.util.Map;
+
+import org.cloudfoundry.multiapps.common.util.JsonUtil;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.sap.cloudfoundry.client.facade.CloudControllerClient;
+
+public class AuthorizationEndpointGetter {
+
+    private final WebClient webClient;
+
+    public AuthorizationEndpointGetter(CloudControllerClient client) {
+        this.webClient = new WebClientFactory().getWebClient(client);
+    }
+
+    @SuppressWarnings("unchecked")
+    public String getAuthorizationEndpoint() {
+        String response = webClient.get()
+                                   .uri("/")
+                                   .retrieve()
+                                   .bodyToMono(String.class)
+                                   .block();
+        Map<String, Object> resource = JsonUtil.convertJsonToMap(response);
+        Map<String, Object> links = (Map<String, Object>) resource.get("links");
+        Map<String, Object> login = (Map<String, Object>) links.get("login");
+        return (String) login.get("href");
+    }
+
+}

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CollectSystemParametersStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CollectSystemParametersStep.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.cloudfoundry.multiapps.common.ContentException;
+import org.cloudfoundry.multiapps.controller.core.cf.clients.AuthorizationEndpointGetter;
 import org.cloudfoundry.multiapps.controller.core.helpers.CredentialsGenerator;
 import org.cloudfoundry.multiapps.controller.core.helpers.SystemParameters;
 import org.cloudfoundry.multiapps.controller.core.model.DeployedMta;
@@ -93,8 +94,7 @@ public class CollectSystemParametersStep extends SyncFlowableStep {
 
     private SystemParameters createSystemParameters(ProcessContext context, CloudControllerClient client, String defaultDomain,
                                                     boolean reserveTemporaryRoutes) {
-        String authorizationEndpoint = client.getCloudInfo()
-                                             .getAuthorizationEndpoint();
+        String authorizationEndpoint = getAuthorizationEndpointGetter(client).getAuthorizationEndpoint();
         String user = context.getVariable(Variables.USER);
         String namespace = context.getVariable(Variables.MTA_NAMESPACE);
         boolean applyNamespace = context.getVariable(Variables.APPLY_NAMESPACE);
@@ -153,6 +153,10 @@ public class CollectSystemParametersStep extends SyncFlowableStep {
                                                 .getVersion();
         getStepLogger().info(Messages.DEPLOYED_MTA_VERSION, deployedMtaVersion);
         return DeploymentType.fromVersions(deployedMtaVersion, newMtaVersion);
+    }
+
+    protected AuthorizationEndpointGetter getAuthorizationEndpointGetter(CloudControllerClient client) {
+        return new AuthorizationEndpointGetter(client);
     }
 
 }

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CollectBlueGreenSystemParametersStepTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CollectBlueGreenSystemParametersStepTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 import java.util.Map;
 
+import com.sap.cloudfoundry.client.facade.CloudControllerClient;
+import org.cloudfoundry.multiapps.controller.core.cf.clients.AuthorizationEndpointGetter;
 import org.cloudfoundry.multiapps.controller.core.helpers.SystemParameters;
 import org.cloudfoundry.multiapps.controller.core.model.SupportedParameters;
 import org.cloudfoundry.multiapps.controller.process.variables.Variables;
@@ -69,7 +71,12 @@ class CollectBlueGreenSystemParametersStepTest extends CollectSystemParametersSt
 
     @Override
     protected CollectBlueGreenSystemParametersStep createStep() {
-        return new CollectBlueGreenSystemParametersStep();
+        return new CollectBlueGreenSystemParametersStep() {
+            @Override
+            protected AuthorizationEndpointGetter getAuthorizationEndpointGetter(CloudControllerClient client) {
+                return authorizationEndpointGetter;
+            }
+        };
     }
 
 }


### PR DESCRIPTION
Part of V3 adoption changes

#### Description: 
The V3 equivalent of info is moved to root level:
<CF api>/v2/info -> <CF api>/

Replace it with only getting the Authorization endpoint,
which was the only thing used from the CloudInfo object


#### Issue: LMCROSSITXSADEPLOY-2255

