### PR TITLE
Cancel long running tasks

### DIFF
--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executors/CancelExpiredTasksThread.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executors/CancelExpiredTasksThread.java
@@ -1,0 +1,63 @@
+package org.cloudfoundry.multiapps.controller.process.executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+
+public class CancelExpiredTasksThread extends Thread {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CancelExpiredTasksThread.class);
+    private Map<Future<?>, Long> tasksWithStartTime = new ConcurrentHashMap<>();
+    private static volatile boolean isActive = true;
+    private long cancelWaitTimeInMillis;
+    private long cancelTimeoutInMillis;
+
+    public CancelExpiredTasksThread(long cancelTimeoutInMillis, long cancelWaitTimeInMillis) {
+        this.cancelTimeoutInMillis = cancelTimeoutInMillis;
+        this.cancelWaitTimeInMillis = cancelWaitTimeInMillis;
+    }
+
+    @Override
+    public void run() {
+        try {
+            while (isActive) {
+                removeDoneTasks();
+                cancelTimeoutTasks();
+                Thread.sleep(cancelWaitTimeInMillis);
+            }
+        } catch (InterruptedException e) {
+            LOGGER.error(e.getMessage(), e);
+            Thread.currentThread()
+                    .interrupt();
+        }
+    }
+
+    public void addTask(Future<?> task) {
+        tasksWithStartTime.put(task, System.currentTimeMillis());
+    }
+
+    public void shutdown() {
+        isActive = false;
+    }
+
+    private void removeDoneTasks() {
+        tasksWithStartTime.keySet()
+                      .removeIf(Future::isDone);
+    }
+
+    private void cancelTimeoutTasks() {
+        long now = System.currentTimeMillis();
+        tasksWithStartTime.forEach((task, startTime) -> {
+            if (shouldBeCanceled(startTime, now)) {
+                task.cancel(true);
+            }
+        });
+    }
+
+    private boolean shouldBeCanceled(long startTime, long now) {
+        return startTime + cancelTimeoutInMillis <= now;
+    }
+}

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executors/TimeoutAsyncJobExecutor.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executors/TimeoutAsyncJobExecutor.java
@@ -1,0 +1,13 @@
+package org.cloudfoundry.multiapps.controller.process.executors;
+
+import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
+
+public class TimeoutAsyncJobExecutor extends DefaultAsyncJobExecutor {
+
+    @Override
+    protected void initAsyncJobExecutionThreadPool() {
+        TimeoutAsyncTaskExecutor taskExecutor = (TimeoutAsyncTaskExecutor) this.taskExecutor;
+        taskExecutor.start();
+        shutdownTaskExecutor = true;
+    }
+}

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executors/TimeoutAsyncTaskExecutor.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/executors/TimeoutAsyncTaskExecutor.java
@@ -1,0 +1,31 @@
+package org.cloudfoundry.multiapps.controller.process.executors;
+
+import org.flowable.common.engine.impl.async.DefaultAsyncTaskExecutor;
+
+import java.util.concurrent.Future;
+
+public class TimeoutAsyncTaskExecutor extends DefaultAsyncTaskExecutor {
+    private final CancelExpiredTasksThread cancelExpiredTasksThread;
+
+    public TimeoutAsyncTaskExecutor(long timeoutInMillis, long waitTimeInMillis) {
+        cancelExpiredTasksThread = new CancelExpiredTasksThread(timeoutInMillis, waitTimeInMillis);
+    }
+
+    @Override
+    public void execute(Runnable task) {
+        Future<?> f = executorService.submit(task);
+        cancelExpiredTasksThread.addTask(f);
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        cancelExpiredTasksThread.start();
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        cancelExpiredTasksThread.shutdown();
+    }
+}


### PR DESCRIPTION
Implement custom AsyncTaskExecutor, which has a running thread, keeping
track of running task. Use that to cancel task, which are running too
long and can exceed expiration time.
JIRA: LMCROSSITXSADEPLOY-2327

Continuation of https://github.com/cloudfoundry-incubator/multiapps-controller/pull/1064