### PR TITLE
Rectify and rename usages of 'stack' variable to 'stackName'

### DIFF
--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
@@ -20,7 +20,7 @@ public class StagingParametersParser implements ParametersParser<Staging> {
         String command = (String) PropertiesUtil.getPropertyValue(parametersList, SupportedParameters.COMMAND, null);
         List<String> buildpacks = PropertiesUtil.getPluralOrSingular(parametersList, SupportedParameters.BUILDPACKS,
                                                                      SupportedParameters.BUILDPACK);
-        String stack = (String) PropertiesUtil.getPropertyValue(parametersList, SupportedParameters.STACK, null);
+        String stackName = (String) PropertiesUtil.getPropertyValue(parametersList, SupportedParameters.STACK, null);
         Integer healthCheckTimeout = (Integer) PropertiesUtil.getPropertyValue(parametersList, SupportedParameters.HEALTH_CHECK_TIMEOUT,
                                                                                null);
         Integer healthCheckInvocationTimeout = (Integer) PropertiesUtil.getPropertyValue(parametersList,
@@ -35,7 +35,7 @@ public class StagingParametersParser implements ParametersParser<Staging> {
         return ImmutableStaging.builder()
                                .command(command)
                                .buildpacks(buildpacks)
-                               .stack(stack)
+                               .stackName(stackName)
                                .healthCheckTimeout(healthCheckTimeout)
                                .invocationTimeout(healthCheckInvocationTimeout)
                                .healthCheckType(healthCheckType)

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/StagingApplicationAttributeUpdater.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/StagingApplicationAttributeUpdater.java
@@ -25,7 +25,7 @@ public class StagingApplicationAttributeUpdater extends ApplicationAttributeUpda
     private boolean hasStagingChanged(Staging staging, Staging existingStaging) {
         List<String> buildpacks = staging.getBuildpacks();
         String command = staging.getCommand();
-        String stack = staging.getStack();
+        String stackName = staging.getStackName();
         Integer healthCheckTimeout = staging.getHealthCheckTimeout();
         Integer healthCheckInvocationTimeout = staging.getInvocationTimeout();
         String healthCheckType = staging.getHealthCheckType();
@@ -33,7 +33,7 @@ public class StagingApplicationAttributeUpdater extends ApplicationAttributeUpda
         Boolean sshEnabled = staging.isSshEnabled();
         return (buildpacks != null && !buildpacks.equals(existingStaging.getBuildpacks()))
             || (command != null && !command.equals(existingStaging.getCommand()))
-            || (stack != null && !stack.equals(existingStaging.getStack()))
+            || (stackName != null && !stackName.equals(existingStaging.getStackName()))
             || (healthCheckTimeout != null && !healthCheckTimeout.equals(existingStaging.getHealthCheckTimeout()))
             || (healthCheckType != null && !healthCheckType.equals(existingStaging.getHealthCheckType()))
             || (healthCheckInvocationTimeout != null && !healthCheckInvocationTimeout.equals(existingStaging.getInvocationTimeout()))

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateStepWithExistingAppTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateStepWithExistingAppTest.java
@@ -38,29 +38,29 @@ import com.sap.cloudfoundry.client.facade.util.JsonUtil;
 
 class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<CreateOrUpdateAppStep> {
 
-	private static final String APP_DIGEST = "12345";
-	private static final String APP_NAME_ENV_KEY = "APP_NAME";
-	private static final String APP_NAME = "test-application";
+    private static final String APP_DIGEST = "12345";
+    private static final String APP_NAME_ENV_KEY = "APP_NAME";
+    private static final String APP_NAME = "test-application";
 
-	static Stream<Arguments> testHandleStagingApplicationAttributes() {
-		return Stream.of(
+    static Stream<Arguments> testHandleStagingApplicationAttributes() {
+        return Stream.of(
 //@formatter:off
 				Arguments.of(ImmutableStaging.builder().addBuildpack("buildpack-1").command("command1").build(),
 						ImmutableStaging.builder().addBuildpack("buildpack-1").command("command2").build(), true),
 				Arguments.of(ImmutableStaging.builder().addBuildpack("buildpack-1").build(),
 						ImmutableStaging.builder().addBuildpack("buildpack-1").build(), false),
 				Arguments.of(
-						ImmutableStaging.builder().addBuildpack("buildpack-1").command("command1").stack("stack1")
+						ImmutableStaging.builder().addBuildpack("buildpack-1").command("command1").stackName("stack1")
 								.healthCheckTimeout(5).healthCheckType("process").isSshEnabled(false).build(),
-						ImmutableStaging.builder().addBuildpack("buildpack-2").command("command2").stack("stack2")
+						ImmutableStaging.builder().addBuildpack("buildpack-2").command("command2").stackName("stack2")
 								.healthCheckTimeout(10).healthCheckType("web").healthCheckHttpEndpoint("/test")
 								.isSshEnabled(true).build(),
 						true),
 				Arguments.of(
-						ImmutableStaging.builder().addBuildpack("buildpack-2").command("command2").stack("stack2")
+						ImmutableStaging.builder().addBuildpack("buildpack-2").command("command2").stackName("stack2")
 								.healthCheckTimeout(10).healthCheckType("web").healthCheckHttpEndpoint("/test")
 								.isSshEnabled(true).build(),
-						ImmutableStaging.builder().addBuildpack("buildpack-2").command("command2").stack("stack2")
+						ImmutableStaging.builder().addBuildpack("buildpack-2").command("command2").stackName("stack2")
 								.healthCheckTimeout(10).healthCheckType("web").healthCheckHttpEndpoint("/test")
 								.isSshEnabled(true).build(),
 						false),
@@ -77,226 +77,240 @@ class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<CreateO
 								.build(),
 						false));
 //@formatter:on
-	}
+    }
 
-	@ParameterizedTest
-	@MethodSource
-	void testHandleStagingApplicationAttributes(Staging existingStaging, Staging staging,
-			boolean expectedPropertiesChanged) {
-		CloudApplication existingApplication = getApplicationBuilder(false).staging(existingStaging).build();
-		CloudApplicationExtended application = getApplicationBuilder(false).staging(staging).build();
-		prepareContext(application, false);
-		prepareClient(existingApplication);
+    @ParameterizedTest
+    @MethodSource
+    void testHandleStagingApplicationAttributes(Staging existingStaging, Staging staging, boolean expectedPropertiesChanged) {
+        CloudApplication existingApplication = getApplicationBuilder(false).staging(existingStaging)
+                                                                           .build();
+        CloudApplicationExtended application = getApplicationBuilder(false).staging(staging)
+                                                                           .build();
+        prepareContext(application, false);
+        prepareClient(existingApplication);
 
-		step.execute(execution);
+        step.execute(execution);
 
-		assertStepFinishedSuccessfully();
-		assertEquals(expectedPropertiesChanged, context.getVariable(Variables.VCAP_APP_PROPERTIES_CHANGED));
-		if (expectedPropertiesChanged) {
-			verify(client).updateApplicationStaging(APP_NAME, staging);
-			return;
-		}
-		verify(client, never()).updateApplicationStaging(eq(APP_NAME), any());
-	}
+        assertStepFinishedSuccessfully();
+        assertEquals(expectedPropertiesChanged, context.getVariable(Variables.VCAP_APP_PROPERTIES_CHANGED));
+        if (expectedPropertiesChanged) {
+            verify(client).updateApplicationStaging(APP_NAME, staging);
+            return;
+        }
+        verify(client, never()).updateApplicationStaging(eq(APP_NAME), any());
+    }
 
-	private ImmutableCloudApplicationExtended.Builder getApplicationBuilder(boolean shouldKeepExistingEnv) {
-		return ImmutableCloudApplicationExtended.builder().name(APP_NAME).staging(ImmutableStaging.builder().build())
-				.attributesUpdateStrategy(ImmutableCloudApplicationExtended.AttributeUpdateStrategy.builder()
-						.shouldKeepExistingEnv(shouldKeepExistingEnv).build());
-	}
+    private ImmutableCloudApplicationExtended.Builder getApplicationBuilder(boolean shouldKeepExistingEnv) {
+        return ImmutableCloudApplicationExtended.builder()
+                                                .name(APP_NAME)
+                                                .staging(ImmutableStaging.builder()
+                                                                         .build())
+                                                .attributesUpdateStrategy(ImmutableCloudApplicationExtended.AttributeUpdateStrategy.builder()
+                                                                                                                                   .shouldKeepExistingEnv(shouldKeepExistingEnv)
+                                                                                                                                   .build());
+    }
 
-	private void prepareContext(CloudApplicationExtended application, boolean shouldSkipServiceRebinding) {
-		context.setVariable(Variables.APP_TO_PROCESS, application);
-		context.setVariable(Variables.SERVICE_KEYS_CREDENTIALS_TO_INJECT, Collections.emptyMap());
-		context.setVariable(Variables.SHOULD_SKIP_SERVICE_REBINDING, shouldSkipServiceRebinding);
-	}
+    private void prepareContext(CloudApplicationExtended application, boolean shouldSkipServiceRebinding) {
+        context.setVariable(Variables.APP_TO_PROCESS, application);
+        context.setVariable(Variables.SERVICE_KEYS_CREDENTIALS_TO_INJECT, Collections.emptyMap());
+        context.setVariable(Variables.SHOULD_SKIP_SERVICE_REBINDING, shouldSkipServiceRebinding);
+    }
 
-	private void prepareClient(CloudApplication application) {
-		when(client.getApplication(APP_NAME, false)).thenReturn(application);
-	}
+    private void prepareClient(CloudApplication application) {
+        when(client.getApplication(APP_NAME, false)).thenReturn(application);
+    }
 
-	static Stream<Arguments> testHandleMemoryApplicationAttributes() {
-		return Stream.of(Arguments.of(128, 256, true), Arguments.of(512, 128, true), Arguments.of(1024, 0, false),
-				Arguments.of(1024, 1024, false));
-	}
+    static Stream<Arguments> testHandleMemoryApplicationAttributes() {
+        return Stream.of(Arguments.of(128, 256, true), Arguments.of(512, 128, true), Arguments.of(1024, 0, false),
+                         Arguments.of(1024, 1024, false));
+    }
 
-	@ParameterizedTest
-	@MethodSource
-	void testHandleMemoryApplicationAttributes(int existingMemorySize, int memorySize,
-			boolean expectedPropertiesChanged) {
-		CloudApplication existingApplication = getApplicationBuilder(false).memory(existingMemorySize).build();
-		CloudApplicationExtended application = getApplicationBuilder(false).memory(memorySize).build();
-		prepareContext(application, false);
-		prepareClient(existingApplication);
+    @ParameterizedTest
+    @MethodSource
+    void testHandleMemoryApplicationAttributes(int existingMemorySize, int memorySize, boolean expectedPropertiesChanged) {
+        CloudApplication existingApplication = getApplicationBuilder(false).memory(existingMemorySize)
+                                                                           .build();
+        CloudApplicationExtended application = getApplicationBuilder(false).memory(memorySize)
+                                                                           .build();
+        prepareContext(application, false);
+        prepareClient(existingApplication);
 
-		step.execute(execution);
+        step.execute(execution);
 
-		assertStepFinishedSuccessfully();
-		assertEquals(expectedPropertiesChanged, context.getVariable(Variables.VCAP_APP_PROPERTIES_CHANGED));
-		if (expectedPropertiesChanged) {
-			verify(client).updateApplicationMemory(APP_NAME, memorySize);
-			return;
-		}
-		verify(client, never()).updateApplicationMemory(eq(APP_NAME), anyInt());
-	}
+        assertStepFinishedSuccessfully();
+        assertEquals(expectedPropertiesChanged, context.getVariable(Variables.VCAP_APP_PROPERTIES_CHANGED));
+        if (expectedPropertiesChanged) {
+            verify(client).updateApplicationMemory(APP_NAME, memorySize);
+            return;
+        }
+        verify(client, never()).updateApplicationMemory(eq(APP_NAME), anyInt());
+    }
 
-	static Stream<Arguments> testHandleDiskQuotaApplicationAttributes() {
-		return Stream.of(Arguments.of(128, 256, true), Arguments.of(512, 128, true), Arguments.of(1024, 0, false),
-				Arguments.of(1024, 1024, false));
-	}
+    static Stream<Arguments> testHandleDiskQuotaApplicationAttributes() {
+        return Stream.of(Arguments.of(128, 256, true), Arguments.of(512, 128, true), Arguments.of(1024, 0, false),
+                         Arguments.of(1024, 1024, false));
+    }
 
-	@ParameterizedTest
-	@MethodSource
-	void testHandleDiskQuotaApplicationAttributes(int existingDiskQuotaSize, int diskQuotaSize,
-			boolean expectedPropertiesChanged) {
-		CloudApplication existingApplication = getApplicationBuilder(false).diskQuota(existingDiskQuotaSize).build();
-		CloudApplicationExtended application = getApplicationBuilder(false).diskQuota(diskQuotaSize).build();
-		prepareContext(application, false);
-		prepareClient(existingApplication);
+    @ParameterizedTest
+    @MethodSource
+    void testHandleDiskQuotaApplicationAttributes(int existingDiskQuotaSize, int diskQuotaSize, boolean expectedPropertiesChanged) {
+        CloudApplication existingApplication = getApplicationBuilder(false).diskQuota(existingDiskQuotaSize)
+                                                                           .build();
+        CloudApplicationExtended application = getApplicationBuilder(false).diskQuota(diskQuotaSize)
+                                                                           .build();
+        prepareContext(application, false);
+        prepareClient(existingApplication);
 
-		step.execute(execution);
+        step.execute(execution);
 
-		assertStepFinishedSuccessfully();
-		assertEquals(expectedPropertiesChanged, context.getVariable(Variables.VCAP_APP_PROPERTIES_CHANGED));
-		if (expectedPropertiesChanged) {
-			verify(client).updateApplicationDiskQuota(APP_NAME, diskQuotaSize);
-			return;
-		}
-		verify(client, never()).updateApplicationDiskQuota(eq(APP_NAME), anyInt());
-	}
+        assertStepFinishedSuccessfully();
+        assertEquals(expectedPropertiesChanged, context.getVariable(Variables.VCAP_APP_PROPERTIES_CHANGED));
+        if (expectedPropertiesChanged) {
+            verify(client).updateApplicationDiskQuota(APP_NAME, diskQuotaSize);
+            return;
+        }
+        verify(client, never()).updateApplicationDiskQuota(eq(APP_NAME), anyInt());
+    }
 
-	static Stream<Arguments> testHandleRoutesApplicationAttributes() {
-		return Stream.of(Arguments.of(Collections.emptySet(), constructRoutes("example.com"), true),
-				Arguments.of(constructRoutes("example.com"), Collections.emptySet(), true),
-				Arguments.of(constructRoutes("example.com"), constructRoutes("example.com", "example1.com"), true),
-				Arguments.of(constructRoutes("example.com"), constructRoutes("example.com"), false));
-	}
+    static Stream<Arguments> testHandleRoutesApplicationAttributes() {
+        return Stream.of(Arguments.of(Collections.emptySet(), constructRoutes("example.com"), true),
+                         Arguments.of(constructRoutes("example.com"), Collections.emptySet(), true),
+                         Arguments.of(constructRoutes("example.com"), constructRoutes("example.com", "example1.com"), true),
+                         Arguments.of(constructRoutes("example.com"), constructRoutes("example.com"), false));
+    }
 
-	@ParameterizedTest
-	@MethodSource
-	void testHandleRoutesApplicationAttributes(Set<CloudRouteSummary> existingRoutes, Set<CloudRouteSummary> routes,
-			boolean expectedPropertiesChanged) {
-		CloudApplication existingApplication = getApplicationBuilder(false).routes(existingRoutes).build();
-		CloudApplicationExtended application = getApplicationBuilder(false).routes(routes).build();
-		prepareContext(application, false);
-		prepareClient(existingApplication);
+    @ParameterizedTest
+    @MethodSource
+    void testHandleRoutesApplicationAttributes(Set<CloudRouteSummary> existingRoutes, Set<CloudRouteSummary> routes,
+                                               boolean expectedPropertiesChanged) {
+        CloudApplication existingApplication = getApplicationBuilder(false).routes(existingRoutes)
+                                                                           .build();
+        CloudApplicationExtended application = getApplicationBuilder(false).routes(routes)
+                                                                           .build();
+        prepareContext(application, false);
+        prepareClient(existingApplication);
 
-		step.execute(execution);
+        step.execute(execution);
 
-		assertStepFinishedSuccessfully();
-		assertEquals(expectedPropertiesChanged, context.getVariable(Variables.VCAP_APP_PROPERTIES_CHANGED));
-		if (expectedPropertiesChanged) {
-			verify(client).updateApplicationRoutes(APP_NAME, routes);
-			return;
-		}
-		verify(client, never()).updateApplicationRoutes(eq(APP_NAME), anySet());
-	}
+        assertStepFinishedSuccessfully();
+        assertEquals(expectedPropertiesChanged, context.getVariable(Variables.VCAP_APP_PROPERTIES_CHANGED));
+        if (expectedPropertiesChanged) {
+            verify(client).updateApplicationRoutes(APP_NAME, routes);
+            return;
+        }
+        verify(client, never()).updateApplicationRoutes(eq(APP_NAME), anySet());
+    }
 
-	private static Set<CloudRouteSummary> constructRoutes(String... uriStrings) {
-		return Stream.of(uriStrings).map(uri -> new ApplicationURI(uri, false).toCloudRouteSummary())
-				.collect(Collectors.toSet());
-	}
+    private static Set<CloudRouteSummary> constructRoutes(String... uriStrings) {
+        return Stream.of(uriStrings)
+                     .map(uri -> new ApplicationURI(uri, false).toCloudRouteSummary())
+                     .collect(Collectors.toSet());
+    }
 
-	static Stream<Arguments> testHandleApplicationServices() {
-		return Stream.of(
-				Arguments.of(List.of("service-1"), List.of("service-1", "service-2"), false,
-						List.of("service-1", "service-2")),
-				Arguments.of(Collections.emptyList(), List.of("service-1"), false, List.of("service-1")),
-				Arguments.of(List.of("service-1", "service-2"), Collections.emptyList(), true, null),
-				Arguments.of(List.of("service-1"), List.of("service-2"), false, List.of("service-1", "service-2")),
-				Arguments.of(List.of("service-1"), Collections.emptyList(), false, List.of("service-1")),
-				Arguments.of(Collections.emptyList(), List.of("service-1", "service-2"), true, null));
-	}
+    static Stream<Arguments> testHandleApplicationServices() {
+        return Stream.of(Arguments.of(List.of("service-1"), List.of("service-1", "service-2"), false, List.of("service-1", "service-2")),
+                         Arguments.of(Collections.emptyList(), List.of("service-1"), false, List.of("service-1")),
+                         Arguments.of(List.of("service-1", "service-2"), Collections.emptyList(), true, null),
+                         Arguments.of(List.of("service-1"), List.of("service-2"), false, List.of("service-1", "service-2")),
+                         Arguments.of(List.of("service-1"), Collections.emptyList(), false, List.of("service-1")),
+                         Arguments.of(Collections.emptyList(), List.of("service-1", "service-2"), true, null));
+    }
 
-	@ParameterizedTest
-	@MethodSource
-	void testHandleApplicationServices(List<String> existingServices, List<String> services,
-			boolean shouldSkipServiceRebinding, List<String> expectedServicestoUpdate) {
-		CloudApplication existingApplication = getApplicationBuilder(false).services(existingServices).build();
-		CloudApplicationExtended application = getApplicationBuilder(false).services(services).build();
-		prepareContext(application, shouldSkipServiceRebinding);
-		prepareClient(existingApplication);
+    @ParameterizedTest
+    @MethodSource
+    void testHandleApplicationServices(List<String> existingServices, List<String> services, boolean shouldSkipServiceRebinding,
+                                       List<String> expectedServicestoUpdate) {
+        CloudApplication existingApplication = getApplicationBuilder(false).services(existingServices)
+                                                                           .build();
+        CloudApplicationExtended application = getApplicationBuilder(false).services(services)
+                                                                           .build();
+        prepareContext(application, shouldSkipServiceRebinding);
+        prepareClient(existingApplication);
 
-		step.execute(execution);
+        step.execute(execution);
 
-		assertStepFinishedSuccessfully();
-		if (shouldSkipServiceRebinding) {
-			assertTrue(context.getVariable(Variables.SERVICES_TO_UNBIND_BIND).isEmpty());
-			return;
-		}
-		assertTrue(expectedServicestoUpdate.containsAll(context.getVariable(Variables.SERVICES_TO_UNBIND_BIND)));
-	}
+        assertStepFinishedSuccessfully();
+        if (shouldSkipServiceRebinding) {
+            assertTrue(context.getVariable(Variables.SERVICES_TO_UNBIND_BIND)
+                              .isEmpty());
+            return;
+        }
+        assertTrue(expectedServicestoUpdate.containsAll(context.getVariable(Variables.SERVICES_TO_UNBIND_BIND)));
+    }
 
-	static Stream<Arguments> testHandleApplicationEnv() {
-		return Stream.of(Arguments.of(Map.of("foo", "bar"), Map.of("foo1", "bar2"), true, true),
-				Arguments.of(Map.of("foo", "bar"), Map.of("foo1", "bar2"), false, true),
-				Arguments.of(Map.of("foo", "bar"), Map.of("foo", "bar"), true, false),
-				Arguments.of(Map.of("foo", "bar"), Map.of("foo", "bar"), false, false));
-	}
+    static Stream<Arguments> testHandleApplicationEnv() {
+        return Stream.of(Arguments.of(Map.of("foo", "bar"), Map.of("foo1", "bar2"), true, true),
+                         Arguments.of(Map.of("foo", "bar"), Map.of("foo1", "bar2"), false, true),
+                         Arguments.of(Map.of("foo", "bar"), Map.of("foo", "bar"), true, false),
+                         Arguments.of(Map.of("foo", "bar"), Map.of("foo", "bar"), false, false));
+    }
 
-	@ParameterizedTest
-	@MethodSource
-	void testHandleApplicationEnv(Map<String, String> existingAppEnv, Map<String, String> newAppEnv,
-			boolean keepExistingEnv, boolean expectedUserPropertiesChanged) {
-		CloudApplication existingApplication = getApplicationBuilder(keepExistingEnv).env(existingAppEnv).build();
-		CloudApplicationExtended application = getApplicationBuilder(keepExistingEnv).env(newAppEnv).build();
-		prepareContext(application, false);
-		prepareClient(existingApplication);
+    @ParameterizedTest
+    @MethodSource
+    void testHandleApplicationEnv(Map<String, String> existingAppEnv, Map<String, String> newAppEnv, boolean keepExistingEnv,
+                                  boolean expectedUserPropertiesChanged) {
+        CloudApplication existingApplication = getApplicationBuilder(keepExistingEnv).env(existingAppEnv)
+                                                                                     .build();
+        CloudApplicationExtended application = getApplicationBuilder(keepExistingEnv).env(newAppEnv)
+                                                                                     .build();
+        prepareContext(application, false);
+        prepareClient(existingApplication);
 
-		step.shouldPrettyPrint = () -> false;
-		step.execute(execution);
+        step.shouldPrettyPrint = () -> false;
+        step.execute(execution);
 
-		assertStepFinishedSuccessfully();
-		assertEquals(expectedUserPropertiesChanged, context.getVariable(Variables.USER_PROPERTIES_CHANGED));
-		if (expectedUserPropertiesChanged) {
-			Map<String, String> expectedEnvMap = buildExpectedEnvMap(existingAppEnv, newAppEnv, keepExistingEnv);
-			verify(client).updateApplicationEnv(eq(APP_NAME), eq(expectedEnvMap));
-			return;
-		}
-		verify(client, never()).updateApplicationEnv(eq(APP_NAME), anyMap());
-	}
+        assertStepFinishedSuccessfully();
+        assertEquals(expectedUserPropertiesChanged, context.getVariable(Variables.USER_PROPERTIES_CHANGED));
+        if (expectedUserPropertiesChanged) {
+            Map<String, String> expectedEnvMap = buildExpectedEnvMap(existingAppEnv, newAppEnv, keepExistingEnv);
+            verify(client).updateApplicationEnv(eq(APP_NAME), eq(expectedEnvMap));
+            return;
+        }
+        verify(client, never()).updateApplicationEnv(eq(APP_NAME), anyMap());
+    }
 
-	private Map<String, String> buildExpectedEnvMap(Map<String, String> existingAppEnv, Map<String, String> newAppEnv,
-			boolean keepExistingEnv) {
-		if (!keepExistingEnv) {
-			return newAppEnv;
-		}
-		Map<String, String> expectedEnvMap = new HashMap<>(existingAppEnv);
-		expectedEnvMap.putAll(newAppEnv);
-		return expectedEnvMap;
-	}
+    private Map<String, String> buildExpectedEnvMap(Map<String, String> existingAppEnv, Map<String, String> newAppEnv,
+                                                    boolean keepExistingEnv) {
+        if (!keepExistingEnv) {
+            return newAppEnv;
+        }
+        Map<String, String> expectedEnvMap = new HashMap<>(existingAppEnv);
+        expectedEnvMap.putAll(newAppEnv);
+        return expectedEnvMap;
+    }
 
-	@Test
-	void testAddExistingAppDigestToNewEnv() {
-		String applicationDigestJsonEnv = JsonUtil.convertToJson(Map.of(Constants.ATTR_APP_CONTENT_DIGEST, APP_DIGEST));
-		CloudApplication existingApplication = getApplicationBuilder(false)
-				.env(Map.of(Constants.ENV_DEPLOY_ATTRIBUTES, applicationDigestJsonEnv)).build();
-		Map<String, String> newApplicationEnv = Map.of(APP_NAME_ENV_KEY, APP_NAME);
-		CloudApplicationExtended application = getApplicationBuilder(false).env(newApplicationEnv).build();
-		prepareContext(application, false);
-		prepareClient(existingApplication);
+    @Test
+    void testAddExistingAppDigestToNewEnv() {
+        String applicationDigestJsonEnv = JsonUtil.convertToJson(Map.of(Constants.ATTR_APP_CONTENT_DIGEST, APP_DIGEST));
+        CloudApplication existingApplication = getApplicationBuilder(false).env(Map.of(Constants.ENV_DEPLOY_ATTRIBUTES,
+                                                                                       applicationDigestJsonEnv))
+                                                                           .build();
+        Map<String, String> newApplicationEnv = Map.of(APP_NAME_ENV_KEY, APP_NAME);
+        CloudApplicationExtended application = getApplicationBuilder(false).env(newApplicationEnv)
+                                                                           .build();
+        prepareContext(application, false);
+        prepareClient(existingApplication);
 
-		step.shouldPrettyPrint = () -> false;
-		step.execute(execution);
+        step.shouldPrettyPrint = () -> false;
+        step.execute(execution);
 
-		assertStepFinishedSuccessfully();
-		assertEquals(true, context.getVariable(Variables.USER_PROPERTIES_CHANGED));
+        assertStepFinishedSuccessfully();
+        assertEquals(true, context.getVariable(Variables.USER_PROPERTIES_CHANGED));
 
-		Map<String, String> expectedEnv = buildExpectedEnvWithDeployAttributes(newApplicationEnv,
-				applicationDigestJsonEnv);
-		verify(client).updateApplicationEnv(eq(APP_NAME), eq(expectedEnv));
-	}
+        Map<String, String> expectedEnv = buildExpectedEnvWithDeployAttributes(newApplicationEnv, applicationDigestJsonEnv);
+        verify(client).updateApplicationEnv(eq(APP_NAME), eq(expectedEnv));
+    }
 
-	private Map<String, String> buildExpectedEnvWithDeployAttributes(Map<String, String> newApplicationEnv,
-			String applicationDigestJsonEnv) {
-		Map<String, String> expectedEnvMap = new HashMap<>(newApplicationEnv);
-		expectedEnvMap.put(Constants.ENV_DEPLOY_ATTRIBUTES, applicationDigestJsonEnv);
-		return expectedEnvMap;
-	}
+    private Map<String, String> buildExpectedEnvWithDeployAttributes(Map<String, String> newApplicationEnv,
+                                                                     String applicationDigestJsonEnv) {
+        Map<String, String> expectedEnvMap = new HashMap<>(newApplicationEnv);
+        expectedEnvMap.put(Constants.ENV_DEPLOY_ATTRIBUTES, applicationDigestJsonEnv);
+        return expectedEnvMap;
+    }
 
-	@Override
-	protected CreateOrUpdateAppStep createStep() {
-		return new CreateOrUpdateAppStep();
-	}
+    @Override
+    protected CreateOrUpdateAppStep createStep() {
+        return new CreateOrUpdateAppStep();
+    }
 
 }


### PR DESCRIPTION
Description: 
This Pull Request contains changes for renaming the variable 'stack' -> 'stackName', 
because it leads to misunderstanding of what the variable refers to (the object stack or only its name).
Originally the variable 'stack' only referred to the name of Stack object.

Issue:
 Related issue: LMCROSSITXSADEPLOY-2284

