### PR TITLE
Bump version of jackson library to 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <spring-security.version>5.6.0</spring-security.version>
         <nimbus-jose-jwt.version>9.10.1</nimbus-jose-jwt.version>
         <hikari.version>3.4.3</hikari.version>
-        <jackson.version>2.12.4</jackson.version>
+        <jackson.version>2.13.1</jackson.version>
         <liquibase.version>4.4.1</liquibase.version>
         <liquibase-slf4j.version>4.0.0</liquibase-slf4j.version>
         <cloudfoundry-client.version>2.16.0</cloudfoundry-client.version>


### PR DESCRIPTION
Due to white-source vulnerability - jackson version should be updated.

