### PR TITLE
Refactor step timeout handling & update timeouts

### DIFF
--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/ExecuteTaskStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/ExecuteTaskStep.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.multiapps.controller.process.steps;
 
 import java.text.MessageFormat;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.LongSupplier;
@@ -53,7 +54,7 @@ public class ExecuteTaskStep extends TimeoutAsyncFlowableStep {
     }
 
     @Override
-    public Integer getTimeout(ProcessContext context) {
+    public Duration getTimeout(ProcessContext context) {
         return context.getVariable(Variables.START_TIMEOUT);
     }
 

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/RestartAppStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/RestartAppStep.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.multiapps.controller.process.steps;
 
 import java.text.MessageFormat;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -92,7 +93,7 @@ public class RestartAppStep extends TimeoutAsyncFlowableStepWithHooks implements
     }
 
     @Override
-    public Integer getTimeout(ProcessContext context) {
+    public Duration getTimeout(ProcessContext context) {
         return context.getVariable(Variables.START_TIMEOUT);
     }
 

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/StageAppStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/StageAppStep.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.multiapps.controller.process.steps;
 
 import java.text.MessageFormat;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
@@ -42,7 +43,7 @@ public class StageAppStep extends TimeoutAsyncFlowableStep {
     }
 
     @Override
-    public Integer getTimeout(ProcessContext context) {
+    public Duration getTimeout(ProcessContext context) {
         return context.getVariable(Variables.START_TIMEOUT);
     }
 

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/TimeoutAsyncFlowableStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/TimeoutAsyncFlowableStep.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.multiapps.controller.process.steps;
 
 import java.text.MessageFormat;
+import java.time.Duration;
 
 import org.cloudfoundry.multiapps.common.SLException;
 import org.cloudfoundry.multiapps.controller.process.Constants;
@@ -21,7 +22,7 @@ public abstract class TimeoutAsyncFlowableStep extends AsyncFlowableStep {
     private boolean hasTimedOut(ProcessContext context) {
         long stepStartTime = getStepStartTime(context);
         long currentTime = System.currentTimeMillis();
-        return (currentTime - stepStartTime) >= getTimeout(context) * 1000;
+        return (currentTime - stepStartTime) >= getTimeout(context).toMillis();
     }
 
     private long getStepStartTime(ProcessContext context) {
@@ -48,5 +49,5 @@ public abstract class TimeoutAsyncFlowableStep extends AsyncFlowableStep {
         return getClass().getSimpleName();
     }
 
-    public abstract Integer getTimeout(ProcessContext context);
+    public abstract Duration getTimeout(ProcessContext context);
 }

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/UploadAppStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/UploadAppStep.java
@@ -4,6 +4,7 @@ import static java.text.MessageFormat.format;
 
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -48,7 +49,7 @@ import com.sap.cloudfoundry.client.facade.domain.Status;
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
 public class UploadAppStep extends TimeoutAsyncFlowableStep {
 
-    static final int DEFAULT_APP_UPLOAD_TIMEOUT = (int) TimeUnit.HOURS.toSeconds(1);
+    static final int DEFAULT_APP_UPLOAD_TIMEOUT = (int) TimeUnit.MINUTES.toSeconds(15);
     private static final Logger LOGGER = LoggerFactory.getLogger(UploadAppStep.class);
     @Inject
     protected ApplicationArchiveReader applicationArchiveReader;
@@ -208,11 +209,11 @@ public class UploadAppStep extends TimeoutAsyncFlowableStep {
     }
 
     @Override
-    public Integer getTimeout(ProcessContext context) {
+    public Duration getTimeout(ProcessContext context) {
         CloudApplication app = context.getVariable(Variables.APP_TO_PROCESS);
         int uploadTimeout = extractUploadTimeoutFromAppAttributes(app, DEFAULT_APP_UPLOAD_TIMEOUT);
         getStepLogger().debug(Messages.UPLOAD_APP_TIMEOUT, uploadTimeout);
-        return uploadTimeout;
+        return Duration.ofSeconds(uploadTimeout);
     }
 
     private int extractUploadTimeoutFromAppAttributes(CloudApplication app, int defaultAppUploadTimeout) {

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/variables/Variables.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/variables/Variables.java
@@ -1,11 +1,11 @@
 package org.cloudfoundry.multiapps.controller.process.variables;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudApplicationExtended;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudServiceInstanceExtended;
@@ -128,10 +128,10 @@ public interface Variables {
     Variable<Integer> MTA_MAJOR_SCHEMA_VERSION = ImmutableSimpleVariable.<Integer> builder()
                                                                         .name("mtaMajorSchemaVersion")
                                                                         .build();
-    Variable<Integer> START_TIMEOUT = ImmutableSimpleVariable.<Integer> builder()
-                                                             .name("startTimeout")
-                                                             .defaultValue((int) TimeUnit.HOURS.toSeconds(1))
-                                                             .build();
+    Variable<Duration> START_TIMEOUT = ImmutableSimpleVariable.<Duration> builder()
+                                                              .name("startTimeout")
+                                                              .defaultValue(Duration.ofMinutes(15))
+                                                              .build();
     Variable<Integer> UPDATED_SERVICE_BROKER_SUBSCRIBERS_COUNT = ImmutableSimpleVariable.<Integer> builder()
                                                                                         .name("updatedServiceBrokerSubscribersCount")
                                                                                         .build();

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/PollExecuteTaskStatusStepTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/PollExecuteTaskStatusStepTest.java
@@ -4,10 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudApplicationExtended;
@@ -28,7 +28,7 @@ class PollExecuteTaskStatusStepTest extends AsyncStepOperationTest<ExecuteTaskSt
     @Mock
     private RecentLogsRetriever recentLogsRetriever;
 
-    private static final int START_TIMEOUT = 900;
+    private static final Duration START_TIMEOUT = Duration.ofSeconds(900);
     private static final String TASK_NAME = "foo";
     private static final String APPLICATION_NAME = "bar";
 
@@ -52,23 +52,23 @@ class PollExecuteTaskStatusStepTest extends AsyncStepOperationTest<ExecuteTaskSt
             // (0)
             Arguments.of(CloudTask.State.SUCCEEDED, 100L, AsyncExecutionState.FINISHED),
             // (1)
-            Arguments.of(CloudTask.State.SUCCEEDED, TimeUnit.SECONDS.toMillis(START_TIMEOUT) + 1, AsyncExecutionState.FINISHED),
+            Arguments.of(CloudTask.State.SUCCEEDED, START_TIMEOUT.toMillis() + 1, AsyncExecutionState.FINISHED),
             // (2)
             Arguments.of(CloudTask.State.FAILED, 100L, AsyncExecutionState.ERROR),
             // (3)
-            Arguments.of(CloudTask.State.FAILED, TimeUnit.SECONDS.toMillis(START_TIMEOUT) + 1, AsyncExecutionState.ERROR),
+            Arguments.of(CloudTask.State.FAILED, START_TIMEOUT.toMillis() + 1, AsyncExecutionState.ERROR),
             // (4)
             Arguments.of(CloudTask.State.PENDING, 100L, AsyncExecutionState.RUNNING),
             // (5)
-            Arguments.of(CloudTask.State.PENDING, TimeUnit.SECONDS.toMillis(START_TIMEOUT) + 1, AsyncExecutionState.RUNNING),
+            Arguments.of(CloudTask.State.PENDING, START_TIMEOUT.toMillis() + 1, AsyncExecutionState.RUNNING),
             // (6)
             Arguments.of(CloudTask.State.RUNNING, 100L, AsyncExecutionState.RUNNING),
             // (7)
-            Arguments.of(CloudTask.State.RUNNING, TimeUnit.SECONDS.toMillis(START_TIMEOUT) + 1, AsyncExecutionState.RUNNING),
+            Arguments.of(CloudTask.State.RUNNING, START_TIMEOUT.toMillis() + 1, AsyncExecutionState.RUNNING),
             // (8)
             Arguments.of(CloudTask.State.CANCELING, 100L, AsyncExecutionState.RUNNING),
             // (9)
-            Arguments.of(CloudTask.State.CANCELING, TimeUnit.SECONDS.toMillis(START_TIMEOUT) + 1, AsyncExecutionState.RUNNING)
+            Arguments.of(CloudTask.State.CANCELING, START_TIMEOUT.toMillis() + 1, AsyncExecutionState.RUNNING)
 // @formatter:on
         );
     }

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/StageAppStepTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/StageAppStepTest.java
@@ -3,6 +3,7 @@ package org.cloudfoundry.multiapps.controller.process.steps;
 import static org.mockito.ArgumentMatchers.any;
 
 import java.text.MessageFormat;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
@@ -81,7 +82,7 @@ class StageAppStepTest extends SyncFlowableStepTest<StageAppStep> {
 
     @Test
     void testGetTimeoutCustomValue() {
-        int timeout = 10;
+        var timeout = Duration.ofSeconds(10);
         context.setVariable(Variables.START_TIMEOUT, timeout);
         Assertions.assertEquals(timeout, step.getTimeout(context));
     }

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/TimeoutASyncFlowableStepWithHooksStepTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/TimeoutASyncFlowableStepWithHooksStepTest.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.multiapps.controller.process.steps;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
@@ -80,8 +81,8 @@ class TimeoutASyncFlowableStepWithHooksStepTest extends SyncFlowableStepTest<Tim
         }
 
         @Override
-        public Integer getTimeout(ProcessContext context) {
-            return 1;
+        public Duration getTimeout(ProcessContext context) {
+            return Duration.ofSeconds(1);
         }
 
         @Override

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/UploadAppStepTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/UploadAppStepTest.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.multiapps.controller.process.steps;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Duration;
 import java.util.Map;
 
 import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudApplicationExtended;
@@ -49,8 +50,9 @@ public class UploadAppStepTest {
         private void testGetTimeout(CloudApplicationExtended app, int expectedUploadTimeout) {
             context.setVariable(Variables.APP_TO_PROCESS, app);
 
-            int uploadTimeout = step.getTimeout(context);
-            assertEquals(expectedUploadTimeout, uploadTimeout);
+            var expectedTimeout = Duration.ofSeconds(expectedUploadTimeout);
+            var actualTimeout = step.getTimeout(context);
+            assertEquals(expectedTimeout, actualTimeout);
         }
 
         @Override

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/ValidateDeployParametersStepTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/ValidateDeployParametersStepTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.cert.X509Certificate;
 import java.text.MessageFormat;
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -183,14 +184,14 @@ class ValidateDeployParametersStepTest extends SyncFlowableStepTest<ValidateDepl
 
         private final String appArchiveId;
         private final String extDescriptorId;
-        private final int startTimeout;
+        private final Duration startTimeout;
         private final String versionRule;
         private final boolean shouldVerifyArchive;
 
         public StepInput(String appArchiveId, String extDescriptorId, int startTimeout, String versionRule, boolean shouldVerifyArchive) {
             this.appArchiveId = appArchiveId;
             this.extDescriptorId = extDescriptorId;
-            this.startTimeout = startTimeout;
+            this.startTimeout = Duration.ofSeconds(startTimeout);
             this.versionRule = versionRule;
             this.shouldVerifyArchive = shouldVerifyArchive;
         }


### PR DESCRIPTION
#### Description: 

Change `getTimeout` method to return Duration instead of a simple integer.
This will prevent time unit inconsistencies.
