### PR TITLE
Do not set error state if operation is aborted

### DIFF
--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/OperationInErrorStateHandler.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/OperationInErrorStateHandler.java
@@ -151,11 +151,17 @@ public class OperationInErrorStateHandler {
         Operation operation = operationService.createQuery()
                                               .processId(processInstanceId)
                                               .singleResult();
-        operation = ImmutableOperation.builder()
-                                      .from(operation)
-                                      .state(Operation.State.ERROR)
-                                      .build();
-        operationService.update(operation, operation);
+        if (!isOperationAlreadyAborted(operation)) {
+            operation = ImmutableOperation.builder()
+                                          .from(operation)
+                                          .state(Operation.State.ERROR)
+                                          .build();
+            operationService.update(operation, operation);
+        }
+    }
+
+    private boolean isOperationAlreadyAborted(Operation operation) {
+        return Operation.State.ABORTED.equals(operation.getState());
     }
 
     protected Date getCurrentTimestamp() {


### PR DESCRIPTION
Flowable call the ErrorProcessListener after FailedJobCommandFactory.
Our FailedJobCommandFactory calls AbortProcessAction (which sets state
to aborted) in the case where --abort-on-error is set. In other words,
the process is initially aborted in case --abort-on-error and then the
ErrorProcessListener is called.
JIRA: LMCROSSITXSADEPLOY-2128

#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->


#### Issue: <!-- Link to a Github Issue, delete if not applicable -->

