### PR TITLE
setting jdbc property for rapid recovery

### DIFF
--- a/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/util/DataSourceFactory.java
+++ b/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/util/DataSourceFactory.java
@@ -27,6 +27,7 @@ public class DataSourceFactory {
         hikariConfig.setConnectionTimeout(60000);
         hikariConfig.setIdleTimeout(60000);
         hikariConfig.setMinimumIdle(10);
+        hikariConfig.addDataSourceProperty("tcpKeepAlive", true);
         if (maximumPoolSize != null) {
             hikariConfig.setMaximumPoolSize(maximumPoolSize);
         }


### PR DESCRIPTION
#### Description: 
Adding 'tcpKeepAlive' configuration to help db rapid recovery. This invokes 'isAlive' method when fetching connections.

#### Issue: LMCROSSITXSADEPLOY-2434

