### PR TITLE
Adopt flowable 6.6.0 and add timeout for long jobs

### DIFF
--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executor/CancelExpiredTasksThread.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executor/CancelExpiredTasksThread.java
@@ -1,0 +1,64 @@
+package org.cloudfoundry.multiapps.controller.process.executor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class CancelExpiredTasksThread extends Thread {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CancelExpiredTasksThread.class);
+    private Map<Future<?>, Long> tasksStartTime = new ConcurrentHashMap<>();
+    private AtomicBoolean isActive = new AtomicBoolean(true);
+    private long cancelWaitTimeInMillis;
+    private long cancelTimeoutInMillis;
+
+    public CancelExpiredTasksThread(long cancelTimeoutInMillis, long cancelWaitTimeInMillis) {
+        this.cancelTimeoutInMillis = cancelTimeoutInMillis;
+        this.cancelWaitTimeInMillis = cancelWaitTimeInMillis;
+    }
+
+    @Override
+    public void run() {
+        try {
+            while (isActive.get()) {
+                removeDoneTasks();
+                cancelTimeoutTasks();
+                Thread.sleep(cancelWaitTimeInMillis);
+            }
+        } catch (InterruptedException e) {
+            LOGGER.error(e.getMessage(), e);
+            Thread.currentThread()
+                  .interrupt();
+        }
+    }
+
+    public void addTask(Future<?> task) {
+        tasksStartTime.put(task, System.currentTimeMillis());
+    }
+
+    public void shutdown() {
+        isActive.set(false);
+    }
+
+    private void removeDoneTasks() {
+        tasksStartTime.keySet()
+                      .removeIf(Future::isDone);
+    }
+
+    private void cancelTimeoutTasks() {
+        long now = System.currentTimeMillis();
+        tasksStartTime.forEach((task, startTime) -> {
+            if (shouldBeCanceled(startTime, now)) {
+                task.cancel(true);
+            }
+        });
+    }
+
+    private boolean shouldBeCanceled(long startTime, long now) {
+        return startTime + cancelTimeoutInMillis <= now;
+    }
+}

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executor/TimeoutAsyncJobExecutor.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executor/TimeoutAsyncJobExecutor.java
@@ -1,0 +1,13 @@
+package org.cloudfoundry.multiapps.controller.process.executor;
+
+import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
+
+public class TimeoutAsyncJobExecutor extends DefaultAsyncJobExecutor {
+
+    @Override
+    protected void initAsyncJobExecutionThreadPool() {
+        TimeoutAsyncTaskExecutor taskExecutor = (TimeoutAsyncTaskExecutor) this.taskExecutor;
+        taskExecutor.start();
+        shutdownTaskExecutor = true;
+    }
+}

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executor/TimeoutAsyncTaskExecutor.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executor/TimeoutAsyncTaskExecutor.java
@@ -1,0 +1,33 @@
+package org.cloudfoundry.multiapps.controller.process.executor;
+
+import org.flowable.common.engine.impl.async.DefaultAsyncTaskExecutor;
+
+import java.util.concurrent.Future;
+
+public class TimeoutAsyncTaskExecutor extends DefaultAsyncTaskExecutor {
+
+    private final CancelExpiredTasksThread cancelExpiredTasksThread;
+
+    public TimeoutAsyncTaskExecutor(long timeoutInMillis, long waitTimeInMillis) {
+        executorNeedsShutdown = true;
+        cancelExpiredTasksThread = new CancelExpiredTasksThread(timeoutInMillis, waitTimeInMillis);
+    }
+
+    @Override
+    public void execute(Runnable task) {
+        Future<?> f = executorService.submit(task);
+        cancelExpiredTasksThread.addTask(f);
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        cancelExpiredTasksThread.start();
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        cancelExpiredTasksThread.shutdown();
+    }
+}

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/MockDelegateExecution.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/MockDelegateExecution.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.ReadOnlyDelegateExecution;
 import org.flowable.variable.api.persistence.entity.VariableInstance;
 import org.mockito.Mockito;
 
