### PR TITLE
Add ordering by timestamp for HistoricOperationEvent

### DIFF
--- a/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/query/HistoricOperationEventQuery.java
+++ b/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/query/HistoricOperationEventQuery.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.multiapps.controller.persistence.query;
 
 import java.util.Date;
 
+import org.cloudfoundry.multiapps.controller.persistence.OrderDirection;
 import org.cloudfoundry.multiapps.controller.persistence.model.HistoricOperationEvent;
 
 public interface HistoricOperationEventQuery extends Query<HistoricOperationEvent, HistoricOperationEventQuery> {
@@ -13,5 +14,7 @@ public interface HistoricOperationEventQuery extends Query<HistoricOperationEven
     HistoricOperationEventQuery type(HistoricOperationEvent.EventType type);
 
     HistoricOperationEventQuery olderThan(Date time);
+
+    HistoricOperationEventQuery orderByTimestamp(OrderDirection orderDirection);
 
 }

--- a/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/query/impl/HistoricOperationEventQueryImpl.java
+++ b/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/query/impl/HistoricOperationEventQueryImpl.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
 
+import org.cloudfoundry.multiapps.controller.persistence.OrderDirection;
 import org.cloudfoundry.multiapps.controller.persistence.dto.HistoricOperationEventDto;
 import org.cloudfoundry.multiapps.controller.persistence.dto.HistoricOperationEventDto.AttributeNames;
 import org.cloudfoundry.multiapps.controller.persistence.model.HistoricOperationEvent;
@@ -84,6 +85,12 @@ public class HistoricOperationEventQueryImpl extends AbstractQueryImpl<HistoricO
     @Override
     public int delete() {
         return executeInTransaction(manager -> createDeleteQuery(manager, queryCriteria, HistoricOperationEventDto.class).executeUpdate());
+    }
+
+    @Override
+    public HistoricOperationEventQuery orderByTimestamp(OrderDirection orderDirection) {
+        setOrder(AttributeNames.TIMESTAMP, orderDirection);
+        return this;
     }
 
 }

