### PR TITLE
Add backwards-compatibility for variable "startTimeout" & fix parameter conversion error on process start

### DIFF
--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/metadata/parameters/StartTimeoutParameterConverter.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/metadata/parameters/StartTimeoutParameterConverter.java
@@ -1,19 +1,27 @@
 package org.cloudfoundry.multiapps.controller.process.metadata.parameters;
 
 import org.cloudfoundry.multiapps.common.SLException;
-import org.cloudfoundry.multiapps.controller.api.model.parameters.IntegerParameterConverter;
+import org.cloudfoundry.multiapps.controller.api.model.parameters.ParameterConverter;
 import org.cloudfoundry.multiapps.controller.process.Messages;
 import org.cloudfoundry.multiapps.controller.process.variables.Variables;
 
-public class StartTimeoutParameterConverter extends IntegerParameterConverter {
+import java.text.MessageFormat;
+import java.time.Duration;
+
+public class StartTimeoutParameterConverter implements ParameterConverter {
 
     @Override
-    public Integer convert(Object value) {
-        int startTimeout = super.convert(value);
-        if (startTimeout < 0) {
-            throw new SLException(Messages.ERROR_PARAMETER_1_MUST_NOT_BE_NEGATIVE, startTimeout, Variables.START_TIMEOUT.getName());
+    public Duration convert(Object value) {
+        int startTimeoutInSeconds;
+        try {
+            startTimeoutInSeconds = Integer.parseInt(String.valueOf(value));
+        } catch (NumberFormatException e) {
+            throw new SLException(e, MessageFormat.format("Parameter value is not integer {0}", value));
         }
-        return startTimeout;
+        if (startTimeoutInSeconds < 0) {
+            throw new SLException(Messages.ERROR_PARAMETER_1_MUST_NOT_BE_NEGATIVE, startTimeoutInSeconds, Variables.START_TIMEOUT.getName());
+        }
+        return Duration.ofSeconds(startTimeoutInSeconds);
     }
 
 }

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/variables/Variables.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/variables/Variables.java
@@ -128,10 +128,42 @@ public interface Variables {
     Variable<Integer> MTA_MAJOR_SCHEMA_VERSION = ImmutableSimpleVariable.<Integer> builder()
                                                                         .name("mtaMajorSchemaVersion")
                                                                         .build();
-    Variable<Duration> START_TIMEOUT = ImmutableSimpleVariable.<Duration> builder()
-                                                              .name("startTimeout")
-                                                              .defaultValue(Duration.ofMinutes(15))
-                                                              .build();
+    //TODO: change to ImmutableSimpleVariable.<Duration> builder()
+    //                                       .name("startTimeout")
+    //                                       .defaultValue(Duration.ofMinutes(15))
+    //                                       .build();
+    // in next tact
+    Variable<Duration> START_TIMEOUT = new Variable<>() {
+        @Override
+        public String getName() {
+            return "startTimeout";
+        }
+
+        @Override
+        public Duration getDefaultValue() {
+            return Duration.ofMinutes(15);
+        }
+
+        @Override
+        public Serializer<Duration> getSerializer() {
+            return new Serializer<>() {
+
+                @Override
+                public Object serialize(Duration object) {
+                    return object;
+                }
+
+                @Override
+                public Duration deserialize(Object serializedObject) {
+                    if (serializedObject instanceof Integer) {
+                        return Duration.ofSeconds((Integer) serializedObject);
+                    }
+                    return (Duration) serializedObject;
+                }
+            };
+        }
+    };
+
     Variable<Integer> UPDATED_SERVICE_BROKER_SUBSCRIBERS_COUNT = ImmutableSimpleVariable.<Integer> builder()
                                                                                         .name("updatedServiceBrokerSubscribersCount")
                                                                                         .build();

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/metadata/parameters/StartTimeoutParameterConverterTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/metadata/parameters/StartTimeoutParameterConverterTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.cloudfoundry.multiapps.common.SLException;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+
 class StartTimeoutParameterConverterTest {
 
     @Test
@@ -20,8 +22,9 @@ class StartTimeoutParameterConverterTest {
 
     @Test
     void testConvert() {
-        int startTimeout = (int) new StartTimeoutParameterConverter().convert("1000");
-        assertEquals(1000, startTimeout);
+        var expectedStartTimeout = Duration.ofSeconds(1000);
+        var actualStartTimeout = new StartTimeoutParameterConverter().convert("1000");
+        assertEquals(expectedStartTimeout, actualStartTimeout);
     }
 
 }


### PR DESCRIPTION
#### Description: 
Fix parameter conversion error of process parameter "startTimeout"
Add temporary backwards-compatibility for process variable "startTimeout"