@@ -389,6 +390,11 @@ public class MockDelegateExecution implements DelegateExecution {
     @Override
     public void setCurrentFlowableListener(FlowableListener currentListener) {
 
+    }
+
+    @Override
+    public ReadOnlyDelegateExecution snapshotReadOnly() {
+        return null;
     }
 
     @Override

--- a/multiapps-controller-shutdown-client/src/main/java/org/cloudfoundry/multiapps/controller/shutdown/client/ShutdownClientImpl.java
+++ b/multiapps-controller-shutdown-client/src/main/java/org/cloudfoundry/multiapps/controller/shutdown/client/ShutdownClientImpl.java
@@ -18,7 +18,7 @@ import org.cloudfoundry.multiapps.controller.core.model.ApplicationShutdown;
 class ShutdownClientImpl implements ShutdownClient {
 
     private static final String X_CF_APP_INSTANCE = "x-cf-app-instance";
-    private static final String SHUTDOWN_ENDPOINT = "/admin/shutdown";
+    private static final String SHUTDOWN_ENDPOINT = "/rest/admin/shutdown";
 
     private final String applicationUrl;
     /**

--- a/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/monitoring/FlowableJobExecutorInformation.java
+++ b/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/monitoring/FlowableJobExecutorInformation.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
+import org.flowable.spring.SpringProcessEngineConfiguration;
 
 @Named
 public class FlowableJobExecutorInformation {
@@ -14,13 +14,13 @@ public class FlowableJobExecutorInformation {
 
     protected Instant lastUpdateTime;
 
-    private DefaultAsyncJobExecutor jobExecutor;
+    private SpringProcessEngineConfiguration processEngineConfiguration;
 
     private int currentJobExecutorQueueSize = 0;
 
     @Inject
-    public FlowableJobExecutorInformation(DefaultAsyncJobExecutor jobExecutor) {
-        this.jobExecutor = jobExecutor;
+    public FlowableJobExecutorInformation(SpringProcessEngineConfiguration processEngineConfiguration) {
+        this.processEngineConfiguration = processEngineConfiguration;
     }
 
     public int getCurrentJobExecutorQueueSize() {
@@ -37,8 +37,8 @@ public class FlowableJobExecutorInformation {
     }
 
     private void updateCurrentJobExecutorQueueSize() {
-        currentJobExecutorQueueSize = jobExecutor.getThreadPoolQueue()
-                                                 .size();
+        currentJobExecutorQueueSize = processEngineConfiguration.getAsyncExecutorThreadPoolQueue()
+                                                                .size();
         updateTime();
     }
 

--- a/multiapps-controller-web/src/test/java/org/cloudfoundry/multiapps/controller/web/monitoring/FlowableJobExecutorInformationTest.java
+++ b/multiapps-controller-web/src/test/java/org/cloudfoundry/multiapps/controller/web/monitoring/FlowableJobExecutorInformationTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.util.concurrent.BlockingQueue;
 
-import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
+import org.flowable.spring.SpringProcessEngineConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -19,7 +19,7 @@ class FlowableJobExecutorInformationTest {
     private static final int UPDATED_JOBS_IN_QUEUE = 1;
 
     @Mock
-    private DefaultAsyncJobExecutor asyncExecutor;
+    private SpringProcessEngineConfiguration processEngineConfiguration;
     @Mock
     private BlockingQueue<Runnable> blockingQueue;
 
@@ -34,23 +34,23 @@ class FlowableJobExecutorInformationTest {
 
     @Test
     void testGetCurrentJobExecutorQueueSize() {
-        prepareJobExecutor(JOBS_IN_QUEUE);
+        prepareProcessEngineConfiguration(JOBS_IN_QUEUE);
 
         int currentJobExecutorQueueSize = flowableJobExecutorInformation.getCurrentJobExecutorQueueSize();
         assertEquals(JOBS_IN_QUEUE, currentJobExecutorQueueSize);
     }
 
-    private void prepareJobExecutor(int jobsInQueue) {
+    private void prepareProcessEngineConfiguration(int jobsInQueue) {
         when(blockingQueue.size()).thenReturn(jobsInQueue);
-        when(asyncExecutor.getThreadPoolQueue()).thenReturn(blockingQueue);
+        when(processEngineConfiguration.getAsyncExecutorThreadPoolQueue()).thenReturn(blockingQueue);
     }
 
     @Test
     void testGetCurrentJobExecutorQueueSizeFromCache() {
-        prepareJobExecutor(JOBS_IN_QUEUE);
+        prepareProcessEngineConfiguration(JOBS_IN_QUEUE);
         flowableJobExecutorInformation.getCurrentJobExecutorQueueSize();
 
-        prepareJobExecutor(UPDATED_JOBS_IN_QUEUE);
+        prepareProcessEngineConfiguration(UPDATED_JOBS_IN_QUEUE);
         int currentJobExecutorQueueSize = flowableJobExecutorInformation.getCurrentJobExecutorQueueSize();
 
         assertEquals(JOBS_IN_QUEUE, currentJobExecutorQueueSize);
@@ -58,17 +58,17 @@ class FlowableJobExecutorInformationTest {
 
     @Test
     void testGetCurrentJobExecutorQueueSizeExpiredCache() {
-        flowableJobExecutorInformation = new FlowableJobExecutorInformation(asyncExecutor) {
+        flowableJobExecutorInformation = new FlowableJobExecutorInformation(processEngineConfiguration) {
             @Override
             protected void updateTime() {
                 lastUpdateTime = Instant.now()
                                         .minusSeconds(120);
             }
         };
-        prepareJobExecutor(JOBS_IN_QUEUE);
+        prepareProcessEngineConfiguration(JOBS_IN_QUEUE);
         flowableJobExecutorInformation.getCurrentJobExecutorQueueSize();
 
-        prepareJobExecutor(UPDATED_JOBS_IN_QUEUE);
+        prepareProcessEngineConfiguration(UPDATED_JOBS_IN_QUEUE);
         int currentJobExecutorQueueSize = flowableJobExecutorInformation.getCurrentJobExecutorQueueSize();
 
         assertEquals(UPDATED_JOBS_IN_QUEUE, currentJobExecutorQueueSize);

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>
         <eclipselink.version>2.7.7</eclipselink.version>
-        <flowable.version>6.5.0</flowable.version>
+        <flowable.version>6.6.0</flowable.version>
         <spring.version>5.3.5</spring.version>
         <spring-security.version>5.4.5</spring-security.version>
         <spring-security-jwt.version>1.1.1.RELEASE</spring-security-jwt.version>


### PR DESCRIPTION
Implement custom AsyncTaskExecutor, which has a running thread, keeping
track of running task. Use that to cancel task, which are running too
long and can exceed expiration time.
JIRA: LMCROSSITXSADEPLOY-2327