--- a/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/services/HistoricOperationEventService.java
+++ b/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/services/HistoricOperationEventService.java
@@ -19,7 +19,7 @@ import org.cloudfoundry.multiapps.controller.persistence.query.impl.HistoricOper
 public class HistoricOperationEventService extends PersistenceService<HistoricOperationEvent, HistoricOperationEventDto, Long> {
 
     @Inject
-    private HistoricOperationEventMapper historicOperationEventMapper;
+    protected HistoricOperationEventMapper historicOperationEventMapper;
 
     @Inject
     public HistoricOperationEventService(EntityManagerFactory entityManagerFactory) {

--- a/multiapps-controller-persistence/src/test/java/org/cloudfoundry/multiapps/controller/persistence/services/HistoricOperationEventServiceTest.java
+++ b/multiapps-controller-persistence/src/test/java/org/cloudfoundry/multiapps/controller/persistence/services/HistoricOperationEventServiceTest.java
@@ -1,0 +1,176 @@
+package org.cloudfoundry.multiapps.controller.persistence.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.cloudfoundry.multiapps.common.ConflictException;
+import org.cloudfoundry.multiapps.common.NotFoundException;
+import org.cloudfoundry.multiapps.controller.persistence.OrderDirection;
+import org.cloudfoundry.multiapps.controller.persistence.model.HistoricOperationEvent;
+import org.cloudfoundry.multiapps.controller.persistence.model.HistoricOperationEvent.EventType;
+import org.cloudfoundry.multiapps.controller.persistence.model.ImmutableHistoricOperationEvent;
+import org.cloudfoundry.multiapps.controller.persistence.services.HistoricOperationEventService.HistoricOperationEventMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class HistoricOperationEventServiceTest {
+
+    private final HistoricOperationEventService historicOperationEventService = createHistoricOperationEventService();
+
+    private static final String PROCESS_ID = "processId_1";
+
+    private static final Date DATE_1 = Date.from(Instant.parse("2020-11-15T13:30:25.010Z"));
+    private static final Date DATE_2 = Date.from(Instant.parse("2020-11-15T13:30:25.020Z"));
+
+    private static final HistoricOperationEvent HISTORIC_OPERATION_1 = createHistoricOperationEvent(1, PROCESS_ID,
+                                                                                                    HistoricOperationEvent.EventType.STARTED,
+                                                                                                    DATE_1);
+    private static final HistoricOperationEvent HISTORIC_OPERATION_2 = createHistoricOperationEvent(2, PROCESS_ID,
+                                                                                                    HistoricOperationEvent.EventType.FINISHED,
+                                                                                                    DATE_2);
+    private static final HistoricOperationEvent HISTORIC_OPERATION_3 = createHistoricOperationEvent(3, "processId_2",
+                                                                                                    HistoricOperationEvent.EventType.STARTED,
+                                                                                                    DATE_2);
+
+    @AfterEach
+    void cleanUp() {
+        historicOperationEventService.createQuery()
+                                     .delete();
+    }
+
+    @Test
+    void testAdd() {
+        historicOperationEventService.add(HISTORIC_OPERATION_1);
+        List<HistoricOperationEvent> historicOperations = historicOperationEventService.createQuery()
+                                                                                       .list();
+        assertEquals(1, historicOperations.size());
+        verifyHistoricOperationsAreEqual(HISTORIC_OPERATION_1, historicOperations.get(0));
+    }
+
+    @Test
+    void testFindById() {
+        historicOperationEventService.add(HISTORIC_OPERATION_1);
+        verifyHistoricOperationsAreEqual(HISTORIC_OPERATION_1, historicOperationEventService.createQuery()
+                                                                                            .id(1L)
+                                                                                            .singleResult());
+    }
+
+    @Test
+    void testFindByType() {
+        historicOperationEventService.add(HISTORIC_OPERATION_1);
+        List<HistoricOperationEvent> historicOperations = historicOperationEventService.createQuery()
+                                                                                       .type(HistoricOperationEvent.EventType.STARTED)
+                                                                                       .list();
+        assertEquals(1, historicOperations.size());
+        verifyHistoricOperationsAreEqual(HISTORIC_OPERATION_1, historicOperations.get(0));
+    }
+
+    @Test
+    void testFindByProcessId() {
+        historicOperationEventService.add(HISTORIC_OPERATION_1);
+        historicOperationEventService.add(HISTORIC_OPERATION_2);
+        historicOperationEventService.add(HISTORIC_OPERATION_3);
+        List<HistoricOperationEvent> historicOperations = historicOperationEventService.createQuery()
+                                                                                       .processId(PROCESS_ID)
+                                                                                       .list();
+        assertEquals(2, historicOperations.size());
+        verifyHistoricOperationsAreEqual(HISTORIC_OPERATION_1, historicOperations.get(0));
+        verifyHistoricOperationsAreEqual(HISTORIC_OPERATION_2, historicOperations.get(1));
+    }
+
+    @Test
+    void testDeleteByProcessId() {
+        historicOperationEventService.add(HISTORIC_OPERATION_1);
+        historicOperationEventService.add(HISTORIC_OPERATION_2);
+        historicOperationEventService.add(HISTORIC_OPERATION_3);
+        assertEquals(2, historicOperationEventService.createQuery()
+                                                     .processId(PROCESS_ID)
+                                                     .delete());
+        List<HistoricOperationEvent> historicOperations = historicOperationEventService.createQuery()
+                                                                                       .list();
+        assertEquals(1, historicOperations.size());
+        verifyHistoricOperationsAreEqual(HISTORIC_OPERATION_3, historicOperations.get(0));
+    }
+
+    @Test
+    void testFindOlderThanOperations() {
+        historicOperationEventService.add(HISTORIC_OPERATION_1);
+        historicOperationEventService.add(HISTORIC_OPERATION_2);
+        historicOperationEventService.add(HISTORIC_OPERATION_3);
+        List<HistoricOperationEvent> historicOperations = historicOperationEventService.createQuery()
+                                                                                       .olderThan(DATE_2)
+                                                                                       .list();
+        assertEquals(1, historicOperations.size());
+        verifyHistoricOperationsAreEqual(HISTORIC_OPERATION_1, historicOperations.get(0));
+
+    }
+
+    @Test
+    void testOrderByTimestamp() {
+        historicOperationEventService.add(HISTORIC_OPERATION_1);
+        historicOperationEventService.add(HISTORIC_OPERATION_2);
+        List<HistoricOperationEvent> historicOperations = historicOperationEventService.createQuery()
+                                                                                       .orderByTimestamp(OrderDirection.ASCENDING)
+                                                                                       .list();
+        assertEquals(2, historicOperations.size());
+        verifyHistoricOperationsAreEqual(HISTORIC_OPERATION_1, historicOperations.get(0));
+        verifyHistoricOperationsAreEqual(HISTORIC_OPERATION_2, historicOperations.get(1));
+    }
+
+    @Test
+    void testOrderOlderTimestampWithHigherIndex() {
+        historicOperationEventService.add(HISTORIC_OPERATION_2);
+        HistoricOperationEvent olderHistoricOperationEvent = createHistoricOperationEvent(3, PROCESS_ID, EventType.STARTED,
+                                                                                          Date.from(Instant.parse("2020-11-15T13:30:24.010Z")));
+        historicOperationEventService.add(olderHistoricOperationEvent);
+        List<HistoricOperationEvent> historicOperations = historicOperationEventService.createQuery()
+                                                                                       .orderByTimestamp(OrderDirection.ASCENDING)
+                                                                                       .list();
+        assertEquals(2, historicOperations.size());
+        verifyHistoricOperationsAreEqual(olderHistoricOperationEvent, historicOperations.get(0));
+        verifyHistoricOperationsAreEqual(HISTORIC_OPERATION_2, historicOperations.get(1));
+    }
+
+    @Test
+    void testThrowExceptionOnConflictingEntity() {
+        historicOperationEventService.add(HISTORIC_OPERATION_1);
+        assertThrows(ConflictException.class, () -> historicOperationEventService.add(HISTORIC_OPERATION_1));
+    }
+
+    @Test
+    void testThrowExceptionOnEntityNotFound() {
+        assertThrows(NotFoundException.class, () -> historicOperationEventService.update(HISTORIC_OPERATION_1, HISTORIC_OPERATION_2));
+    }
+
+    private static ImmutableHistoricOperationEvent createHistoricOperationEvent(long id, String processId,
+                                                                                HistoricOperationEvent.EventType type, Date timeStamp) {
+        return ImmutableHistoricOperationEvent.builder()
+                                              .id(id)
+                                              .processId(processId)
+                                              .type(type)
+                                              .timestamp(timeStamp)
+                                              .build();
+    }
+
+    private HistoricOperationEventService createHistoricOperationEventService() {
+        EntityManagerFactory entityManagerFactory = Persistence.createEntityManagerFactory("TestDefault");
+        HistoricOperationEventService historicOperationEventService = new HistoricOperationEventService(entityManagerFactory);
+        historicOperationEventService.historicOperationEventMapper = new HistoricOperationEventMapper();
+        return historicOperationEventService;
+    }
+
+    private void verifyHistoricOperationsAreEqual(HistoricOperationEvent expectedOperationEvent,
+                                                  HistoricOperationEvent actualOperationEvent) {
+        assertEquals(expectedOperationEvent.getId(), actualOperationEvent.getId());
+        assertEquals(expectedOperationEvent.getType(), actualOperationEvent.getType());
+        assertEquals(expectedOperationEvent.getProcessId(), actualOperationEvent.getProcessId());
+        assertEquals(expectedOperationEvent.getTimestamp(), actualOperationEvent.getTimestamp());
+    }
+}

--- a/multiapps-controller-persistence/src/test/resources/META-INF/persistence.xml
+++ b/multiapps-controller-persistence/src/test/resources/META-INF/persistence.xml
@@ -8,6 +8,7 @@
         <class>org.cloudfoundry.multiapps.controller.persistence.dto.ConfigurationSubscriptionDto</class>
         <class>org.cloudfoundry.multiapps.controller.persistence.dto.OperationDto</class>
         <class>org.cloudfoundry.multiapps.controller.persistence.dto.ConfigurationEntryDto</class>
+        <class>org.cloudfoundry.multiapps.controller.persistence.dto.HistoricOperationEventDto</class>
         <class>org.cloudfoundry.multiapps.controller.persistence.dto.ProgressMessageDto</class>
         <class>org.cloudfoundry.multiapps.controller.dto.persistence.HistoricOperationEventDto</class>
         <class>org.cloudfoundry.multiapps.controller.persistence.dto.AccessTokenDto</class>

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/ProcessHelper.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/ProcessHelper.java
@@ -8,6 +8,7 @@ import javax.inject.Named;
 
 import org.cloudfoundry.multiapps.controller.api.model.Operation;
 import org.cloudfoundry.multiapps.controller.api.model.Operation.State;
+import org.cloudfoundry.multiapps.controller.persistence.OrderDirection;
 import org.cloudfoundry.multiapps.controller.persistence.model.HistoricOperationEvent;
 import org.cloudfoundry.multiapps.controller.persistence.services.HistoricOperationEventService;
 import org.cloudfoundry.multiapps.controller.process.flowable.FlowableFacade;
@@ -57,6 +58,7 @@ public class ProcessHelper {
     public List<HistoricOperationEvent> getHistoricOperationEventByProcessId(String processId) {
         return historicOperationEventService.createQuery()
                                             .processId(processId)
+                                            .orderByTimestamp(OrderDirection.ASCENDING)
                                             .list();
     }
 

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/ProcessHelperTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/ProcessHelperTest.java
@@ -3,6 +3,7 @@ package org.cloudfoundry.multiapps.controller.process.util;
 import java.util.List;
 
 import org.cloudfoundry.multiapps.controller.api.model.Operation.State;
+import org.cloudfoundry.multiapps.controller.persistence.OrderDirection;
 import org.cloudfoundry.multiapps.controller.persistence.model.HistoricOperationEvent;
 import org.cloudfoundry.multiapps.controller.persistence.model.ImmutableHistoricOperationEvent;
 import org.cloudfoundry.multiapps.controller.persistence.query.HistoricOperationEventQuery;
@@ -39,6 +40,8 @@ class ProcessHelperTest {
                .thenReturn(historicOperationEventQuery);
         Mockito.when(historicOperationEventQuery.processId(PROCESS_ID))
                .thenReturn(historicOperationEventQuery);
+        Mockito.when(historicOperationEventQuery.orderByTimestamp(Mockito.any()))
+               .thenReturn(historicOperationEventQuery);
     }
 
     @Test
@@ -69,6 +72,14 @@ class ProcessHelperTest {
     void testIsProcessAbortedWhenThereIsNotAbortedProcess() {
         mockHistoricEventsWithTypes(HistoricOperationEvent.EventType.FINISHED);
         Assertions.assertEquals(State.FINISHED, processHelper.computeProcessState(PROCESS_ID));
+    }
+
+    @Test
+    void isGetHistoricOperationEventOrdered() {
+        mockHistoricEventsWithTypes(HistoricOperationEvent.EventType.FINISHED);
+        processHelper.getHistoricOperationEventByProcessId(PROCESS_ID);
+        Mockito.verify(historicOperationEventQuery)
+               .orderByTimestamp(OrderDirection.ASCENDING);
     }
 
     private void mockHistoricEventsWithTypes(HistoricOperationEvent.EventType type) {


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
Operation events are sorted by their index value by default. This causes problems in OperationsHelper, which relies on the
operation's last event type being the most up to date. The issue is that an operation event with an older timestamp
can have a higher index if it is added after the latest event.
