### PR TITLE
Increasing versions for log4j and jclouds. Explicitly setting version of gson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <jclouds.version>2.3.0</jclouds.version>
         <guava.version>30.1.1-jre</guava.version>
         <guice.version>5.0.1</guice.version>
+        <gson.version>2.8.9</gson.version>
         <resilience4j.version>1.5.0</resilience4j.version>
         <immutables.version>2.8.8</immutables.version>
         <micrometer.version>1.5.5</micrometer.version>
@@ -769,6 +770,12 @@
                 <groupId>org.apache.jclouds.provider</groupId>
                 <artifactId>azureblob</artifactId>
                 <version>${jclouds.version}</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
             </dependency>
             <!-- https://mvnrepository.com/artifact/com.aliyun.oss/aliyun-sdk-oss -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <reactor-netty.version>0.9.12.RELEASE</reactor-netty.version>
         <jgit.version>4.11.9.201909030838-r</jgit.version>
         <swagger.version>1.6.2</swagger.version>
-        <jclouds.version>2.3.0</jclouds.version>
+        <jclouds.version>2.4.0</jclouds.version>
         <guava.version>30.1.1-jre</guava.version>
         <guice.version>5.0.1</guice.version>
         <gson.version>2.8.9</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <derby.version>10.14.2.0</derby.version>
         <h2.version>1.4.200</h2.version>
         <servlet-api.version>4.0.4</servlet-api.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <slf4j.version>1.7.30</slf4j.version>
         <commons-io.version>2.8.0</commons-io.version>
         <commons-fileupload.version>1.4</commons-fileupload.version>
@@ -771,6 +771,8 @@
                 <artifactId>azureblob</artifactId>
                 <version>${jclouds.version}</version>
             </dependency>
+            <!-- Transitive dependency from jclouds. They're using an old version with security vulnerabilities.
+             In order to avoid the vulnerabilities explicit versioning is required.-->
             <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
             <dependency>
                 <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION

In order to fix some vulnerabilities increasing versions of the following was required:
- jclouds
- gson
- log4j
